### PR TITLE
feat(auth): add YouTube channel switcher

### DIFF
--- a/crates/innertube/src/endpoints.rs
+++ b/crates/innertube/src/endpoints.rs
@@ -9,7 +9,9 @@ use crate::models::browse::{
 };
 use crate::models::context::Context;
 use crate::models::lyrics::{self, PlainLyrics, TimedLyricLine};
-use crate::models::metadata::{self, AccountInfo, NextResult, Rating, SearchResult, SongItem};
+use crate::models::metadata::{
+    self, AccountIdentity, AccountInfo, NextResult, Rating, SearchResult, SongItem,
+};
 use crate::models::player::{
     ContentPlaybackContext, PlaybackContext, PlayerBody, PlayerResponse, ServiceIntegrityDimensions,
 };
@@ -187,6 +189,40 @@ impl InnerTube {
         let body = AccountMenuBody { context: self.context_for(client) };
         let value = self.post("account/account_menu", client, &body, true).await?;
         Ok(metadata::parse_account_menu(&value))
+    }
+
+    /// Validate and refresh one delegated identity without mutating the transport's shared
+    /// selection. This keeps unrelated in-flight requests on the previously committed channel.
+    pub async fn account_menu_for_identity(
+        &self,
+        client: &YouTubeClient,
+        data_sync_id: &str,
+    ) -> Result<AccountInfo, Error> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct AccountMenuBody {
+            context: Context,
+        }
+        let body = AccountMenuBody { context: self.context_for_identity(client, data_sync_id) };
+        let value = self.post("account/account_menu", client, &body, true).await?;
+        Ok(metadata::parse_account_menu(&value))
+    }
+
+    /// Every usable YouTube identity under the signed-in Google account. The official web client
+    /// opens this sibling endpoint from the account menu; `account/account_menu` itself only
+    /// carries the active header.
+    pub async fn account_identities(
+        &self,
+        client: &YouTubeClient,
+    ) -> Result<Vec<AccountIdentity>, Error> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct AccountsListBody {
+            context: Context,
+        }
+        let body = AccountsListBody { context: self.context_for(client) };
+        let value = self.post("account/accounts_list", client, &body, true).await?;
+        Ok(metadata::parse_account_identities(&value))
     }
 
     /// Raw `browse` call (context/01, context/08). `browse_id`/`params` optional; response is the

--- a/crates/innertube/src/lib.rs
+++ b/crates/innertube/src/lib.rs
@@ -20,7 +20,9 @@ pub use models::browse::{
 };
 pub use models::context::Locale;
 pub use models::lyrics::{PlainLyrics, TimedLyricLine};
-pub use models::metadata::{AccountInfo, NextResult, Rating, SearchResult, SongItem};
+pub use models::metadata::{
+    AccountIdentity, AccountInfo, NextResult, Rating, SearchResult, SongItem,
+};
 pub use models::player::{
     find_format, AudioQuality, Format, PlaybackTracking, PlayerResponse, StreamingData,
 };

--- a/crates/innertube/src/models/metadata.rs
+++ b/crates/innertube/src/models/metadata.rs
@@ -270,14 +270,11 @@ pub fn parse_account_identities(root: &Value) -> Vec<AccountIdentity> {
     }
 
     for section in sections {
+        // Only the Google-account header. A section *title* is a group label ("Brand accounts"),
+        // not an address, and putting one in `email` shows it under a channel name in the picker.
         let email = find_all(section, "googleAccountHeaderRenderer")
             .into_iter()
-            .find_map(|h| account_text(h.get("email")))
-            .or_else(|| {
-                find_all(section, "accountItemSectionHeaderRenderer")
-                    .into_iter()
-                    .find_map(|h| account_text(h.get("title")))
-            });
+            .find_map(|h| account_text(h.get("email")));
         for item in find_all(section, "accountItem") {
             push_account_identity(&mut identities, item, email.as_deref(), response_id.as_deref());
         }

--- a/crates/innertube/src/models/metadata.rs
+++ b/crates/innertube/src/models/metadata.rs
@@ -159,13 +159,32 @@ pub struct NextResult {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct AccountInfo {
     pub name: Option<String>,
-    /// Channel handle or email (whichever the header carries).
     pub handle: Option<String>,
+    pub email: Option<String>,
     pub thumbnail: Option<String>,
+    /// The channel browse id (`UC…`) when the response links one. Never used for delegation.
+    pub channel_id: Option<String>,
     /// `onBehalfOfUser` id, `||`-split (context/04A). None when absent / single-account.
     pub data_sync_id: Option<String>,
     /// A login-bound visitorData, if the response carried one (context/15).
     pub visitor_data: Option<String>,
+}
+
+/// One usable YouTube identity returned by `account/accounts_list`.
+///
+/// `data_sync_id` is server-issued identity material from `datasyncIdToken` or `pageIdToken`, not
+/// something inferred from the channel browse id. Rows without such a token are intentionally not
+/// returned: displaying an identity that requests cannot actually select is worse than omitting it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountIdentity {
+    pub name: String,
+    pub handle: Option<String>,
+    pub email: Option<String>,
+    pub thumbnail: Option<String>,
+    pub channel_id: Option<String>,
+    pub data_sync_id: String,
+    /// YouTube's current/default marker. The app's persisted choice may deliberately differ.
+    pub is_selected: bool,
 }
 
 /// Parse a `search` response into song items. context/08.
@@ -214,26 +233,154 @@ fn lyrics_browse_id(root: &Value) -> Option<String> {
 /// Parse an `account/account_menu` response into an account summary. context/01, context/15.
 pub fn parse_account_menu(root: &Value) -> AccountInfo {
     let header = find_all(root, "activeAccountHeaderRenderer").into_iter().next();
-    let name = header.and_then(|h| runs_text(h.get("accountName")));
-    // YTM labels the second line `channelHandle` on newer accounts, `email` on older ones.
-    let handle = header
-        .and_then(|h| runs_text(h.get("channelHandle")).or_else(|| runs_text(h.get("email"))));
+    let name = header.and_then(|h| account_text(h.get("accountName")));
+    let handle = header.and_then(|h| account_text(h.get("channelHandle")));
+    let email = header.and_then(|h| account_text(h.get("email")));
     let thumbnail = header.and_then(last_thumbnail);
+    let channel_id = header.and_then(channel_browse_id);
 
     let rc = root.get("responseContext");
     // dataSyncId lives in the response context, not the menu header. context/04A.
-    let data_sync_id = rc
-        .and_then(|r| r.get("mainAppWebResponseContext"))
-        .and_then(|m| m.get("datasyncId"))
-        .and_then(Value::as_str)
-        .map(split_datasync_id);
+    let data_sync_id = response_data_sync_id(root);
     let visitor_data = rc
         .and_then(|r| r.get("visitorData"))
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
         .map(str::to_owned);
 
-    AccountInfo { name, handle, thumbnail, data_sync_id, visitor_data }
+    AccountInfo { name, handle, email, thumbnail, channel_id, data_sync_id, visitor_data }
+}
+
+/// Parse every selectable channel from `account/accounts_list`.
+///
+/// The action envelope differs between YouTube clients, so this deliberately anchors on
+/// `accountSectionListRenderer` / `accountItem` rather than one absolute JSON path. Section headers
+/// provide the Google-account email; each row provides its channel metadata and supported identity
+/// tokens.
+pub fn parse_account_identities(root: &Value) -> Vec<AccountIdentity> {
+    let response_id = response_data_sync_id(root);
+    let mut identities = Vec::new();
+    let sections = find_all(root, "accountSectionListRenderer");
+
+    if sections.is_empty() {
+        for item in find_all(root, "accountItem") {
+            push_account_identity(&mut identities, item, None, response_id.as_deref());
+        }
+        return identities;
+    }
+
+    for section in sections {
+        let email = find_all(section, "googleAccountHeaderRenderer")
+            .into_iter()
+            .find_map(|h| account_text(h.get("email")))
+            .or_else(|| {
+                find_all(section, "accountItemSectionHeaderRenderer")
+                    .into_iter()
+                    .find_map(|h| account_text(h.get("title")))
+            });
+        for item in find_all(section, "accountItem") {
+            push_account_identity(&mut identities, item, email.as_deref(), response_id.as_deref());
+        }
+    }
+    identities
+}
+
+fn push_account_identity(
+    identities: &mut Vec<AccountIdentity>,
+    item: &Value,
+    email: Option<&str>,
+    response_id: Option<&str>,
+) {
+    let Some(identity) = parse_account_identity(item, email, response_id) else { return };
+    if identities.iter().all(|i| i.data_sync_id != identity.data_sync_id) {
+        identities.push(identity);
+    }
+}
+
+fn parse_account_identity(
+    item: &Value,
+    email: Option<&str>,
+    response_id: Option<&str>,
+) -> Option<AccountIdentity> {
+    if item.get("isDisabled").and_then(Value::as_bool) == Some(true)
+        || item.get("hasChannel").and_then(Value::as_bool) == Some(false)
+    {
+        return None;
+    }
+    let name = account_text(item.get("accountName"))?;
+    let endpoint = item.get("serviceEndpoint")?.get("selectActiveIdentityEndpoint")?;
+    let tokens = endpoint
+        .get("supportedTokens")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+
+    // Prefer the purpose-built data-sync token. Some WEB responses only provide pageIdToken;
+    // that is still an explicit server-issued identity token and is the value YouTube's web
+    // switcher uses for onBehalfOfUser. A `UC…` browse id is never substituted here.
+    let token_data_sync_id = tokens.iter().find_map(|token| {
+        let value = token.get("datasyncIdToken").or_else(|| token.get("dataSyncIdToken"))?;
+        value
+            .get("datasyncIdToken")
+            .or_else(|| value.get("datasyncId"))
+            .or_else(|| value.get("dataSyncId"))
+            .and_then(Value::as_str)
+            .and_then(normalize_data_sync_id)
+    });
+    let page_id = tokens.iter().find_map(|token| {
+        token
+            .get("pageIdToken")
+            .and_then(|value| value.get("pageId"))
+            .and_then(Value::as_str)
+            .and_then(nonempty_string)
+    });
+    let is_selected = item.get("isSelected").and_then(Value::as_bool).unwrap_or(false);
+    let selected_response_id = is_selected.then_some(response_id).flatten().map(str::to_owned);
+    let data_sync_id = token_data_sync_id.or(page_id).or(selected_response_id)?;
+
+    Some(AccountIdentity {
+        name,
+        handle: account_text(item.get("channelHandle")),
+        email: email.and_then(nonempty_string),
+        thumbnail: last_thumbnail(item),
+        channel_id: channel_browse_id(item),
+        data_sync_id,
+        is_selected,
+    })
+}
+
+fn account_text(value: Option<&Value>) -> Option<String> {
+    value.and_then(|v| {
+        runs_text_opt(v)
+            .or_else(|| v.get("simpleText").and_then(Value::as_str).and_then(nonempty_string))
+            .or_else(|| v.as_str().and_then(nonempty_string))
+    })
+}
+
+fn channel_browse_id(node: &Value) -> Option<String> {
+    find_all(node, "browseEndpoint").into_iter().find_map(|endpoint| {
+        endpoint
+            .get("browseId")
+            .and_then(Value::as_str)
+            .filter(|id| id.starts_with("UC"))
+            .map(str::to_owned)
+    })
+}
+
+fn response_data_sync_id(root: &Value) -> Option<String> {
+    root.get("responseContext")
+        .and_then(|r| r.get("mainAppWebResponseContext"))
+        .and_then(|m| m.get("datasyncId").or_else(|| m.get("dataSyncId")))
+        .and_then(Value::as_str)
+        .and_then(normalize_data_sync_id)
+}
+
+fn normalize_data_sync_id(raw: &str) -> Option<String> {
+    nonempty_string(&split_datasync_id(raw))
+}
+
+fn nonempty_string(raw: &str) -> Option<String> {
+    (!raw.trim().is_empty()).then(|| raw.trim().to_owned())
 }
 
 /// Split a `dataSyncId` (`"<id>||<other>"`): prefer the part before `||`, else after. context/04A.
@@ -854,24 +1001,90 @@ mod tests {
 
     #[test]
     fn parses_account_menu() {
-        let root = json!({
-            "responseContext": {
-                "visitorData": "CgtNEWVISITOR",
-                "mainAppWebResponseContext": { "datasyncId": "1234||5678" }
-            },
-            "actions": [{ "openPopupAction": { "popup": { "multiPageMenuRenderer": { "sections": [{
-                "activeAccountHeaderRenderer": {
-                    "accountName": { "runs": [{ "text": "Jane Doe" }] },
-                    "channelHandle": { "runs": [{ "text": "@janedoe" }] },
-                    "accountPhoto": { "thumbnails": [{ "url": "small.jpg" }, { "url": "big.jpg" }] }
-                }
-            }] } } } }]
-        });
+        let root: Value =
+            serde_json::from_str(include_str!("../../tests/fixtures/account_menu_single.json"))
+                .unwrap();
         let a = parse_account_menu(&root);
-        assert_eq!(a.name.as_deref(), Some("Jane Doe"));
-        assert_eq!(a.handle.as_deref(), Some("@janedoe"));
-        assert_eq!(a.thumbnail.as_deref(), Some("big.jpg"));
-        assert_eq!(a.data_sync_id.as_deref(), Some("1234"));
-        assert_eq!(a.visitor_data.as_deref(), Some("CgtNEWVISITOR"));
+        assert_eq!(a.name.as_deref(), Some("Personal channel"));
+        assert_eq!(a.handle.as_deref(), Some("@personal"));
+        assert_eq!(a.email.as_deref(), Some("listener@example.invalid"));
+        assert_eq!(a.thumbnail.as_deref(), Some("https://example.invalid/avatar-large.jpg"));
+        assert_eq!(a.channel_id.as_deref(), Some("UCSANITIZEDPERSONAL"));
+        assert_eq!(a.data_sync_id.as_deref(), Some("personal-sync"));
+        assert_eq!(a.visitor_data.as_deref(), Some("CgtSANITIZEDVISITOR"));
+    }
+
+    #[test]
+    fn parses_one_selectable_identity() {
+        let root: Value =
+            serde_json::from_str(include_str!("../../tests/fixtures/accounts_list_one.json"))
+                .unwrap();
+        let identities = parse_account_identities(&root);
+        assert_eq!(identities.len(), 1);
+        let identity = &identities[0];
+        assert_eq!(identity.name, "Personal channel");
+        assert_eq!(identity.handle.as_deref(), Some("@personal"));
+        assert_eq!(identity.email.as_deref(), Some("listener@example.invalid"));
+        assert_eq!(identity.channel_id.as_deref(), Some("UCSANITIZEDPERSONAL"));
+        assert_eq!(identity.data_sync_id, "personal-sync");
+        assert!(identity.is_selected);
+    }
+
+    #[test]
+    fn parses_multiple_identities_and_keeps_a_persisted_non_default_choice() {
+        let root: Value =
+            serde_json::from_str(include_str!("../../tests/fixtures/accounts_list_multiple.json"))
+                .unwrap();
+        let identities = parse_account_identities(&root);
+        assert_eq!(identities.len(), 2);
+        assert!(identities[0].is_selected);
+
+        // The app restores by server-issued id, not YouTube's current/default marker.
+        let persisted = identities.iter().find(|i| i.data_sync_id == "brand-page-id").unwrap();
+        assert_eq!(persisted.name, "Brand channel");
+        assert_eq!(persisted.channel_id.as_deref(), Some("UCSANITIZEDBRAND"));
+        assert!(!persisted.is_selected);
+    }
+
+    #[test]
+    fn missing_identity_metadata_stays_optional() {
+        let root: Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/accounts_list_missing_optional.json"
+        ))
+        .unwrap();
+        let identities = parse_account_identities(&root);
+        assert_eq!(identities.len(), 1);
+        let identity = &identities[0];
+        assert_eq!(identity.name, "No optional metadata");
+        assert_eq!(identity.handle, None);
+        assert_eq!(identity.email, None);
+        assert_eq!(identity.thumbnail, None);
+        assert_eq!(identity.channel_id, None);
+    }
+
+    #[test]
+    fn malformed_or_unusable_identity_tokens_are_not_selectable() {
+        let root: Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/accounts_list_malformed_ids.json"
+        ))
+        .unwrap();
+        let identities = parse_account_identities(&root);
+        assert_eq!(identities.len(), 2);
+        assert_eq!(identities[0].name, "Missing token");
+        assert_eq!(identities[0].data_sync_id, "active-response-sync");
+        assert_eq!(identities[1].name, "Fallback token");
+        assert_eq!(identities[1].data_sync_id, "fallback-sync");
+    }
+
+    #[test]
+    fn absent_or_empty_response_datasync_id_is_none() {
+        assert_eq!(parse_account_menu(&json!({})).data_sync_id, None);
+        assert_eq!(
+            parse_account_menu(&json!({
+                "responseContext": { "mainAppWebResponseContext": { "datasyncId": "||" } }
+            }))
+            .data_sync_id,
+            None
+        );
     }
 }

--- a/crates/innertube/src/transport.rs
+++ b/crates/innertube/src/transport.rs
@@ -123,6 +123,10 @@ impl InnerTube {
         self.session.write().unwrap().data_sync_id = id;
     }
 
+    pub fn data_sync_id(&self) -> Option<String> {
+        self.session.read().unwrap().data_sync_id.clone()
+    }
+
     pub fn set_visitor_data(&self, vd: Option<String>) {
         self.session.write().unwrap().visitor_data = vd;
     }
@@ -134,6 +138,19 @@ impl InnerTube {
         // `onBehalfOfUser` makes Google *require* a credential: with no cookie it turns a request
         // that would have worked anonymously into a hard 401. Only send it when we can authenticate.
         let dsid = s.cookie.as_ref().and(s.data_sync_id.as_deref());
+        client.to_context(&s.locale, s.visitor_data.as_deref(), dsid)
+    }
+
+    /// Build a one-off authenticated context for identity validation without changing the shared
+    /// session seen by concurrent browse/playback requests. The caller commits the id only after
+    /// the validation response succeeds.
+    pub(crate) fn context_for_identity(
+        &self,
+        client: &YouTubeClient,
+        data_sync_id: &str,
+    ) -> crate::models::context::Context {
+        let s = self.session.read().unwrap();
+        let dsid = s.cookie.as_ref().map(|_| data_sync_id);
         client.to_context(&s.locale, s.visitor_data.as_deref(), dsid)
     }
 
@@ -399,6 +416,24 @@ mod tests {
 
         it.set_cookie(Some("SAPISID=secret".into()));
         assert_eq!(it.context_for(web).user.on_behalf_of_user.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn identity_validation_context_does_not_mutate_the_committed_session() {
+        let clients = crate::clients::Clients::bundled();
+        let web = clients.get(crate::clients::METADATA_CLIENT).unwrap();
+        let session = Session {
+            cookie: Some("SAPISID=secret".into()),
+            data_sync_id: Some("committed-id".into()),
+            ..Default::default()
+        };
+        let it = InnerTube::new(session, None).unwrap();
+
+        assert_eq!(
+            it.context_for_identity(web, "candidate-id").user.on_behalf_of_user.as_deref(),
+            Some("candidate-id")
+        );
+        assert_eq!(it.context_for(web).user.on_behalf_of_user.as_deref(), Some("committed-id"));
     }
 
     #[test]

--- a/crates/innertube/tests/fixtures/account_menu_single.json
+++ b/crates/innertube/tests/fixtures/account_menu_single.json
@@ -1,0 +1,36 @@
+{
+  "responseContext": {
+    "visitorData": "CgtSANITIZEDVISITOR",
+    "mainAppWebResponseContext": {
+      "datasyncId": "personal-sync||device-sync"
+    }
+  },
+  "actions": [
+    {
+      "openPopupAction": {
+        "popup": {
+          "multiPageMenuRenderer": {
+            "sections": [
+              {
+                "activeAccountHeaderRenderer": {
+                  "accountName": { "runs": [{ "text": "Personal channel" }] },
+                  "channelHandle": { "runs": [{ "text": "@personal" }] },
+                  "email": { "runs": [{ "text": "listener@example.invalid" }] },
+                  "accountPhoto": {
+                    "thumbnails": [
+                      { "url": "https://example.invalid/avatar-small.jpg" },
+                      { "url": "https://example.invalid/avatar-large.jpg" }
+                    ]
+                  },
+                  "navigationEndpoint": {
+                    "browseEndpoint": { "browseId": "UCSANITIZEDPERSONAL" }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/innertube/tests/fixtures/accounts_list_malformed_ids.json
+++ b/crates/innertube/tests/fixtures/accounts_list_malformed_ids.json
@@ -1,0 +1,75 @@
+{
+  "responseContext": {
+    "mainAppWebResponseContext": { "datasyncId": "active-response-sync||device-sync" }
+  },
+  "actions": [
+    {
+      "getMultiPageMenuAction": {
+        "menu": {
+          "multiPageMenuRenderer": {
+            "sections": [
+              {
+                "accountSectionListRenderer": {
+                  "contents": [
+                    {
+                      "accountItemSectionRenderer": {
+                        "contents": [
+                          {
+                            "accountItem": {
+                              "accountName": { "runs": [{ "text": "Missing token" }] },
+                              "isSelected": true,
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {}
+                              }
+                            }
+                          },
+                          {
+                            "accountItem": {
+                              "accountName": { "runs": [{ "text": "Empty token" }] },
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {
+                                  "supportedTokens": [
+                                    { "datasyncIdToken": { "datasyncIdToken": "||" } }
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "accountItem": {
+                              "accountName": { "runs": [{ "text": "Fallback token" }] },
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {
+                                  "supportedTokens": [
+                                    { "datasyncIdToken": { "datasyncIdToken": "||fallback-sync" } }
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "accountItem": {
+                              "accountName": { "runs": [{ "text": "No channel" }] },
+                              "hasChannel": false,
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {
+                                  "supportedTokens": [
+                                    { "pageIdToken": { "pageId": "must-not-be-used" } }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/innertube/tests/fixtures/accounts_list_missing_optional.json
+++ b/crates/innertube/tests/fixtures/accounts_list_missing_optional.json
@@ -1,0 +1,42 @@
+{
+  "actions": [
+    {
+      "getMultiPageMenuAction": {
+        "menu": {
+          "multiPageMenuRenderer": {
+            "sections": [
+              {
+                "accountSectionListRenderer": {
+                  "contents": [
+                    {
+                      "accountItemSectionRenderer": {
+                        "contents": [
+                          {
+                            "accountItem": {
+                              "accountName": { "runs": [{ "text": "No optional metadata" }] },
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {
+                                  "supportedTokens": [
+                                    {
+                                      "datasyncIdToken": {
+                                        "datasyncIdToken": "minimal-sync"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/innertube/tests/fixtures/accounts_list_multiple.json
+++ b/crates/innertube/tests/fixtures/accounts_list_multiple.json
@@ -1,0 +1,74 @@
+{
+  "responseContext": {
+    "mainAppWebResponseContext": { "datasyncId": "default-sync||device-sync" }
+  },
+  "actions": [
+    {
+      "getMultiPageMenuAction": {
+        "menu": {
+          "multiPageMenuRenderer": {
+            "sections": [
+              {
+                "accountSectionListRenderer": {
+                  "header": {
+                    "googleAccountHeaderRenderer": {
+                      "email": { "runs": [{ "text": "listener@example.invalid" }] }
+                    }
+                  },
+                  "contents": [
+                    {
+                      "accountItemSectionRenderer": {
+                        "contents": [
+                          {
+                            "accountItem": {
+                              "accountName": { "runs": [{ "text": "Default channel" }] },
+                              "channelHandle": { "runs": [{ "text": "@default" }] },
+                              "isSelected": true,
+                              "hasChannel": true,
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {
+                                  "supportedTokens": [
+                                    {
+                                      "datasyncIdToken": {
+                                        "datasyncIdToken": "default-sync"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "accountItem": {
+                              "accountName": { "runs": [{ "text": "Brand channel" }] },
+                              "channelHandle": { "runs": [{ "text": "@brand" }] },
+                              "accountPhoto": {
+                                "thumbnails": [{ "url": "https://example.invalid/brand.jpg" }]
+                              },
+                              "isSelected": false,
+                              "hasChannel": true,
+                              "navigationEndpoint": {
+                                "browseEndpoint": { "browseId": "UCSANITIZEDBRAND" }
+                              },
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {
+                                  "supportedTokens": [
+                                    { "pageIdToken": { "pageId": "brand-page-id" } }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/innertube/tests/fixtures/accounts_list_one.json
+++ b/crates/innertube/tests/fixtures/accounts_list_one.json
@@ -1,0 +1,59 @@
+{
+  "responseContext": {
+    "mainAppWebResponseContext": { "datasyncId": "personal-sync||device-sync" }
+  },
+  "actions": [
+    {
+      "getMultiPageMenuAction": {
+        "menu": {
+          "multiPageMenuRenderer": {
+            "sections": [
+              {
+                "accountSectionListRenderer": {
+                  "header": {
+                    "googleAccountHeaderRenderer": {
+                      "email": { "runs": [{ "text": "listener@example.invalid" }] }
+                    }
+                  },
+                  "contents": [
+                    {
+                      "accountItemSectionRenderer": {
+                        "contents": [
+                          {
+                            "accountItem": {
+                              "accountName": { "simpleText": "Personal channel" },
+                              "channelHandle": { "runs": [{ "text": "@personal" }] },
+                              "accountPhoto": {
+                                "thumbnails": [{ "url": "https://example.invalid/personal.jpg" }]
+                              },
+                              "isSelected": true,
+                              "hasChannel": true,
+                              "navigationEndpoint": {
+                                "browseEndpoint": { "browseId": "UCSANITIZEDPERSONAL" }
+                              },
+                              "serviceEndpoint": {
+                                "selectActiveIdentityEndpoint": {
+                                  "supportedTokens": [
+                                    {
+                                      "datasyncIdToken": {
+                                        "datasyncIdToken": "personal-sync||ignored-device-part"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -156,7 +156,7 @@ pub async fn get_queue(state: St<'_>) -> Result<serde_json::Value, String> {
 }
 
 /// Settings the UI is allowed to read *and write*. Session/auth material (`session_cookie`,
-/// `data_sync_id`, `account_json`, `visitor_data`) and internal blobs (`queue_json`,
+/// `selected_identity_json`, `data_sync_id`, `account_json`, `visitor_data`) and internal blobs (`queue_json`,
 /// `queue_position`) never cross into the webview — they'd otherwise ship the login credential to
 /// the renderer on every open — and the webview can't overwrite them either.
 const UI_SETTINGS: [&str; 13] = [
@@ -282,6 +282,19 @@ pub async fn clear_caches(state: St<'_>) -> Result<(), String> {
 #[tauri::command]
 pub async fn get_account(state: St<'_>) -> Result<serde_json::Value, String> {
     Ok(state.account_snapshot())
+}
+
+#[tauri::command]
+pub async fn get_account_identities(state: St<'_>) -> Result<Vec<serde_json::Value>, String> {
+    state.account_identities().await
+}
+
+#[tauri::command]
+pub async fn switch_account(
+    state: St<'_>,
+    selection_key: String,
+) -> Result<serde_json::Value, String> {
+    state.switch_account(&selection_key).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -156,9 +156,10 @@ pub async fn get_queue(state: St<'_>) -> Result<serde_json::Value, String> {
 }
 
 /// Settings the UI is allowed to read *and write*. Session/auth material (`session_cookie`,
-/// `selected_identity_json`, `data_sync_id`, `account_json`, `visitor_data`) and internal blobs (`queue_json`,
-/// `queue_position`) never cross into the webview — they'd otherwise ship the login credential to
-/// the renderer on every open — and the webview can't overwrite them either.
+/// `selected_identity_json`, `data_sync_id`, `account_json`, `account_selection_pending`,
+/// `visitor_data`) and internal blobs (`queue_json`, `queue_position`) never cross into the webview
+/// — they'd otherwise ship the login credential to the renderer on every open — and the webview
+/// can't overwrite them either.
 const UI_SETTINGS: [&str; 13] = [
     "volume",
     "proxy",

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -110,6 +110,48 @@ impl Db {
         let _ = conn.execute("DELETE FROM settings WHERE key = ?1", [key]);
     }
 
+    /// Persist the canonical selected identity and its two legacy projections atomically. Older
+    /// releases still read `data_sync_id` / `account_json`; keeping all three in one transaction
+    /// prevents a restart from pairing one channel's request delegation with another's display.
+    pub fn set_auth_identity(
+        &self,
+        selected_json: &str,
+        data_sync_id: Option<&str>,
+        account_json: &str,
+    ) -> rusqlite::Result<()> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO settings(key, value) VALUES('selected_identity_json', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [selected_json],
+        )?;
+        if let Some(id) = data_sync_id {
+            tx.execute(
+                "INSERT INTO settings(key, value) VALUES('data_sync_id', ?1)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                [id],
+            )?;
+        } else {
+            tx.execute("DELETE FROM settings WHERE key = 'data_sync_id'", [])?;
+        }
+        tx.execute(
+            "INSERT INTO settings(key, value) VALUES('account_json', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [account_json],
+        )?;
+        tx.commit()
+    }
+
+    pub fn clear_auth_identity(&self) -> rusqlite::Result<()> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction()?;
+        for key in ["selected_identity_json", "data_sync_id", "account_json"] {
+            tx.execute("DELETE FROM settings WHERE key = ?1", [key])?;
+        }
+        tx.commit()
+    }
+
     pub fn all_settings(&self) -> Vec<(String, String)> {
         let conn = self.0.lock().unwrap();
         let mut out = Vec::new();
@@ -451,6 +493,32 @@ mod tests {
         d.record_play("stale", "{}", 1_000, 60);
         d.record_play("fresh", "{}", 5_000, 60); // prunes anything before 4_940
         assert_eq!(d.top_plays(0, 20), vec![("{}".to_string(), 1)]);
+    }
+
+    #[test]
+    fn auth_identity_projections_are_updated_and_cleared_together() {
+        let d = db();
+        d.set_auth_identity(
+            r#"{"data_sync_id":"channel-a"}"#,
+            Some("channel-a"),
+            r#"{"name":"Channel A"}"#,
+        )
+        .unwrap();
+        assert_eq!(d.get_setting("data_sync_id").as_deref(), Some("channel-a"));
+        assert_eq!(
+            d.get_setting("selected_identity_json").as_deref(),
+            Some(r#"{"data_sync_id":"channel-a"}"#)
+        );
+        assert_eq!(d.get_setting("account_json").as_deref(), Some(r#"{"name":"Channel A"}"#));
+
+        d.set_auth_identity(r#"{"data_sync_id":null}"#, None, r#"{"name":"Single channel"}"#)
+            .unwrap();
+        assert_eq!(d.get_setting("data_sync_id"), None, "a stale delegated id must be deleted");
+
+        d.clear_auth_identity().unwrap();
+        assert_eq!(d.get_setting("selected_identity_json"), None);
+        assert_eq!(d.get_setting("data_sync_id"), None);
+        assert_eq!(d.get_setting("account_json"), None);
     }
 }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -115,12 +115,18 @@ impl Db {
     /// prevents a restart from pairing one channel's request delegation with another's display.
     pub fn set_auth_identity(
         &self,
+        session_cookie: &str,
         selected_json: &str,
         data_sync_id: Option<&str>,
         account_json: &str,
     ) -> rusqlite::Result<()> {
         let mut conn = self.0.lock().unwrap();
         let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO settings(key, value) VALUES('session_cookie', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [session_cookie],
+        )?;
         tx.execute(
             "INSERT INTO settings(key, value) VALUES('selected_identity_json', ?1)
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -140,13 +146,38 @@ impl Db {
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             [account_json],
         )?;
+        tx.execute("DELETE FROM settings WHERE key = 'account_selection_pending'", [])?;
+        tx.commit()
+    }
+
+    /// Persist an authenticated cookie while deliberately leaving the account unfinished. Keeping
+    /// the marker and removal of stale identity projections in the same transaction means a crash
+    /// during the required picker cannot restart into YouTube's default channel silently.
+    pub fn set_pending_auth_selection(&self, session_cookie: &str) -> rusqlite::Result<()> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO settings(key, value) VALUES('session_cookie', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [session_cookie],
+        )?;
+        for key in ["selected_identity_json", "data_sync_id", "account_json"] {
+            tx.execute("DELETE FROM settings WHERE key = ?1", [key])?;
+        }
+        tx.execute(
+            "INSERT INTO settings(key, value) VALUES('account_selection_pending', 'true')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [],
+        )?;
         tx.commit()
     }
 
     pub fn clear_auth_identity(&self) -> rusqlite::Result<()> {
         let mut conn = self.0.lock().unwrap();
         let tx = conn.transaction()?;
-        for key in ["selected_identity_json", "data_sync_id", "account_json"] {
+        for key in
+            ["selected_identity_json", "data_sync_id", "account_json", "account_selection_pending"]
+        {
             tx.execute("DELETE FROM settings WHERE key = ?1", [key])?;
         }
         tx.commit()
@@ -499,6 +530,7 @@ mod tests {
     fn auth_identity_projections_are_updated_and_cleared_together() {
         let d = db();
         d.set_auth_identity(
+            "SAPISID=cookie-a",
             r#"{"data_sync_id":"channel-a"}"#,
             Some("channel-a"),
             r#"{"name":"Channel A"}"#,
@@ -510,10 +542,24 @@ mod tests {
             Some(r#"{"data_sync_id":"channel-a"}"#)
         );
         assert_eq!(d.get_setting("account_json").as_deref(), Some(r#"{"name":"Channel A"}"#));
+        assert_eq!(d.get_setting("session_cookie").as_deref(), Some("SAPISID=cookie-a"));
 
-        d.set_auth_identity(r#"{"data_sync_id":null}"#, None, r#"{"name":"Single channel"}"#)
-            .unwrap();
+        d.set_pending_auth_selection("SAPISID=cookie-b").unwrap();
+        assert_eq!(d.get_setting("session_cookie").as_deref(), Some("SAPISID=cookie-b"));
+        assert_eq!(d.get_setting("selected_identity_json"), None);
+        assert_eq!(d.get_setting("data_sync_id"), None);
+        assert_eq!(d.get_setting("account_json"), None);
+        assert_eq!(d.get_setting("account_selection_pending").as_deref(), Some("true"));
+
+        d.set_auth_identity(
+            "SAPISID=cookie-b",
+            r#"{"data_sync_id":null}"#,
+            None,
+            r#"{"name":"Single channel"}"#,
+        )
+        .unwrap();
         assert_eq!(d.get_setting("data_sync_id"), None, "a stale delegated id must be deleted");
+        assert_eq!(d.get_setting("account_selection_pending"), None);
 
         d.clear_auth_identity().unwrap();
         assert_eq!(d.get_setting("selected_identity_json"), None);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,7 +201,7 @@ pub fn run() {
             // (context/04 §A) only if we've never stored one.
             let proxy = db.get_setting("proxy");
             let cookie = db.get_setting("session_cookie").filter(|s| !s.is_empty());
-            let data_sync_id = db.get_setting("data_sync_id").filter(|s| !s.is_empty());
+            let data_sync_id = state::persisted_data_sync_id(&db);
             let visitor_data = db.get_setting("visitor_data").filter(|s| !s.is_empty());
             // First run (no stored visitorData): bootstrap it in the background after the window is
             // up, rather than blocking setup on a network GET (up to 60s on a bad connection). See
@@ -378,6 +378,8 @@ pub fn run() {
             commands::get_stream_clients,
             commands::clear_caches,
             commands::get_account,
+            commands::get_account_identities,
+            commands::switch_account,
             commands::sign_out,
             commands::login_webview,
             commands::open_mini,

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use tauri::webview::PageLoadEvent;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
-use crate::state::AppState;
+use crate::state::{AppState, SignInOutcome};
 
 const LOGIN_LABEL: &str = "login";
 
@@ -45,9 +45,13 @@ pub fn open_login(app: AppHandle, state: Arc<AppState>) {
                     let cookie = read_login_cookies(&app);
                     if innertube::cookie_sapisid(&cookie).is_some() {
                         match state.sign_in(cookie).await {
-                            Ok(_) => {
+                            Ok(SignInOutcome::Complete) => {
                                 let _ = app.emit("login-done", ());
                             }
+                            // The authenticated cookie is saved, but the account remains
+                            // deliberately unfinished until the main-window picker selects a
+                            // server-issued delegated identity.
+                            Ok(SignInOutcome::SelectionRequired) => {}
                             Err(e) => {
                                 let _ = app.emit("login-error", e);
                             }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -198,6 +198,10 @@ fn selected_identity_from_db(db: &Db) -> Option<SelectedIdentity> {
         })
 }
 
+fn auth_selection_pending(db: &Db) -> bool {
+    db.get_setting("account_selection_pending").as_deref() == Some("true")
+}
+
 /// Startup compatibility: prefer the canonical model, then fall back to the pre-switcher setting.
 pub(crate) fn persisted_data_sync_id(db: &Db) -> Option<String> {
     selected_identity_from_db(db)
@@ -384,9 +388,6 @@ impl AppState {
             }
         };
 
-        // Plaintext SQLite — acceptable for a single-user personal tool (context/15). Persist the
-        // cookie only after account_menu proved it authenticates.
-        self.db.set_setting("session_cookie", &cookie);
         let active_visitor_data = active.visitor_data.clone();
 
         // Losing the list endpoint must not regress ordinary one-channel sign-in. It only removes
@@ -479,10 +480,11 @@ impl AppState {
         }
 
         if identities.len() > 1 {
-            // No persisted choice for these cookies: keep the authenticated cookie, but remove any
-            // stale legacy projection so a restart cannot silently act as the old channel.
+            // No persisted choice for these cookies: atomically keep the authenticated cookie,
+            // mark the login unfinished, and remove stale projections. A restart will reopen the
+            // required picker instead of silently acting as YouTube's default channel.
             self.it.set_data_sync_id(None);
-            self.db.clear_auth_identity().map_err(|error| {
+            self.db.set_pending_auth_selection(&cookie).map_err(|error| {
                 self.restore_auth_transport(previous_cookie.clone(), previous_data_sync_id.clone());
                 self.restore_session_cookie_setting(previous_cookie.as_deref());
                 error.to_string()
@@ -572,8 +574,17 @@ impl AppState {
         let account = selected.account_json(true);
         let selected_json = serde_json::to_string(&selected).map_err(|e| e.to_string())?;
         let account_json = account.to_string();
+        let session_cookie = self
+            .it
+            .cookie()
+            .ok_or("The YouTube session expired before the channel could be saved.")?;
         self.db
-            .set_auth_identity(&selected_json, selected.data_sync_id.as_deref(), &account_json)
+            .set_auth_identity(
+                &session_cookie,
+                &selected_json,
+                selected.data_sync_id.as_deref(),
+                &account_json,
+            )
             .map_err(|e| format!("Couldn't save the selected YouTube channel: {e}"))?;
         self.persist_visitor_data(visitor_data);
         self.it.set_data_sync_id(selected.data_sync_id.clone());
@@ -612,6 +623,13 @@ impl AppState {
     /// Current account for the UI. New installs derive it from the canonical selected identity;
     /// legacy `account_json` remains a read fallback so existing databases migrate without a wipe.
     pub fn account_snapshot(&self) -> serde_json::Value {
+        if auth_selection_pending(&self.db) && self.it.is_logged_in() {
+            return serde_json::json!({
+                "signedIn": true,
+                "selectionRequired": true,
+                "canSwitch": true,
+            });
+        }
         if let Some(selected) = selected_identity_from_db(&self.db) {
             return selected.account_json(self.it.is_logged_in());
         }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,11 +1,15 @@
 //! App state: transport, player, db, and the queue/playback manager. context/11.
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use std::sync::Arc;
 
-use innertube::{AudioQuality, Clients, InnerTube, SongItem, MAIN_CLIENT};
+use innertube::{
+    AccountIdentity, AccountInfo, AudioQuality, Clients, InnerTube, SongItem, MAIN_CLIENT,
+};
 use listen_protocol::{Playback, PlaybackKind, Track};
 use player::Player;
 use tauri::{AppHandle, Emitter};
@@ -79,6 +83,150 @@ pub enum RepeatMode {
 enum Fill {
     Playing,
     Queued(Option<String>),
+}
+
+/// Canonical persisted account selection. `data_sync_id` drives request delegation; every display
+/// field beside it belongs to that same identity. `account_json` and the legacy `data_sync_id`
+/// setting are written only as atomic projections of this model.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+struct SelectedIdentity {
+    #[serde(default)]
+    data_sync_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    handle: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    thumbnail: Option<String>,
+    #[serde(default)]
+    channel_id: Option<String>,
+    #[serde(default)]
+    has_multiple_identities: bool,
+}
+
+pub enum SignInOutcome {
+    Complete,
+    SelectionRequired,
+}
+
+impl SelectedIdentity {
+    fn from_account_info(info: AccountInfo, has_multiple_identities: bool) -> Option<Self> {
+        Some(Self {
+            data_sync_id: info.data_sync_id,
+            name: Some(info.name?),
+            handle: info.handle,
+            email: info.email,
+            thumbnail: info.thumbnail,
+            channel_id: info.channel_id,
+            has_multiple_identities,
+        })
+    }
+
+    fn from_identity(
+        identity: &AccountIdentity,
+        refreshed: AccountInfo,
+        has_multiple_identities: bool,
+    ) -> Self {
+        Self {
+            data_sync_id: Some(identity.data_sync_id.clone()),
+            name: refreshed.name.or_else(|| Some(identity.name.clone())),
+            handle: refreshed.handle.or_else(|| identity.handle.clone()),
+            email: refreshed.email.or_else(|| identity.email.clone()),
+            thumbnail: refreshed.thumbnail.or_else(|| identity.thumbnail.clone()),
+            channel_id: refreshed.channel_id.or_else(|| identity.channel_id.clone()),
+            has_multiple_identities,
+        }
+    }
+
+    fn account_json(&self, signed_in: bool) -> serde_json::Value {
+        serde_json::json!({
+            "signedIn": signed_in,
+            "name": self.name,
+            "handle": self.handle,
+            "email": self.email,
+            "thumbnail": self.thumbnail,
+            "channelId": self.channel_id,
+            "canSwitch": self.has_multiple_identities,
+        })
+    }
+
+    fn as_account_identity(&self) -> Option<AccountIdentity> {
+        Some(AccountIdentity {
+            name: self.name.clone().unwrap_or_default(),
+            handle: self.handle.clone(),
+            email: self.email.clone(),
+            thumbnail: self.thumbnail.clone(),
+            channel_id: self.channel_id.clone(),
+            data_sync_id: self.data_sync_id.clone()?,
+            is_selected: false,
+        })
+    }
+}
+
+fn selected_identity_from_db(db: &Db) -> Option<SelectedIdentity> {
+    db.get_setting("selected_identity_json")
+        .and_then(|json| serde_json::from_str::<SelectedIdentity>(&json).ok())
+        .filter(|identity| identity.name.is_some() || identity.data_sync_id.is_some())
+        .or_else(|| {
+            let account = db
+                .get_setting("account_json")
+                .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())?;
+            let string = |key: &str| {
+                account
+                    .get(key)
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_owned)
+            };
+            Some(SelectedIdentity {
+                data_sync_id: db.get_setting("data_sync_id").filter(|id| !id.is_empty()),
+                name: string("name"),
+                handle: string("handle"),
+                email: string("email"),
+                thumbnail: string("thumbnail"),
+                channel_id: string("channelId"),
+                has_multiple_identities: account
+                    .get("canSwitch")
+                    .and_then(serde_json::Value::as_bool)
+                    // Pre-switcher account_json has no flag. Keep the action discoverable until
+                    // the startup identity refresh determines whether this legacy user has one
+                    // channel or several.
+                    .unwrap_or(true),
+            })
+        })
+}
+
+/// Startup compatibility: prefer the canonical model, then fall back to the pre-switcher setting.
+pub(crate) fn persisted_data_sync_id(db: &Db) -> Option<String> {
+    selected_identity_from_db(db)
+        .and_then(|identity| identity.data_sync_id)
+        .or_else(|| db.get_setting("data_sync_id").filter(|id| !id.is_empty()))
+}
+
+fn identity_selection_key(data_sync_id: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    "limusic-account-identity-v1".hash(&mut hasher);
+    data_sync_id.hash(&mut hasher);
+    format!("identity-{:016x}", hasher.finish())
+}
+
+fn identity_snapshot(
+    identity: &AccountIdentity,
+    selected_data_sync_id: Option<&str>,
+) -> serde_json::Value {
+    let selected =
+        selected_data_sync_id.map(|id| id == identity.data_sync_id).unwrap_or(identity.is_selected);
+    serde_json::json!({
+        "selectionKey": identity_selection_key(&identity.data_sync_id),
+        "name": identity.name,
+        "handle": identity.handle,
+        "email": identity.email,
+        "thumbnail": identity.thumbnail,
+        "channelId": identity.channel_id,
+        "selected": selected,
+    })
 }
 
 #[derive(Default)]
@@ -196,65 +344,277 @@ impl AppState {
     // --- auth (context/15) ------------------------------------------------------------------
 
     /// Sign in with the Cookie header captured from the login webview (context/15 Path A).
-    /// Validates SAPISID presence, sets the cookie on the transport, fetches `account_menu`
-    /// (→ dataSyncId + display info + a fresh visitorData), and persists it all to `settings`.
-    /// Returns the account JSON for the UI.
-    pub async fn sign_in(&self, cookie: String) -> Result<serde_json::Value, String> {
+    ///
+    /// `account_menu` validates the cookie and provides the active header. `accounts_list` then
+    /// discovers every server-selectable identity. A persisted matching identity wins over
+    /// Google's current default; a new multi-channel login pauses before finalization and asks the
+    /// UI to choose.
+    pub async fn sign_in(&self, cookie: String) -> Result<SignInOutcome, String> {
         let cookie = cookie.trim().to_owned();
         if innertube::cookie_sapisid(&cookie).is_none() {
             return Err("Sign-in didn't complete — try signing in again.".into());
         }
+        let previous_cookie = self.it.cookie();
+        let previous_data_sync_id = self.it.data_sync_id();
+        let persisted_identity = selected_identity_from_db(&self.db);
+        let persisted_id = persisted_identity
+            .as_ref()
+            .and_then(|identity| identity.data_sync_id.clone())
+            .or_else(|| self.db.get_setting("data_sync_id").filter(|id| !id.is_empty()));
+
         self.it.set_cookie(Some(cookie.clone()));
+        // Discovery must not inherit a stale/default identity. The persisted id is restored only
+        // after the fresh accounts list proves that this cookie can act as it.
+        self.it.set_data_sync_id(None);
         let client =
             self.clients.get(innertube::METADATA_CLIENT).ok_or("metadata client missing")?;
-        let info = match self.it.account_menu(client).await {
+        let active = match self.it.account_menu(client).await {
             // A valid, authenticating cookie returns the account header (name). No name means the
             // session didn't actually authenticate — reject it up front so we don't "succeed" into
             // a silently-empty library.
             Ok(i) if i.name.is_some() => i,
             Ok(_) => {
-                self.it.set_cookie(None);
+                self.restore_auth_transport(previous_cookie, previous_data_sync_id);
                 return Err("That session didn't authenticate — sign in again.".into());
             }
             // Auth didn't take (network) — roll back so we're not half-logged-in.
             Err(e) => {
-                self.it.set_cookie(None);
+                self.restore_auth_transport(previous_cookie, previous_data_sync_id);
                 return Err(format!("Sign-in failed: {e}"));
             }
         };
-        // Persist. Plaintext SQLite — acceptable for a single-user personal tool (context/15).
+
+        // Plaintext SQLite — acceptable for a single-user personal tool (context/15). Persist the
+        // cookie only after account_menu proved it authenticates.
         self.db.set_setting("session_cookie", &cookie);
-        if let Some(id) = &info.data_sync_id {
-            self.it.set_data_sync_id(Some(id.clone()));
-            self.db.set_setting("data_sync_id", id);
+        let active_visitor_data = active.visitor_data.clone();
+
+        // Losing the list endpoint must not regress ordinary one-channel sign-in. It only removes
+        // the optional switcher for this login attempt; account_menu still supplies a valid active
+        // identity exactly as older releases used it.
+        let identities = match self.it.account_identities(client).await {
+            Ok(identities) => identities,
+            Err(error) => {
+                tracing::warn!(%error, "could not discover alternate YouTube identities");
+                Vec::new()
+            }
+        };
+
+        let chosen = persisted_id
+            .as_deref()
+            .and_then(|id| identities.iter().find(|identity| identity.data_sync_id == id));
+        if let Some(identity) = chosen {
+            if identities.len() == 1 {
+                let selected = SelectedIdentity::from_identity(identity, active, false);
+                self.persist_selected_identity(selected, active_visitor_data.as_deref())
+                    .inspect_err(|_| {
+                        self.restore_auth_transport(
+                            previous_cookie.clone(),
+                            previous_data_sync_id.clone(),
+                        );
+                        self.restore_session_cookie_setting(previous_cookie.as_deref());
+                    })?;
+                return Ok(SignInOutcome::Complete);
+            }
+            self.activate_identity(identity, identities.len() > 1, client).await.inspect_err(
+                |_| {
+                    self.restore_auth_transport(
+                        previous_cookie.clone(),
+                        previous_data_sync_id.clone(),
+                    );
+                    self.restore_session_cookie_setting(previous_cookie.as_deref());
+                },
+            )?;
+            return Ok(SignInOutcome::Complete);
         }
-        if let Some(vd) = &info.visitor_data {
-            self.it.set_visitor_data(Some(vd.clone()));
-            self.db.set_setting("visitor_data", vd);
+
+        // An incomplete/changed list response must not replace a previously selected channel with
+        // Google's current default. Revalidate the stored server-issued id directly;
+        // account_menu either confirms it and refreshes metadata, or the login fails closed.
+        if let Some(data_sync_id) = persisted_id.as_deref() {
+            let identity = persisted_identity
+                .as_ref()
+                .and_then(SelectedIdentity::as_account_identity)
+                .unwrap_or_else(|| AccountIdentity {
+                    name: String::new(),
+                    handle: None,
+                    email: None,
+                    thumbnail: None,
+                    channel_id: None,
+                    data_sync_id: data_sync_id.to_owned(),
+                    is_selected: false,
+                });
+            self.activate_identity(
+                &identity,
+                identities.len() > 1
+                    || persisted_identity
+                        .as_ref()
+                        .is_some_and(|saved| saved.has_multiple_identities),
+                client,
+            )
+            .await
+            .inspect_err(|_| {
+                self.restore_auth_transport(previous_cookie.clone(), previous_data_sync_id.clone());
+                self.restore_session_cookie_setting(previous_cookie.as_deref());
+            })?;
+            return Ok(SignInOutcome::Complete);
         }
-        let account = serde_json::json!({
-            "signedIn": true,
-            "name": info.name,
-            "handle": info.handle,
-            "thumbnail": info.thumbnail,
-        });
-        self.db.set_setting("account_json", &account.to_string());
+
+        if identities.len() == 1 {
+            // One channel stays seamless. Reuse the already-fetched active header instead of
+            // introducing another network request or a new delegated id into the historical
+            // single-account path.
+            let selected = SelectedIdentity::from_account_info(active, false)
+                .ok_or("That session didn't return an account identity")?;
+            self.persist_selected_identity(selected, active_visitor_data.as_deref()).inspect_err(
+                |_| {
+                    self.restore_auth_transport(
+                        previous_cookie.clone(),
+                        previous_data_sync_id.clone(),
+                    );
+                    self.restore_session_cookie_setting(previous_cookie.as_deref());
+                },
+            )?;
+            return Ok(SignInOutcome::Complete);
+        }
+
+        if identities.len() > 1 {
+            // No persisted choice for these cookies: keep the authenticated cookie, but remove any
+            // stale legacy projection so a restart cannot silently act as the old channel.
+            self.it.set_data_sync_id(None);
+            self.db.clear_auth_identity().map_err(|error| {
+                self.restore_auth_transport(previous_cookie.clone(), previous_data_sync_id.clone());
+                self.restore_session_cookie_setting(previous_cookie.as_deref());
+                error.to_string()
+            })?;
+            self.persist_visitor_data(active_visitor_data.as_deref());
+            let _ = self.app.emit("account-selection-required", ());
+            return Ok(SignInOutcome::SelectionRequired);
+        }
+
+        // No selectable token was exposed (the normal historical single-channel response). Keep
+        // the seamless path and persist the active header + response-context dataSyncId together.
+        let selected = SelectedIdentity::from_account_info(active, false)
+            .ok_or("That session didn't return an account identity")?;
+        self.persist_selected_identity(selected, active_visitor_data.as_deref()).inspect_err(
+            |_| {
+                self.restore_auth_transport(previous_cookie.clone(), previous_data_sync_id.clone());
+                self.restore_session_cookie_setting(previous_cookie.as_deref());
+            },
+        )?;
+        Ok(SignInOutcome::Complete)
+    }
+
+    /// Fresh switcher rows for the account picker. Raw delegated ids never cross the Tauri
+    /// boundary; the UI receives a process-local opaque selector and display metadata only.
+    pub async fn account_identities(&self) -> Result<Vec<serde_json::Value>, String> {
+        if !self.it.is_logged_in() {
+            return Err("Sign in before switching channels.".into());
+        }
+        let client =
+            self.clients.get(innertube::METADATA_CLIENT).ok_or("metadata client missing")?;
+        let identities = self.it.account_identities(client).await.map_err(|e| e.to_string())?;
+        let selected_id = self.it.data_sync_id();
+        Ok(identities
+            .iter()
+            .map(|identity| identity_snapshot(identity, selected_id.as_deref()))
+            .collect())
+    }
+
+    /// Switch without a Google re-login. The selector is resolved against a fresh server list and
+    /// account_menu must succeed under a one-off context for that exact identity before the shared
+    /// transport, persistence, or UI is updated.
+    pub async fn switch_account(&self, selection_key: &str) -> Result<serde_json::Value, String> {
+        if !self.it.is_logged_in() {
+            return Err("Sign in before switching channels.".into());
+        }
+        let client =
+            self.clients.get(innertube::METADATA_CLIENT).ok_or("metadata client missing")?;
+        let identities = self.it.account_identities(client).await.map_err(|e| e.to_string())?;
+        let identity = identities
+            .iter()
+            .find(|identity| identity_selection_key(&identity.data_sync_id) == selection_key)
+            .ok_or(
+                "That YouTube channel is no longer available. Refresh the list and try again.",
+            )?;
+        self.activate_identity(identity, identities.len() > 1, client).await
+    }
+
+    async fn activate_identity(
+        &self,
+        identity: &AccountIdentity,
+        has_multiple_identities: bool,
+        client: &innertube::YouTubeClient,
+    ) -> Result<serde_json::Value, String> {
+        let refreshed =
+            match self.it.account_menu_for_identity(client, &identity.data_sync_id).await {
+                Ok(info) if info.name.is_some() => info,
+                Ok(_) => {
+                    return Err(
+                        "YouTube did not confirm that channel. Try signing in again.".into()
+                    );
+                }
+                Err(error) => {
+                    return Err(format!("Couldn't switch YouTube channel: {error}"));
+                }
+            };
+        let visitor_data = refreshed.visitor_data.clone();
+        let selected =
+            SelectedIdentity::from_identity(identity, refreshed, has_multiple_identities);
+        self.persist_selected_identity(selected, visitor_data.as_deref())
+    }
+
+    fn persist_selected_identity(
+        &self,
+        selected: SelectedIdentity,
+        visitor_data: Option<&str>,
+    ) -> Result<serde_json::Value, String> {
+        let account = selected.account_json(true);
+        let selected_json = serde_json::to_string(&selected).map_err(|e| e.to_string())?;
+        let account_json = account.to_string();
+        self.db
+            .set_auth_identity(&selected_json, selected.data_sync_id.as_deref(), &account_json)
+            .map_err(|e| format!("Couldn't save the selected YouTube channel: {e}"))?;
+        self.persist_visitor_data(visitor_data);
+        self.it.set_data_sync_id(selected.data_sync_id.clone());
         let _ = self.app.emit("auth-changed", &account);
         Ok(account)
+    }
+
+    fn restore_auth_transport(&self, cookie: Option<String>, data_sync_id: Option<String>) {
+        self.it.set_cookie(cookie);
+        self.it.set_data_sync_id(data_sync_id);
+    }
+
+    fn restore_session_cookie_setting(&self, cookie: Option<&str>) {
+        if let Some(cookie) = cookie {
+            self.db.set_setting("session_cookie", cookie);
+        } else {
+            self.db.delete_setting("session_cookie");
+        }
+    }
+
+    fn persist_visitor_data(&self, visitor_data: Option<&str>) {
+        if let Some(visitor_data) = visitor_data {
+            self.it.set_visitor_data(Some(visitor_data.to_owned()));
+            self.db.set_setting("visitor_data", visitor_data);
+        }
     }
 
     pub async fn sign_out(&self) {
         self.it.set_cookie(None);
         self.it.set_data_sync_id(None);
         self.db.delete_setting("session_cookie");
-        self.db.delete_setting("data_sync_id");
-        self.db.delete_setting("account_json");
+        let _ = self.db.clear_auth_identity();
         let _ = self.app.emit("auth-changed", serde_json::json!({ "signedIn": false }));
     }
 
-    /// Current account for the UI. `signedIn` reflects the live cookie; the rest is the last
-    /// persisted display info.
+    /// Current account for the UI. New installs derive it from the canonical selected identity;
+    /// legacy `account_json` remains a read fallback so existing databases migrate without a wipe.
     pub fn account_snapshot(&self) -> serde_json::Value {
+        if let Some(selected) = selected_identity_from_db(&self.db) {
+            return selected.account_json(self.it.is_logged_in());
+        }
         let mut v = self
             .db
             .get_setting("account_json")

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -216,12 +216,7 @@ fn identity_selection_key(data_sync_id: &str) -> String {
     format!("identity-{:016x}", hasher.finish())
 }
 
-fn identity_snapshot(
-    identity: &AccountIdentity,
-    selected_data_sync_id: Option<&str>,
-) -> serde_json::Value {
-    let selected =
-        selected_data_sync_id.map(|id| id == identity.data_sync_id).unwrap_or(identity.is_selected);
+fn identity_snapshot(identity: &AccountIdentity, selected: bool) -> serde_json::Value {
     serde_json::json!({
         "selectionKey": identity_selection_key(&identity.data_sync_id),
         "name": identity.name,
@@ -429,36 +424,43 @@ impl AppState {
             return Ok(SignInOutcome::Complete);
         }
 
-        // An incomplete/changed list response must not replace a previously selected channel with
-        // Google's current default. Revalidate the stored server-issued id directly;
-        // account_menu either confirms it and refreshes metadata, or the login fails closed.
-        if let Some(data_sync_id) = persisted_id.as_deref() {
-            let identity = persisted_identity
-                .as_ref()
-                .and_then(SelectedIdentity::as_account_identity)
-                .unwrap_or_else(|| AccountIdentity {
-                    name: String::new(),
-                    handle: None,
-                    email: None,
-                    thumbnail: None,
-                    channel_id: None,
-                    data_sync_id: data_sync_id.to_owned(),
-                    is_selected: false,
-                });
-            self.activate_identity(
-                &identity,
-                identities.len() > 1
-                    || persisted_identity
-                        .as_ref()
-                        .is_some_and(|saved| saved.has_multiple_identities),
-                client,
-            )
-            .await
-            .inspect_err(|_| {
-                self.restore_auth_transport(previous_cookie.clone(), previous_data_sync_id.clone());
-                self.restore_session_cookie_setting(previous_cookie.as_deref());
-            })?;
-            return Ok(SignInOutcome::Complete);
+        // A missing/unreadable list must not replace a previously selected channel with Google's
+        // current default. Revalidate the stored server-issued id directly; account_menu either
+        // confirms it and refreshes metadata, or the login fails closed.
+        //
+        // Only when the list is empty. A list that came back and does *not* contain the persisted
+        // id means these cookies belong to a different Google account, so the stored id is theirs
+        // to drop: forcing it here would delegate account A's channel onto account B's cookie and
+        // fail every sign-in until the user signs out first.
+        if identities.is_empty() {
+            if let Some(data_sync_id) = persisted_id.as_deref() {
+                let identity = persisted_identity
+                    .as_ref()
+                    .and_then(SelectedIdentity::as_account_identity)
+                    .unwrap_or_else(|| AccountIdentity {
+                        name: String::new(),
+                        handle: None,
+                        email: None,
+                        thumbnail: None,
+                        channel_id: None,
+                        data_sync_id: data_sync_id.to_owned(),
+                        is_selected: false,
+                    });
+                self.activate_identity(
+                    &identity,
+                    persisted_identity.as_ref().is_some_and(|saved| saved.has_multiple_identities),
+                    client,
+                )
+                .await
+                .inspect_err(|_| {
+                    self.restore_auth_transport(
+                        previous_cookie.clone(),
+                        previous_data_sync_id.clone(),
+                    );
+                    self.restore_session_cookie_setting(previous_cookie.as_deref());
+                })?;
+                return Ok(SignInOutcome::Complete);
+            }
         }
 
         if identities.len() == 1 {
@@ -517,9 +519,19 @@ impl AppState {
             self.clients.get(innertube::METADATA_CLIENT).ok_or("metadata client missing")?;
         let identities = self.it.account_identities(client).await.map_err(|e| e.to_string())?;
         let selected_id = self.it.data_sync_id();
+        // Nothing is selected yet during a forced first pick, so YouTube's own default marker
+        // would be a lie: the user hasn't chosen it, and picking it is still a required step.
+        let pending = auth_selection_pending(&self.db);
         Ok(identities
             .iter()
-            .map(|identity| identity_snapshot(identity, selected_id.as_deref()))
+            .map(|identity| {
+                let selected = !pending
+                    && selected_id
+                        .as_deref()
+                        .map(|id| id == identity.data_sync_id)
+                        .unwrap_or(identity.is_selected);
+                identity_snapshot(identity, selected)
+            })
             .collect())
     }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -77,7 +77,21 @@ export interface Account {
 	signedIn: boolean;
 	name?: string | null;
 	handle?: string | null;
+	email?: string | null;
 	thumbnail?: string | null;
+	channelId?: string | null;
+	canSwitch?: boolean;
+}
+
+export interface AccountIdentity {
+	/** Opaque, process-local selector. Raw delegated/data-sync ids stay in Rust. */
+	selectionKey: string;
+	name: string;
+	handle?: string | null;
+	email?: string | null;
+	thumbnail?: string | null;
+	channelId?: string | null;
+	selected: boolean;
 }
 
 export interface BrowseItem {
@@ -263,6 +277,10 @@ export const allowFontFile = (path: string) => invoke<void>('allow_font_file', {
 
 // --- auth (context/15) ---------------------------------------------------------------------
 export const getAccount = () => invoke<Account>('get_account');
+export const getAccountIdentities = () =>
+	invoke<AccountIdentity[]>('get_account_identities');
+export const switchAccount = (selectionKey: string) =>
+	invoke<Account>('switch_account', { selectionKey });
 export const signOut = () => invoke<void>('sign_out');
 /** Open the in-app Google sign-in webview (context/15 Path A). Result arrives via onAuthChanged. */
 export const loginWebview = () => invoke<void>('login_webview');
@@ -359,6 +377,8 @@ export const onPlaybackNotice = (cb: (msg: string) => void): Promise<UnlistenFn>
 	listen<{ message: string }>('playback-notice', (e) => cb(e.payload.message));
 export const onAuthChanged = (cb: (a: Account) => void): Promise<UnlistenFn> =>
 	listen<Account>('auth-changed', (e) => cb(e.payload));
+export const onAccountSelectionRequired = (cb: () => void): Promise<UnlistenFn> =>
+	listen('account-selection-required', () => cb());
 /**
  * Local music disappeared from disk. Fired when a play attempt finds nothing there, carrying the
  * song (and album, if that emptied it) so every view holding those ids can drop them at once.

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -81,6 +81,8 @@ export interface Account {
 	thumbnail?: string | null;
 	channelId?: string | null;
 	canSwitch?: boolean;
+	/** The cookie authenticated, but a multi-channel login is not complete until one is chosen. */
+	selectionRequired?: boolean;
 }
 
 export interface AccountIdentity {

--- a/ui/src/lib/components/AccountMenu.svelte
+++ b/ui/src/lib/components/AccountMenu.svelte
@@ -6,7 +6,7 @@
 	import { UserCircleIcon, Logout01Icon, ArrowDown01Icon } from '@hugeicons/core-free-icons';
 	import { Button } from '$lib/components/ui/button';
 	import * as api from '$lib/api';
-	import { auth } from '$lib/player.svelte';
+	import { auth, openChannelPicker } from '$lib/player.svelte';
 	import { thumb } from '$lib/thumb';
 
 	let menuOpen = $state(false);
@@ -31,6 +31,11 @@
 	function signInGoogle() {
 		api.loginWebview(); // native sign-in window takes over; result arrives via auth-changed
 		menuOpen = false;
+	}
+
+	function switchChannel() {
+		menuOpen = false;
+		openChannelPicker();
 	}
 </script>
 
@@ -77,10 +82,18 @@
 		{#if auth.account?.signedIn}
 			<div class="mb-3">
 				<div class="truncate text-sm font-medium">{auth.account.name ?? 'Account'}</div>
-				{#if auth.account.handle}
-					<div class="truncate text-xs text-muted-foreground">{auth.account.handle}</div>
+				{#if auth.account.handle || auth.account.email}
+					<div class="truncate text-xs text-muted-foreground">
+						{auth.account.handle ?? auth.account.email}
+					</div>
 				{/if}
 			</div>
+			{#if auth.account.canSwitch}
+				<Button variant="outline" size="sm" class="mb-2 w-full gap-2" onclick={switchChannel}>
+					<HugeiconsIcon icon={UserCircleIcon} class="h-4 w-4" />
+					Switch channel
+				</Button>
+			{/if}
 			<Button variant="outline" size="sm" class="w-full gap-2" onclick={doSignOut}>
 				<HugeiconsIcon icon={Logout01Icon} class="h-4 w-4" />
 				Sign out

--- a/ui/src/lib/components/ChannelPicker.svelte
+++ b/ui/src/lib/components/ChannelPicker.svelte
@@ -70,16 +70,18 @@
 		}
 	}
 
-	function onOpenChange(open: boolean) {
-		// A new multi-channel login is intentionally unfinished until one usable identity is chosen.
-		if (!open && ui.channelPickerRequired) {
-			queueMicrotask(() => (ui.channelPickerOpen = true));
-		}
-	}
+	// A new multi-channel login is intentionally unfinished until one usable identity is chosen, so
+	// escape and click-outside are inert until then. Cancel sign-in is the way out.
+	let dismissable: 'ignore' | 'close' = $derived(ui.channelPickerRequired ? 'ignore' : 'close');
 </script>
 
-<Dialog.Root bind:open={ui.channelPickerOpen} {onOpenChange}>
-	<Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-md" showCloseButton={!ui.channelPickerRequired}>
+<Dialog.Root bind:open={ui.channelPickerOpen}>
+	<Dialog.Content
+		class="gap-0 overflow-hidden p-0 sm:max-w-md"
+		showCloseButton={!ui.channelPickerRequired}
+		escapeKeydownBehavior={dismissable}
+		interactOutsideBehavior={dismissable}
+	>
 		<div class="border-b px-5 py-4">
 			<Dialog.Title class="text-lg font-semibold">Choose a YouTube channel</Dialog.Title>
 			<Dialog.Description class="mt-1 text-xs text-muted-foreground">

--- a/ui/src/lib/components/ChannelPicker.svelte
+++ b/ui/src/lib/components/ChannelPicker.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { CheckmarkCircle02Icon, UserCircleIcon } from '@hugeicons/core-free-icons';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+	import * as api from '$lib/api';
+	import type { AccountIdentity } from '$lib/api';
+	import { toast, ui } from '$lib/player.svelte';
+	import { thumb } from '$lib/thumb';
+
+	let loading = $state(false);
+	let switching = $state<string | null>(null);
+	let cancelling = $state(false);
+	let error = $state<string | null>(null);
+	let loadedForOpen = $state(false);
+
+	$effect(() => {
+		if (!ui.channelPickerOpen) {
+			loadedForOpen = false;
+			error = null;
+			return;
+		}
+		if (loadedForOpen) return;
+		loadedForOpen = true;
+		void loadIdentities();
+	});
+
+	async function loadIdentities() {
+		loading = true;
+		error = null;
+		try {
+			ui.channelIdentities = await api.getAccountIdentities();
+		} catch (e) {
+			error = String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function choose(identity: AccountIdentity) {
+		if (switching) return;
+		switching = identity.selectionKey;
+		error = null;
+		try {
+			const wasRequired = ui.channelPickerRequired;
+			await api.switchAccount(identity.selectionKey);
+			ui.channelPickerRequired = false;
+			ui.channelPickerOpen = false;
+			ui.channelIdentities = [];
+			toast.success(wasRequired ? `Signed in as ${identity.name}` : `Switched to ${identity.name}`);
+		} catch (e) {
+			error = String(e);
+			toast.error(error);
+		} finally {
+			switching = null;
+		}
+	}
+
+	async function cancelSignIn() {
+		if (cancelling || switching) return;
+		cancelling = true;
+		try {
+			await api.signOut();
+			ui.channelPickerRequired = false;
+			ui.channelPickerOpen = false;
+		} catch (e) {
+			error = String(e);
+		} finally {
+			cancelling = false;
+		}
+	}
+
+	function onOpenChange(open: boolean) {
+		// A new multi-channel login is intentionally unfinished until one usable identity is chosen.
+		if (!open && ui.channelPickerRequired) {
+			queueMicrotask(() => (ui.channelPickerOpen = true));
+		}
+	}
+</script>
+
+<Dialog.Root bind:open={ui.channelPickerOpen} {onOpenChange}>
+	<Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-md" showCloseButton={!ui.channelPickerRequired}>
+		<div class="border-b px-5 py-4">
+			<Dialog.Title class="text-lg font-semibold">Choose a YouTube channel</Dialog.Title>
+			<Dialog.Description class="mt-1 text-xs text-muted-foreground">
+				Library, likes and playlists will use this channel. You can switch again later.
+			</Dialog.Description>
+		</div>
+
+		<div class="max-h-[26rem] min-h-32 overflow-y-auto p-2">
+			{#if loading}
+				<p class="px-3 py-8 text-center text-sm text-muted-foreground">Loading channels…</p>
+			{:else if error}
+				<div class="space-y-3 px-3 py-6 text-center">
+					<p class="text-sm text-destructive">{error}</p>
+					<Button variant="outline" size="sm" onclick={loadIdentities}>Try again</Button>
+				</div>
+			{:else if ui.channelIdentities.length === 0}
+				<p class="px-3 py-8 text-center text-sm text-muted-foreground">
+					YouTube did not return any selectable channels.
+				</p>
+			{:else}
+				{#each ui.channelIdentities as identity (identity.selectionKey)}
+					<button
+						type="button"
+						onclick={() => choose(identity)}
+						disabled={switching !== null}
+						class="flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+					>
+						{#if identity.thumbnail}
+							<img
+								src={thumb(identity.thumbnail, 96)}
+								alt=""
+								class="h-10 w-10 shrink-0 rounded-full object-cover ring-1 ring-border"
+							/>
+						{:else}
+							<span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted">
+								<HugeiconsIcon icon={UserCircleIcon} class="h-6 w-6 text-muted-foreground" />
+							</span>
+						{/if}
+						<span class="min-w-0 flex-1">
+							<span class="block truncate text-sm font-medium">{identity.name}</span>
+							{#if identity.handle || identity.email}
+								<span class="block truncate text-xs text-muted-foreground">
+									{identity.handle ?? identity.email}
+								</span>
+							{/if}
+						</span>
+						{#if identity.selected}
+							<span class="flex shrink-0 items-center gap-1 text-xs text-primary">
+								<HugeiconsIcon icon={CheckmarkCircle02Icon} class="h-4 w-4" />
+								Selected
+							</span>
+						{/if}
+					</button>
+				{/each}
+			{/if}
+		</div>
+
+		<div class="flex justify-end border-t px-5 py-3">
+			{#if ui.channelPickerRequired}
+				<Button variant="outline" size="sm" onclick={cancelSignIn} disabled={cancelling || switching !== null}>
+					{cancelling ? 'Cancelling…' : 'Cancel sign-in'}
+				</Button>
+			{:else}
+				<Button variant="outline" size="sm" onclick={() => (ui.channelPickerOpen = false)}>
+					Cancel
+				</Button>
+			{/if}
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -3,7 +3,15 @@
 // context/11 UI contract — this module only calls commands / subscribes to events.
 import { browser } from '$app/environment';
 import * as api from './api';
-import type { Account, BrowseItem, NowPlaying, QueueState, Rating, SongItem } from './api';
+import type {
+	Account,
+	AccountIdentity,
+	BrowseItem,
+	NowPlaying,
+	QueueState,
+	Rating,
+	SongItem
+} from './api';
 import { applyLtState, lt } from './lt.svelte';
 import { clearCached } from './pagecache';
 import * as pl from './personal';
@@ -63,36 +71,60 @@ export const library = $state({
 	extrasError: null as string | null
 });
 
+// Account switches can happen while a library request is still in flight. A generation lets the
+// old response finish harmlessly instead of overwriting the newly selected channel's data.
+let libraryGeneration = 0;
+
+function resetLibraryForAccount() {
+	libraryGeneration++;
+	library.items = [];
+	library.loaded = false;
+	library.loading = false;
+	library.error = null;
+	library.albums = [];
+	library.artists = [];
+	library.extrasLoaded = false;
+	library.extrasLoading = false;
+	library.extrasError = null;
+}
+
 /** Fetch the library once (or force a refresh). No-op while a load is in flight. */
 export async function loadLibrary(force = false) {
 	if (library.loading || (library.loaded && !force)) return;
+	const generation = libraryGeneration;
 	library.loading = true;
 	library.error = null;
 	try {
-		library.items = await api.getLibrary();
+		const items = await api.getLibrary();
+		if (generation !== libraryGeneration) return;
+		library.items = items;
 		library.loaded = true;
 	} catch (e) {
-		library.error = String(e);
+		if (generation === libraryGeneration) library.error = String(e);
 	} finally {
-		library.loading = false;
+		if (generation === libraryGeneration) library.loading = false;
 	}
 }
 
 /** Saved albums + artists, same caching rules as `loadLibrary`. */
 export async function loadLibraryExtras(force = false) {
 	if (library.extrasLoading || (library.extrasLoaded && !force)) return;
+	const generation = libraryGeneration;
 	library.extrasLoading = true;
 	library.extrasError = null;
 	try {
-		[library.albums, library.artists] = await Promise.all([
+		const [albums, artists] = await Promise.all([
 			api.getLibraryAlbums(),
 			api.getLibraryArtists()
 		]);
+		if (generation !== libraryGeneration) return;
+		library.albums = albums;
+		library.artists = artists;
 		library.extrasLoaded = true;
 	} catch (e) {
-		library.extrasError = String(e);
+		if (generation === libraryGeneration) library.extrasError = String(e);
 	} finally {
-		library.extrasLoading = false;
+		if (generation === libraryGeneration) library.extrasLoading = false;
 	}
 }
 
@@ -451,11 +483,20 @@ export const ui = $state({
 	toast: null as Toast | null,
 	settingsOpen: false, // the settings modal
 	ltOpen: false, // the Listen Together modal
+	channelPickerOpen: false,
+	channelPickerRequired: false, // true while a multi-channel login is not finalized yet
+	channelIdentities: [] as AccountIdentity[],
 	// Manual sidebar collapse, lg and up (below that the rail is already collapsed by the
 	// breakpoint). Here rather than in Sidebar because the now-playing view and the fullscreen
 	// lyrics panel are overlays that offset themselves by the sidebar's width.
 	sidebarCollapsed: browser && localStorage.getItem('sidebar_collapsed') === '1'
 });
+
+export function openChannelPicker(required = false) {
+	ui.channelPickerRequired = required;
+	ui.channelIdentities = [];
+	ui.channelPickerOpen = true;
+}
 
 export function toggleSidebar() {
 	ui.sidebarCollapsed = !ui.sidebarCollapsed;
@@ -547,18 +588,18 @@ export function initApp(mini = false): () => void {
 		api.onLocalChanged(forgetLocal), // a local file turned out to be gone — drop it everywhere
 		api.onAuthChanged((a) => {
 			auth.account = a;
+			resetLibraryForAccount();
 			if (a.signedIn) {
 				if (!mini) loadLibrary(true);
 			} else {
-				library.items = [];
-				library.loaded = false;
-				library.albums = [];
-				library.artists = [];
-				library.extrasLoaded = false;
+				ui.channelPickerOpen = false;
+				ui.channelPickerRequired = false;
+				ui.channelIdentities = [];
 			}
 			clearCached();
 			auth.epoch++;
 		}),
+		api.onAccountSelectionRequired(() => openChannelPicker(true)),
 		api.onLoginError((msg) => toast.error(msg)),
 		api.onLoginDone(() => toast.success('Signed in')),
 		// Listen Together (context/19): mirror the Rust session state; surface notices as toasts.
@@ -587,7 +628,17 @@ export function initApp(mini = false): () => void {
 	api.getAccount()
 		.then((a) => {
 			auth.account = a;
-			if (a.signedIn) loadLibrary();
+			if (a.signedIn) {
+				loadLibrary();
+				// Older databases predate `canSwitch`. Refresh just the safe display list so those
+				// users gain the switch action without signing in again; single-channel users lose
+				// the provisional action as soon as the one-row response arrives.
+				api.getAccountIdentities()
+					.then((identities) => {
+						if (auth.account?.signedIn) auth.account.canSwitch = identities.length > 1;
+					})
+					.catch(() => {});
+			}
 		})
 		.catch(() => {});
 	// Scan the local folders once at startup: it seeds the Library's Local tab and, more to the

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -628,6 +628,10 @@ export function initApp(mini = false): () => void {
 	api.getAccount()
 		.then((a) => {
 			auth.account = a;
+			if (a.signedIn && a.selectionRequired) {
+				openChannelPicker(true);
+				return;
+			}
 			if (a.signedIn) {
 				loadLibrary();
 				// Older databases predate `canSwitch`. Refresh just the safe display list so those

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -634,14 +634,17 @@ export function initApp(mini = false): () => void {
 			}
 			if (a.signedIn) {
 				loadLibrary();
-				// Older databases predate `canSwitch`. Refresh just the safe display list so those
-				// users gain the switch action without signing in again; single-channel users lose
-				// the provisional action as soon as the one-row response arrives.
-				api.getAccountIdentities()
-					.then((identities) => {
-						if (auth.account?.signedIn) auth.account.canSwitch = identities.length > 1;
-					})
-					.catch(() => {});
+				// Only when the stored answer might be the provisional one: databases that predate
+				// `canSwitch` default it to true so the action stays discoverable, and this is what
+				// demotes single-channel users back to no switcher. A stored `false` is already
+				// authoritative, so most launches skip the request entirely.
+				if (a.canSwitch) {
+					api.getAccountIdentities()
+						.then((identities) => {
+							if (auth.account?.signedIn) auth.account.canSwitch = identities.length > 1;
+						})
+						.catch(() => {});
+				}
 			}
 		})
 		.catch(() => {});

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -23,6 +23,7 @@
 	import LyricsPanel from '$lib/components/LyricsPanel.svelte';
 	import AddToPlaylist from '$lib/components/AddToPlaylist.svelte';
 	import SettingsDialog from '$lib/components/SettingsDialog.svelte';
+	import ChannelPicker from '$lib/components/ChannelPicker.svelte';
 	import ListenTogether from '$lib/components/ListenTogether.svelte';
 	import MiniPlayer from '$lib/components/MiniPlayer.svelte';
 	import NowPlaying from '$lib/components/NowPlaying.svelte';
@@ -116,6 +117,7 @@
 
 	<AddToPlaylist />
 	<SettingsDialog />
+	<ChannelPicker />
 	<ListenTogether />
 
 	<!-- The two notification banners below run at z-[100]. Dialogs and menus sit at z-50 and portal to


### PR DESCRIPTION
## Problem

LiMusic authenticated a Google cookie successfully but always followed YouTube's current/default channel. Users with personal and Brand Account identities could not choose which channel owned library, likes, playlists, and subscriptions, while the displayed account metadata could drift from the delegated `dataSyncId`.

## Implementation

- Discover selectable identities through the account switcher (`account/accounts_list`) opened from `account/account_menu`, accepting only server-issued `datasyncIdToken`, `pageIdToken`, or the selected response-context `datasyncId`.
- Add a minimal post-login and account-menu channel picker without exposing raw delegated IDs to the webview.
- Validate a candidate with a one-off `user.onBehalfOfUser` context, refresh its active account metadata, then atomically persist the authenticated cookie, canonical selected identity, and backward-compatible `data_sync_id` / `account_json` projections.
- Persist an explicit pending-selection marker for unfinished multi-channel login, so an app restart reopens the required picker instead of silently using YouTube's default channel.
- Restore a persisted choice instead of overwriting it with Google's default, preserve the seamless single-channel path, and invalidate stale account-scoped frontend requests after a switch.
- Keep existing cookie/database settings compatible and add no account-specific constants.

## Testing

- `cargo fmt --all --check`
- `cargo test --workspace` (160 passed; 1 existing live-provider test ignored)
- `cargo clippy --workspace --all-targets -- -D warnings` with only four pre-existing unrelated lint rules allowed
- `svelte-check --tsconfig ./tsconfig.json` (0 errors, 0 warnings)
- `vite build`
- Sanitized parser fixtures cover one/multiple identities, persisted selection differing from YouTube's default, missing optional metadata, unusable/malformed IDs, and `||` splitting.
- Persistence tests cover atomic pending-selection, selected-identity projections, and clearing the pending marker on completion.

## InnerTube limitations

YouTube's account switching API is undocumented and may change renderer/token shapes. The implementation prefers `datasyncIdToken`, uses the explicitly supplied `pageIdToken` only as the server-issued switcher fallback, never derives delegation from a `UC...` browse ID, and validates every switch through `account/account_menu`. No `X-Goog-PageId` or `X-Goog-AuthUser` header was added because `context.user.onBehalfOfUser` is sufficient for the observed YouTube Music flow. A live multi-channel test still requires real authenticated cookies and therefore is not automated in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple account and channel identities.
  * Added a channel picker for switching between available identities.
  * Added account discovery and switching through the application interface.
  * Sign-in now prompts for channel selection when required.
  * Account details can include email, channel ID, handle, and selection status.
* **Bug Fixes**
  * Improved account-session persistence, restoration, sign-out cleanup, and stale data handling.
  * Prevented failed identity validation from altering the active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->