### PR TITLE
fix(dev): stabilize local frontend setup

### DIFF
--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
-onlyBuiltDependencies:
-  - '@tailwindcss/oxide'
-  - esbuild
+allowBuilds:
+  '@hugeicons/svelte': false
+  '@tailwindcss/oxide': true
+  esbuild: true

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
 		strictPort: true
 	},
 	plugins: [
+		{
+			name: 'limusic-dev-referrer-policy',
+			configureServer(server) {
+				server.middlewares.use((_req, res, next) => {
+					res.setHeader('Referrer-Policy', 'no-referrer');
+					next();
+				});
+			}
+		},
 		tailwindcss(),
 		sveltekit({
 			compilerOptions: {


### PR DESCRIPTION
## Problem

Local frontend development had two independent setup issues:

- Google image CDN returned HTTP 429 for some thumbnail requests carrying `Referer: http://localhost:5183/`, so WebKit displayed broken-image glyphs even though the same images loaded correctly in the AppImage.
- pnpm 11 rejected installs because `@hugeicons/svelte` declares a postinstall script but the workspace did not make an explicit allow/deny decision for it.

## Implementation

- Add a Vite `configureServer` middleware that sends `Referrer-Policy: no-referrer` only from the development server. It does not enter the static release output or affect the AppImage's `tauri://localhost` origin.
- Replace the legacy pnpm build allowlist with explicit pnpm 11 policy: permit the required `esbuild` and `@tailwindcss/oxide` build helpers, and deny Hugeicons' optional postinstall, which only prints a project promotion message.

## Impact

Local development loads Google-hosted thumbnails without the localhost referrer that triggers CDN throttling, and `pnpm install` completes non-interactively. Release behavior is unchanged.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm ignored-builds` (no automatically ignored builds; Hugeicons explicitly denied)
- `pnpm check` (0 errors, 0 warnings)
- `pnpm build`
- Verified the live Vite response includes `Referrer-Policy: no-referrer`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added a development-server privacy safeguard that prevents referrer information from being sent in responses.

* **Build & Development**
  * Updated build configuration to enable required tool builds while disabling unnecessary package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->