### PR TITLE
Explicit badge on tracks, albums and cards

### DIFF
--- a/crates/innertube/src/models/browse.rs
+++ b/crates/innertube/src/models/browse.rs
@@ -12,8 +12,9 @@ use serde_json::Value;
 
 use super::metadata::{
     artist_runs, artists_from_runs, duration_from_runs, find_all, find_all_shallow, find_first_str,
-    first_artist_id, flex_column_text, flex_runs, is_video_endpoint, is_video_row, last_thumbnail,
-    list_item_video_id, parse_list_item, runs_text, runs_text_opt, ArtistRun, SongItem,
+    first_artist_id, flex_column_text, flex_runs, is_explicit, is_video_endpoint, is_video_row,
+    last_thumbnail, list_item_video_id, parse_list_item, runs_text, runs_text_opt, ArtistRun,
+    SongItem,
 };
 
 /// One clickable card in a home carousel or library grid. Flat + `kind`-tagged so the UI can
@@ -44,6 +45,9 @@ pub struct BrowseItem {
     /// "hide music videos" setting.
     #[serde(default)]
     pub is_video: bool,
+    /// YouTube marks this card explicit ([`is_explicit`]) — a track, or an album whose tracks are.
+    #[serde(default)]
+    pub explicit: bool,
 }
 
 /// A titled row of cards on the home feed.
@@ -160,6 +164,8 @@ pub struct AlbumPage {
     pub thumbnail: Option<String>,
     pub items: Vec<SongItem>,
     pub continuation: Option<String>,
+    /// The album itself is flagged explicit (its header wears the badge, not just some tracks).
+    pub explicit: bool,
     /// The album's audio playlist id (`OLAK5uy_…`) — the radio seed for autoplay continuation and
     /// the target of the library save (an album in your library is a "like" on this playlist).
     pub playlist_id: Option<String>,
@@ -350,6 +356,7 @@ fn list_item_to_browse_item(node: &Value) -> Option<BrowseItem> {
             duration: None,
             artist_runs: Vec::new(),
             is_video: false,
+            explicit: is_explicit(node),
         });
     }
     let vid = list_item_video_id(node)?;
@@ -366,6 +373,7 @@ fn list_item_to_browse_item(node: &Value) -> Option<BrowseItem> {
         duration: duration_from_runs(runs),
         artist_runs: runs.map(|r| artist_runs(r)).unwrap_or_default(),
         is_video: is_video_row(node),
+        explicit: is_explicit(node),
     })
 }
 
@@ -399,6 +407,7 @@ fn card_shelf_main(card: &Value) -> Option<BrowseItem> {
             duration: duration_from_runs(runs),
             artist_runs: runs.map(|r| artist_runs(r)).unwrap_or_default(),
             is_video: nav.is_some_and(is_video_endpoint),
+            explicit: is_explicit(card),
         });
     }
     let bid = nav
@@ -415,6 +424,7 @@ fn card_shelf_main(card: &Value) -> Option<BrowseItem> {
         duration: None,
         artist_runs: Vec::new(),
         is_video: false,
+        explicit: is_explicit(card),
     })
 }
 
@@ -477,6 +487,7 @@ pub fn parse_album(root: &Value) -> AlbumPage {
         thumbnail,
         items,
         continuation: shelf_continuation(root),
+        explicit: header.is_some_and(is_explicit),
         // Track rows carry the OLAK id; an album with no playable rows still has it on the
         // header's save-to-library button.
         playlist_id: album_playlist_id(root).or_else(|| library_toggle_playlist_id(header)),
@@ -681,6 +692,7 @@ fn parse_carousel_item(node: &Value) -> Option<BrowseItem> {
             duration: song.duration,
             artist_runs: song.artist_runs,
             is_video: song.is_video,
+            explicit: song.explicit,
         });
     }
     None
@@ -714,6 +726,7 @@ fn parse_two_row_item(node: &Value) -> Option<BrowseItem> {
             duration: duration_from_runs(runs),
             artist_runs: runs.map(|r| artist_runs(r)).unwrap_or_default(),
             is_video: is_video_row(node),
+            explicit: is_explicit(node),
         });
     }
     // Playlist via watchPlaylistEndpoint (some carousels expose the raw playlistId).
@@ -731,6 +744,7 @@ fn parse_two_row_item(node: &Value) -> Option<BrowseItem> {
             duration: None,
             artist_runs: Vec::new(),
             is_video: false,
+            explicit: is_explicit(node),
         });
     }
     // Otherwise a browseEndpoint → playlist/album/artist by browseId prefix.
@@ -748,6 +762,7 @@ fn parse_two_row_item(node: &Value) -> Option<BrowseItem> {
         duration: None,
         artist_runs: Vec::new(),
         is_video: false,
+        explicit: is_explicit(node),
     })
 }
 

--- a/crates/innertube/src/models/metadata.rs
+++ b/crates/innertube/src/models/metadata.rs
@@ -72,6 +72,11 @@ pub struct SongItem {
     /// "hide music videos" setting; computed once here, never re-derived downstream.
     #[serde(default)]
     pub is_video: bool,
+    /// YouTube marks this track explicit ([`is_explicit`]). Only browse/search rows carry the
+    /// badge: `/next` panel rows and `/player` don't, so a radio- or autoplay-appended track
+    /// reads false even when the same song shows the badge on an album page.
+    #[serde(default)]
+    pub explicit: bool,
 }
 
 /// How the signed-in user rated a track. One type for both directions: it's what a row's
@@ -124,6 +129,17 @@ pub(crate) fn is_video_row(node: &Value) -> bool {
         Some(ep) if endpoint_video_type(ep).is_some() => is_video_endpoint(ep),
         _ => node.get("navigationEndpoint").is_some_and(is_video_endpoint),
     }
+}
+
+/// True when a renderer node wears YouTube's explicit badge. The badge is the same
+/// `musicInlineBadgeRenderer` everywhere, under one of three keys depending on the node: `badges`
+/// on a list row, `subtitleBadges` on a two-row card, `subtitleBadge` (singular) on a
+/// playlist/album header. Scoped to those keys rather than swept from the whole node, so a card's
+/// badge can't leak onto the row that contains it. Live-verified 2026-08.
+pub(crate) fn is_explicit(node: &Value) -> bool {
+    ["badges", "subtitleBadges", "subtitleBadge"].into_iter().filter_map(|key| node.get(key)).any(
+        |b| find_all(b, "iconType").into_iter().any(|t| t.as_str() == Some("MUSIC_EXPLICIT_BADGE")),
+    )
 }
 
 /// One run of an artist line: the literal text plus its channel browseId when it links one
@@ -428,6 +444,7 @@ pub(crate) fn parse_list_item(node: &Value) -> Option<SongItem> {
         queued_from: None,
         autoplay: false,
         is_video: is_video_row(node),
+        explicit: is_explicit(node),
     })
 }
 
@@ -530,6 +547,9 @@ fn parse_panel_video(node: &Value) -> Option<SongItem> {
         queued_from: None,
         autoplay: false,
         is_video: is_video_row(node),
+        // Queue-panel rows carry no badges today; asking anyway costs a map lookup and picks the
+        // flag up for free if YouTube ever adds one.
+        explicit: is_explicit(node),
     })
 }
 
@@ -1110,6 +1130,31 @@ mod tests {
         assert_eq!(identities[0].data_sync_id, "active-response-sync");
         assert_eq!(identities[1].name, "Fallback token");
         assert_eq!(identities[1].data_sync_id, "fallback-sync");
+    }
+
+    // Three keys, one badge shape, and a badge array that can hold other badges alongside it.
+    // Getting the key wrong reads false everywhere and the flag silently never shows.
+    #[test]
+    fn explicit_badge_is_read_from_every_key_it_arrives_under() {
+        let badge = json!([{ "musicInlineBadgeRenderer": {
+            "icon": { "iconType": "MUSIC_EXPLICIT_BADGE" },
+            "accessibilityData": { "accessibilityData": { "label": "Explicit" } }
+        } }]);
+        // List row (search / playlist / album tracks), two-row card, playlist+album header.
+        assert!(is_explicit(&json!({ "badges": badge })));
+        assert!(is_explicit(&json!({ "subtitleBadges": badge })));
+        assert!(is_explicit(&json!({ "subtitleBadge": badge })));
+        // Alongside another badge, and with no badge at all.
+        assert!(is_explicit(&json!({ "badges": [
+            { "musicInlineBadgeRenderer": { "icon": { "iconType": "MUSIC_NEW_RELEASE_BADGE" } } },
+            badge[0]
+        ] })));
+        assert!(!is_explicit(&json!({ "badges": [
+            { "musicInlineBadgeRenderer": { "icon": { "iconType": "MUSIC_NEW_RELEASE_BADGE" } } }
+        ] })));
+        assert!(!is_explicit(&json!({})));
+        // Never from a nested row: an album card inside a shelf must not badge the shelf's row.
+        assert!(!is_explicit(&json!({ "contents": [{ "subtitleBadges": badge }] })));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -402,6 +402,7 @@ pub async fn get_library(state: St<'_>) -> Result<Vec<BrowseItem>, String> {
                 duration: None,
                 artist_runs: Vec::new(),
                 is_video: false,
+                explicit: false,
             },
         );
     }

--- a/src-tauri/src/local.rs
+++ b/src-tauri/src/local.rs
@@ -455,6 +455,8 @@ fn albums_of(tracks: &[LocalTrack]) -> Vec<BrowseItem> {
                 duration: None,
                 artist_runs: Vec::new(),
                 is_video: false,
+                // Nothing on disk says explicit: no tag carries it and there is no row to badge.
+                explicit: false,
             }
         })
         .collect();
@@ -503,6 +505,7 @@ fn artists_of(tracks: &[LocalTrack]) -> Vec<BrowseItem> {
                 duration: None,
                 artist_runs: Vec::new(),
                 is_video: false,
+                explicit: false,
             }
         })
         .collect();
@@ -559,6 +562,7 @@ fn page_of(title: Option<String>, artist: Option<String>, tracks: &[LocalTrack])
         thumbnail: tracks.iter().find_map(|t| t.cover.clone()),
         items: songs_of(&tracks),
         continuation: None,
+        explicit: false,
         // No YouTube playlist behind it: no radio to seed, nothing to save to the library.
         playlist_id: None,
         in_library: false,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2597,6 +2597,8 @@ fn track_to_song(t: &Track) -> SongItem {
         queued_from: None,
         autoplay: false,
         is_video: false,
+        // The Listen Together wire shape carries no badge, so a mirrored guest queue shows none.
+        explicit: false,
     }
 }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -43,6 +43,9 @@ export interface SongItem {
 	queued_from?: string;
 	/** Appended by autoplay radio continuation — drives the queue's "Autoplay" divider + badge. */
 	autoplay?: boolean;
+	/** YouTube flags the track explicit. Browse/search rows only: `/next` carries no badge, so a
+	 *  radio- or autoplay-appended track arrives without it. */
+	explicit?: boolean;
 }
 
 export interface NowPlaying {
@@ -107,6 +110,8 @@ export interface BrowseItem {
 	duration?: string;
 	/** Song cards only: the artist line run by run, so a card that gets played keeps its links. */
 	artistRuns?: ArtistRun[];
+	/** YouTube flags this track/album explicit. */
+	explicit?: boolean;
 }
 
 export interface HomeSection {
@@ -199,6 +204,8 @@ export interface AlbumPage {
 	thumbnail?: string;
 	items: SongItem[];
 	continuation?: string;
+	/** The album itself is flagged explicit (the header wears the badge, not just some tracks). */
+	explicit?: boolean;
 	/** The album's audio playlist id (`OLAK5uy_…`) — autoplay's radio seed, and the save target. */
 	playlistId?: string;
 	/** Already saved to the signed-in user's library. */

--- a/ui/src/lib/browse.ts
+++ b/ui/src/lib/browse.ts
@@ -21,7 +21,8 @@ export const asSong = (i: BrowseItem): SongItem => ({
 	artist_runs: i.artistRuns,
 	artist_id: i.artistRuns?.find((r) => r.id)?.id,
 	duration: i.duration,
-	thumbnail: i.thumbnail
+	thumbnail: i.thumbnail,
+	explicit: i.explicit
 });
 
 /** Where a non-song item lives. Songs have no page — they play. */

--- a/ui/src/lib/components/ExplicitIcon.svelte
+++ b/ui/src/lib/components/ExplicitIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	// "E" in a rounded square: YouTube's explicit marker. Drawn here because HugeIcons' free set
+	// has no explicit-content icon, to the same 24px box / 1.5 stroke / round joins as the rest of
+	// the icons it sits beside, so it takes size and colour from `class` the same way they do.
+	let { class: cls = '' }: { class?: string } = $props();
+</script>
+
+<svg
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="1.5"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	class={cls}
+	role="img"
+	aria-label="Explicit"
+>
+	<rect x="3" y="3" width="18" height="18" rx="4" />
+	<path d="M15 7.5H9v9h6M9 12h4.5" />
+</svg>

--- a/ui/src/lib/components/MediaCard.svelte
+++ b/ui/src/lib/components/MediaCard.svelte
@@ -14,6 +14,7 @@
 	import { openAddToPlaylist } from '$lib/player.svelte';
 	import TrackMenu from './TrackMenu.svelte';
 	import PlaylistMenu from './PlaylistMenu.svelte';
+	import ExplicitIcon from './ExplicitIcon.svelte';
 
 	let { item, compact = false }: { item: BrowseItem; compact?: boolean } = $props();
 
@@ -155,9 +156,16 @@
 		</div>
 		<div class="min-w-0 {round ? 'text-center' : ''}">
 			<div class="truncate font-medium {compact ? 'text-xs' : 'text-sm'}">{item.title}</div>
-			{#if item.subtitle}
-				<div class="truncate text-muted-foreground {compact ? 'text-[0.6875rem]' : 'text-xs'}">
-					{item.subtitle}
+			{#if item.subtitle || item.explicit}
+				<div
+					class="flex items-center gap-1 text-muted-foreground {round
+						? 'justify-center'
+						: ''} {compact ? 'text-[0.6875rem]' : 'text-xs'}"
+				>
+					{#if item.explicit}
+						<ExplicitIcon class="h-3 w-3 shrink-0" />
+					{/if}
+					<span class="truncate">{item.subtitle}</span>
 				</div>
 			{/if}
 		</div>

--- a/ui/src/lib/components/TrackRow.svelte
+++ b/ui/src/lib/components/TrackRow.svelte
@@ -48,8 +48,9 @@
 		 */
 		showPlayCount?: boolean;
 		/**
-		 * Drop the inline thumbs (the queue panel): two buttons plus the duration leave nothing for
-		 * the title and artists at that width. The ⋯ menu carries like and dislike either way.
+		 * The narrow queue-panel variant: drops the inline thumbs and the explicit mark. Two buttons
+		 * plus the duration leave nothing for the title and artists at that width, and the queue is
+		 * not where you decide what to listen to. The ⋯ menu carries like and dislike either way.
 		 */
 		hideRating?: boolean;
 		onplay: () => void;
@@ -186,7 +187,7 @@
 	<div class="flex shrink-0 items-center {compact ? 'gap-0.5' : 'gap-2'}">
 		<!-- Always on, unlike the thumbs beside it: this is a property of the song, not an action,
 		     so hiding it until the pointer arrives would be hiding half of what it's for. -->
-		{#if song.explicit}
+		{#if song.explicit && !hideRating}
 			<ExplicitIcon class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
 		{/if}
 		{#if showRating}

--- a/ui/src/lib/components/TrackRow.svelte
+++ b/ui/src/lib/components/TrackRow.svelte
@@ -15,6 +15,7 @@
 	import { isLiked, ratingOf, toggleRating } from '$lib/player.svelte';
 	import TrackMenu from './TrackMenu.svelte';
 	import ArtistLine from './ArtistLine.svelte';
+	import ExplicitIcon from './ExplicitIcon.svelte';
 
 	let {
 		song,
@@ -183,6 +184,11 @@
 	{/if}
 
 	<div class="flex shrink-0 items-center {compact ? 'gap-0.5' : 'gap-2'}">
+		<!-- Always on, unlike the thumbs beside it: this is a property of the song, not an action,
+		     so hiding it until the pointer arrives would be hiding half of what it's for. -->
+		{#if song.explicit}
+			<ExplicitIcon class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+		{/if}
 		{#if showRating}
 			<!-- Hover-revealed, except on a row that carries a rating: at rest that filled thumb is the
 			     only place the state shows at all. Faded rather than removed, so the duration and the ⋯

--- a/ui/src/routes/album/[id]/+page.svelte
+++ b/ui/src/routes/album/[id]/+page.svelte
@@ -119,6 +119,9 @@
         title: album?.title ?? "Album",
         subtitle: album?.artist,
         thumbnail: album?.thumbnail,
+        // Recently played keeps this object as the card it draws, so without the flag an album
+        // played from its own page would lose the mark it has everywhere else.
+        explicit: album?.explicit,
     });
 
     function playAll(start: number | null) {

--- a/ui/src/routes/album/[id]/+page.svelte
+++ b/ui/src/routes/album/[id]/+page.svelte
@@ -18,6 +18,7 @@
     import TrackRowSkeleton from "$lib/components/TrackRowSkeleton.svelte";
     import ErrorState from "$lib/components/ErrorState.svelte";
     import ArtistLine from "$lib/components/ArtistLine.svelte";
+    import ExplicitIcon from "$lib/components/ExplicitIcon.svelte";
     import { Skeleton } from "$lib/components/ui/skeleton";
     import * as api from "$lib/api";
     import type { AlbumPage, BrowseItem } from "$lib/api";
@@ -243,6 +244,9 @@
                     <div
                         class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground"
                     >
+                        {#if album.explicit}
+                            <ExplicitIcon class="h-4 w-4 shrink-0" />
+                        {/if}
                         {#if album.artist}
                             <span
                                 class="flex items-center gap-1.5 font-medium text-foreground"


### PR DESCRIPTION
Closes #22.

YouTube ships an explicit flag on browse and search responses and we were dropping it. This reads it and shows an E next to the tracks and albums that carry one.

**Where it comes from.** Always the same `musicInlineBadgeRenderer` with `iconType: MUSIC_EXPLICIT_BADGE`, under one of three keys depending on the node:

| Surface | Key |
|---|---|
| Track rows (search, album, playlist, library) | `badges` on `musicResponsiveListItemRenderer` |
| Cards (album and song tiles) | `subtitleBadges` on `musicTwoRowItemRenderer` |
| Album/playlist header | `subtitleBadge` on `musicResponsiveHeaderRenderer` |

One helper (`is_explicit`) reads all three, scoped to those keys so a card nested in a shelf cannot badge the row containing it.

**Where it isn't.** `/next` panel rows and `/player` carry no badge at all (checked against live responses), so a track appended by autoplay or a radio arrives unflagged. Local files and the Listen Together wire shape have nothing to read it from either.

**UI.** HugeIcons' free set has no explicit mark, so the icon is drawn in `ExplicitIcon.svelte`: an E in a rounded square, same 24px box and 1.5 stroke as the icons beside it. It shows in track rows (left of the thumbs, and visible at rest rather than on hover, since it describes the song instead of offering an action), on album and song cards, and in the album page header. The queue panel drops it for the same reason it drops the thumbs.

`cargo test -p innertube` 55/55, `cargo check --workspace` clean, `pnpm check` 0 errors. Not yet verified on screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit-content indicators to songs, albums, playlists, search results, library cards, and queue items.
  * Explicit markers now appear consistently on track rows, media cards, and album headers.
  * Added accessible, scalable styling for explicit-content icons.
  * Local and generated content is correctly treated as non-explicit when no metadata is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->