### PR TITLE
Update github workflows & ci/cd

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -54,7 +54,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04 # glibc 2.39 — see the header. NOT ubuntu-latest.
+    runs-on: ubuntu-24.04
+    env:
+      RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
     steps:
       - name: Resolve the tag
         id: rel
@@ -119,7 +121,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
             libssl-dev libdbus-1-dev libmpv-dev patchelf file \
-            libjack-jackd2-0 glib-networking
+            libjack-jackd2-0 glib-networking \
+            clang clang++ mold
           # libjack: linuxdeploy excludes it, so fix-appdir-tls.sh copies it in by hand.
           # glib-networking: supplies the gio TLS module that gets bundled. Without it the webview
           # has no TLS backend at all, which is the bug that started this whole saga.
@@ -165,6 +168,7 @@ jobs:
           # Scoped to this step only — no other step (or third-party action) sees the signing key.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+   
           # linuxdeploy bundles an ancient `strip` that chokes on modern ELF sections (DT_RELR).
           NO_STRIP: "true"
           # The bundler runs linuxdeploy/appimagetool, themselves AppImages — the runner has no

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -90,9 +90,6 @@ jobs:
       # blocks raw.githubusercontent.com. Without a snapshot that user has no cipher at all and
       # every restricted track is skipped. It goes stale within days either way, which is fine; the
       # runtime refresh is what keeps it current.
-      #
-      # NEVER FATAL. These registries are third-party. A release must not fail because one is down,
-      # and shipping the empty table is exactly the behaviour we had before this step existed.
       - name: Bake in the player-cipher registry
         shell: bash
         run: |

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/limusic.iml
+++ b/.idea/limusic.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KubernetesApiProvider">{}</component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/limusic.iml" filepath="$PROJECT_DIR$/.idea/limusic.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
I've noticed that the older github workflows were very complicated and decided to edit the majority of them. Here's what I did:

- Use nushell for scripting language (only used in workflows, type-safe unlike bash)
- Containers use fedora image as that's what is recommended.
- Improved build performance by using clang & native linkers
- Nodejs 20 is deprecated so updating to nodejs24 was ideal (only in workflows)
- libmpv automatically downloads via github actions; I couldn't figure out the old version worked.
- On windows, use a package manager (scoop.sh) and download libmpv from source using built-in powershell commands.

Currently passes all tests & workflows work as intended. Tested on fedora 44.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Linux release packaging reliability by configuring the build to use optimized linker tools.
  * Added required build dependencies to the release environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->