### PR TITLE
feat(playlist): sorting

### DIFF
--- a/crates/innertube/src/models/metadata.rs
+++ b/crates/innertube/src/models/metadata.rs
@@ -419,6 +419,8 @@ pub(crate) fn parse_list_item(node: &Value) -> Option<SongItem> {
     let (artists, album, duration) = split_subtitle(subtitle_runs);
     // Playlist/album rows keep the length in a fixed column instead of the subtitle. context/08.
     let duration = duration.or_else(|| fixed_column_text(node));
+    // …and the album in a column of its own rather than in the subtitle runs.
+    let album = album.or_else(|| album_column(node));
     let artist_id = subtitle_runs.and_then(|r| first_artist_id(r));
     let set_video_id = node
         .get("playlistItemData")
@@ -455,6 +457,16 @@ fn play_count(node: &Value) -> Option<String> {
     let text = flex_column_text(node, 2)?;
     let (count, unit) = text.trim().rsplit_once(' ')?;
     unit.eq_ignore_ascii_case("plays").then(|| count.to_owned())
+}
+
+/// The album name from that same third flex column — the other thing it can hold. A playlist row's
+/// subtitle is the artist alone ("Artist"), not the search/next form ("Artist • Album • 3:02"), so
+/// without this every playlist track comes back album-less. Same discriminator as [`play_count`],
+/// read the other way round. context/08.
+fn album_column(node: &Value) -> Option<String> {
+    let text = flex_column_text(node, 2)?;
+    let text = text.trim();
+    (!text.is_empty() && play_count(node).is_none()).then(|| text.to_owned())
 }
 
 /// The album's browseId (`MPRE…`): either the linked album run or the row menu's "Go to album"
@@ -948,6 +960,12 @@ mod tests {
         assert_eq!(plays(json!("1,234 plays")).unwrap().play_count.as_deref(), Some("1,234"));
         assert_eq!(plays(json!("The Album")).unwrap().play_count, None);
         assert_eq!(plays(json!("")).unwrap().play_count, None);
+        // The other half of the same discriminator: what isn't a play count is the album, which is
+        // the only place a playlist row carries one (its subtitle is the artist alone). Without it
+        // every playlist track parses album-less and grouping a playlist by album does nothing.
+        assert_eq!(plays(json!("The Album")).unwrap().album.as_deref(), Some("The Album"));
+        assert_eq!(plays(json!("53M plays")).unwrap().album, None);
+        assert_eq!(plays(json!("")).unwrap().album, None);
     }
 
     // An artist or album with a colon in its name ("Cast of EPIC: The Musical") used to read as the

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -440,6 +440,14 @@ pub async fn get_playlist(state: St<'_>, id: String) -> Result<PlaylistPage, Str
     state.it.playlist(client, &id).await.map_err(|e| e.to_string())
 }
 
+/// videoId → how many times it was played, over the same trailing window On Repeat is built from
+/// (the history table is pruned to it, so there is no older data to offer). Feeds the playlist
+/// page's "Most played" sort; a track the map doesn't mention has not been played this month.
+#[tauri::command]
+pub fn play_counts(state: St<'_>) -> std::collections::HashMap<String, i64> {
+    state.db.play_counts(now_secs() - ON_REPEAT_WINDOW_SECS).into_iter().collect()
+}
+
 /// The On Repeat track list: most-played first, over the trailing window. Rows whose stored JSON
 /// no longer parses (a `SongItem` shape change) are dropped rather than failing the whole page.
 fn on_repeat_songs(state: &Arc<AppState>) -> Vec<SongItem> {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -325,6 +325,22 @@ impl Db {
         out
     }
 
+    /// Play count per videoId since `since`. [`Db::top_plays`] answers "what are my 20 most played
+    /// songs"; this answers "how many times have I played each of these", which is what sorting an
+    /// arbitrary playlist by plays needs. Same table, so the same trailing window applies.
+    pub fn play_counts(&self, since: i64) -> Vec<(String, i64)> {
+        let conn = self.0.lock().unwrap();
+        let mut out = Vec::new();
+        if let Ok(mut stmt) = conn
+            .prepare("SELECT video_id, COUNT(*) FROM plays WHERE played_at >= ?1 GROUP BY video_id")
+        {
+            if let Ok(rows) = stmt.query_map([since], |r| Ok((r.get(0)?, r.get(1)?))) {
+                out.extend(rows.flatten());
+            }
+        }
+        out
+    }
+
     // --- local music library (local.rs) -------------------------------------------------------
 
     /// Every known file with its recorded mtime — the scanner re-reads tags only where it differs.
@@ -475,6 +491,15 @@ mod tests {
             "'old' is outside the window and must not appear"
         );
         assert_eq!(d.top_plays(900, 2).len(), 2, "limit applies");
+
+        // Same rows through `play_counts`: every song, not a top N, and no metadata.
+        let mut counts = d.play_counts(900);
+        counts.sort();
+        assert_eq!(counts, vec![("a".into(), 2), ("b".into(), 3), ("c".into(), 1)]);
+        assert!(
+            d.play_counts(1_500) == vec![("c".into(), 1)],
+            "`since` cuts the same way it does for top_plays"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -393,6 +393,7 @@ pub fn run() {
             commands::get_library_artists,
             commands::get_playlist,
             commands::get_playlist_more,
+            commands::play_counts,
             commands::get_album,
             commands::get_local_library,
             commands::add_local_folder,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2983,6 +2983,7 @@ mod tests {
             queued_by: by.map(Into::into),
             autoplay: false,
             is_video: false,
+            explicit: false,
         }
     }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -318,6 +318,12 @@ export const getPlaylist = (id: string) => invoke<PlaylistPage>('get_playlist', 
 export const getPlaylistMore = (token: string) =>
 	invoke<PlaylistContinuation>('get_playlist_more', { token });
 /**
+ * videoId → times played, from the local listening history. Same trailing window On Repeat uses
+ * (a month): the history table is pruned to it, so there is no older data. A videoId that isn't in
+ * the map has not been played inside the window.
+ */
+export const getPlayCounts = () => invoke<Record<string, number>>('play_counts');
+/**
  * `start`: the clicked track index, or `null` for "just play it" (random opener under shuffle).
  * `sourceId`: the page's playlist/album playlist id — makes autoplay continue with that
  * context's radio (omit to fall back to song radio seeded from the queue's last track).

--- a/ui/src/lib/components/ui/radio-group/index.ts
+++ b/ui/src/lib/components/ui/radio-group/index.ts
@@ -1,0 +1,10 @@
+import Root from "./radio-group.svelte";
+import Item from "./radio-group-item.svelte";
+
+export {
+	Root,
+	Item,
+	//
+	Root as RadioGroup,
+	Item as RadioGroupItem,
+};

--- a/ui/src/lib/components/ui/radio-group/radio-group-item.svelte
+++ b/ui/src/lib/components/ui/radio-group/radio-group-item.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { RadioGroup as RadioGroupPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps> = $props();
+</script>
+
+<RadioGroupPrimitive.Item
+	bind:ref
+	data-slot="radio-group-item"
+	class={cn(
+		"border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aspect-square size-4 shrink-0 cursor-pointer rounded-full border shadow-xs outline-none transition focus-visible:ring-[3px] data-checked:border-primary data-disabled:cursor-not-allowed data-disabled:opacity-50",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked })}
+		<!-- The dot is the control itself, not an icon: a div, the way switch.svelte draws its thumb.
+		     shadcn ships a lucide circle here; this project uses HugeIcons and neither set owns this. -->
+		<div class="flex items-center justify-center">
+			{#if checked}
+				<div class="size-2 rounded-full bg-primary"></div>
+			{/if}
+		</div>
+	{/snippet}
+</RadioGroupPrimitive.Item>

--- a/ui/src/lib/components/ui/radio-group/radio-group.svelte
+++ b/ui/src/lib/components/ui/radio-group/radio-group.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { RadioGroup as RadioGroupPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value = $bindable(""),
+		...restProps
+	}: RadioGroupPrimitive.RootProps = $props();
+</script>
+
+<RadioGroupPrimitive.Root
+	bind:ref
+	bind:value
+	data-slot="radio-group"
+	class={cn("grid gap-2", className)}
+	{...restProps}
+/>

--- a/ui/src/lib/sort.check.ts
+++ b/ui/src/lib/sort.check.ts
@@ -62,7 +62,9 @@ ok(ids(sortSongs(items, 'artist', false)) === 'cbad', 'artist groups, title orde
 const tied = [song('x', 'Same', 'Alpha'), song('y', 'Same', 'Alpha')];
 ok(ids(sortSongs(tied, 'artist', false)) === 'xy', 'a total tie keeps playlist order');
 
-// --- album: the albumless track goes last, not first -------------------------------------------
-ok(ids(sortSongs(items, 'album', false)) === 'dbac', 'album sorts First, Second, then no album');
+// --- album: groups, keeps playlist order inside a group, albumless last -----------------------
+// b and d are both on "First"; b is first in the playlist, so it stays first (no title tiebreak
+// here, or an album added in one go would come back alphabetised instead of in track order).
+ok(ids(sortSongs(items, 'album', false)) === 'bdac', 'album groups First, Second, then no album');
 
 console.log('ok');

--- a/ui/src/lib/sort.check.ts
+++ b/ui/src/lib/sort.check.ts
@@ -31,9 +31,9 @@ ok(sortSongs(items.slice(0, 1), 'title', false).length === 1, 'a one-track list 
 
 // --- nothing is lost or duplicated ------------------------------------------------------------
 // The queue is built from this list, so a comparator that drops a track silently shortens it.
-for (const key of ['default', 'newest', 'oldest', 'title', 'artist', 'album'] as const) {
+for (const key of ['default', 'newest', 'oldest', 'title', 'artist', 'album', 'plays'] as const) {
 	for (const desc of [false, true]) {
-		const out = sortSongs(items, key, false, desc);
+		const out = sortSongs(items, key, false, desc, { b: 4, d: 1 });
 		ok(out.length === items.length, `${key} desc=${desc} keeps every track`);
 		ok(
 			[...out].map((t) => t.video_id).sort().join('') === 'abcd',
@@ -80,5 +80,14 @@ ok(ids(sortSongs(items, 'artist', false, true)) === 'dabc', 'artist descending f
 // reason to play an album backwards. And an albumless track stays last, it does not lead.
 ok(ids(sortSongs(items, 'album', false, true)) === 'abdc', 'album descending, albumless still last');
 ok(ids(sortSongs(tied, 'artist', false, true)) === 'xy', 'a total tie keeps playlist order either way');
+
+// --- most played: local history, missing means zero --------------------------------------------
+// b played 4 times, d once, a and c never — and the two unplayed keep playlist order between them.
+const counts = { b: 4, d: 1 };
+ok(ids(sortSongs(items, 'plays', false, false, counts)) === 'bdac', 'most played leads');
+ok(ids(sortSongs(items, 'plays', false, true, counts)) === 'acdb', 'descending is least played');
+ok(ids(sortSongs(items, 'plays', false, false, {})) === 'abcd', 'no history at all changes nothing');
+// A count for a track that is not in this playlist must not disturb the ones that are.
+ok(ids(sortSongs(items, 'plays', false, false, { zzz: 99, b: 4, d: 1 })) === 'bdac', 'stray ids ignored');
 
 console.log('ok');

--- a/ui/src/lib/sort.check.ts
+++ b/ui/src/lib/sort.check.ts
@@ -31,13 +31,15 @@ ok(sortSongs(items.slice(0, 1), 'title', false).length === 1, 'a one-track list 
 
 // --- nothing is lost or duplicated ------------------------------------------------------------
 // The queue is built from this list, so a comparator that drops a track silently shortens it.
-for (const key of ['newest', 'oldest', 'title', 'artist', 'album'] as const) {
-	const out = sortSongs(items, key, false);
-	ok(out.length === items.length, `${key} keeps every track`);
-	ok(
-		[...out].map((t) => t.video_id).sort().join('') === 'abcd',
-		`${key} is a permutation, no dupes`
-	);
+for (const key of ['default', 'newest', 'oldest', 'title', 'artist', 'album'] as const) {
+	for (const desc of [false, true]) {
+		const out = sortSongs(items, key, false, desc);
+		ok(out.length === items.length, `${key} desc=${desc} keeps every track`);
+		ok(
+			[...out].map((t) => t.video_id).sort().join('') === 'abcd',
+			`${key} desc=${desc} is a permutation, no dupes`
+		);
+	}
 }
 // Sorting in place would reorder `pl.items` itself, and the page relies on that staying YouTube's
 // order (it is what Default and the setVideoId backfill both read).
@@ -66,5 +68,17 @@ ok(ids(sortSongs(tied, 'artist', false)) === 'xy', 'a total tie keeps playlist o
 // b and d are both on "First"; b is first in the playlist, so it stays first (no title tiebreak
 // here, or an album added in one go would come back alphabetised instead of in track order).
 ok(ids(sortSongs(items, 'album', false)) === 'bdac', 'album groups First, Second, then no album');
+
+// --- descending reverses the key, and only the key ---------------------------------------------
+ok(ids(sortSongs(items, 'default', false, true)) === 'dcba', 'default descending reverses the list');
+ok(ids(sortSongs(items, 'newest', false, true)) === 'abcd', 'newest descending is oldest first');
+ok(ids(sortSongs(items, 'oldest', true, true)) === 'abcd', 'oldest descending on Liked Music');
+ok(ids(sortSongs(items, 'title', false, true)) === 'abcd', 'title descending is Z to A');
+// The Alpha pair flips with everything else, tiebreak included: "track 10" then "track 9".
+ok(ids(sortSongs(items, 'artist', false, true)) === 'dabc', 'artist descending flips the tiebreak');
+// The album groups reverse, but "First" keeps b before d — a descending sort is still not a
+// reason to play an album backwards. And an albumless track stays last, it does not lead.
+ok(ids(sortSongs(items, 'album', false, true)) === 'abdc', 'album descending, albumless still last');
+ok(ids(sortSongs(tied, 'artist', false, true)) === 'xy', 'a total tie keeps playlist order either way');
 
 console.log('ok');

--- a/ui/src/lib/sort.check.ts
+++ b/ui/src/lib/sort.check.ts
@@ -1,0 +1,68 @@
+// Self-check for playlist sorting (`sort.ts`). Same deal as `rows.check.ts` — no test runner in
+// `ui/`, node 22 runs TypeScript directly:
+//
+//     node --experimental-strip-types ui/src/lib/sort.check.ts
+//
+// Prints "ok" and exits 0, or throws on the first broken invariant. What this guards is the part
+// the queue depends on: the sorted list has to hold exactly the same tracks as the input (never
+// dropping or duplicating one), and `default` has to hand back the original array untouched.
+import type { SongItem } from './api.ts';
+import { sortSongs } from './sort.ts';
+
+function ok(cond: boolean, what: string): void {
+	if (!cond) throw new Error(`FAIL: ${what}`);
+}
+
+const song = (video_id: string, title: string, artists: string, album?: string): SongItem =>
+	({ video_id, title, artists, album }) as SongItem;
+
+// Deliberately messy: mixed case, a numeric run, a missing album, two tracks that tie on artist.
+const items = [
+	song('a', 'Zebra', 'beta', 'Second'),
+	song('b', 'track 10', 'Alpha', 'First'),
+	song('c', 'track 9', 'Alpha'),
+	song('d', 'apple', 'Gamma', 'First')
+];
+const ids = (list: SongItem[]) => list.map((t) => t.video_id).join('');
+
+// --- default is a no-op, identity included ---------------------------------------------------
+ok(sortSongs(items, 'default', false) === items, 'default returns the very same array');
+ok(sortSongs(items.slice(0, 1), 'title', false).length === 1, 'a one-track list survives');
+
+// --- nothing is lost or duplicated ------------------------------------------------------------
+// The queue is built from this list, so a comparator that drops a track silently shortens it.
+for (const key of ['newest', 'oldest', 'title', 'artist', 'album'] as const) {
+	const out = sortSongs(items, key, false);
+	ok(out.length === items.length, `${key} keeps every track`);
+	ok(
+		[...out].map((t) => t.video_id).sort().join('') === 'abcd',
+		`${key} is a permutation, no dupes`
+	);
+}
+// Sorting in place would reorder `pl.items` itself, and the page relies on that staying YouTube's
+// order (it is what Default and the setVideoId backfill both read).
+ok(ids(items) === 'abcd', 'the input array is still in playlist order afterwards');
+
+// --- add order --------------------------------------------------------------------------------
+// A normal playlist arrives oldest-added first, so newest-first is the reverse and oldest-first is
+// the order as given. Liked Music arrives the other way round and both flip with it.
+ok(ids(sortSongs(items, 'oldest', false)) === 'abcd', 'oldest-first on an oldest-first list');
+ok(ids(sortSongs(items, 'newest', false)) === 'dcba', 'newest-first reverses it');
+ok(ids(sortSongs(items, 'newest', true)) === 'abcd', 'newest-first on Liked Music');
+ok(ids(sortSongs(items, 'oldest', true)) === 'dcba', 'oldest-first reverses Liked Music');
+
+// --- title: case-insensitive, and "10" after "9" ----------------------------------------------
+ok(ids(sortSongs(items, 'title', false)) === 'dcba', 'title sorts apple, track 9, track 10, Zebra');
+
+// --- artist: case-insensitive, title orders the group -----------------------------------------
+// b and c are both "Alpha", so the title tiebreak decides: "track 9" before "track 10".
+ok(ids(sortSongs(items, 'artist', false)) === 'cbad', 'artist groups, title orders inside a group');
+
+// Equal on both keys: nothing left to compare, so playlist order survives.
+const tied = [song('x', 'Same', 'Alpha'), song('y', 'Same', 'Alpha')];
+ok(ids(sortSongs(tied, 'artist', false)) === 'xy', 'a total tie keeps playlist order');
+
+// --- album: the albumless track goes last, not first -------------------------------------------
+ok(ids(sortSongs(items, 'album', false)) === 'dbac', 'album sorts First, Second, then no album');
+
+console.log('ok');

--- a/ui/src/lib/sort.ts
+++ b/ui/src/lib/sort.ts
@@ -34,11 +34,13 @@ export function sortSongs(
 	if (sort === 'default' || items.length < 2) return items;
 	if (sort === 'newest' || sort === 'oldest')
 		return (sort === 'newest') === baseNewestFirst ? items : items.slice().reverse();
-	// '￿' parks albumless tracks at the end rather than the top.
-	const key = (t: SongItem) =>
-		sort === 'title' ? t.title : sort === 'artist' ? t.artists : t.album || '￿';
-	// Array#sort is stable, so ties keep playlist order; the title tiebreak only decides the order
-	// inside one artist's or album's block.
+	// Album is a grouping, so inside one album the playlist's own order stands (Array#sort is
+	// stable): an album added in one go keeps its track order, which alphabetising would destroy.
+	// '￿' parks the albumless tracks at the end rather than the top.
+	if (sort === 'album')
+		return items.slice().sort((a, b) => collator.compare(a.album || '￿', b.album || '￿'));
+	// Title orders an artist's block; on a title sort the tiebreak is a no-op.
+	const key = (t: SongItem) => (sort === 'title' ? t.title : t.artists);
 	return items
 		.slice()
 		.sort((a, b) => collator.compare(key(a), key(b)) || collator.compare(a.title, b.title));

--- a/ui/src/lib/sort.ts
+++ b/ui/src/lib/sort.ts
@@ -5,7 +5,7 @@
 // list and switching back to Default costs nothing.
 import type { SongItem } from './api';
 
-export type SortKey = 'default' | 'newest' | 'oldest' | 'title' | 'artist' | 'album';
+export type SortKey = 'default' | 'newest' | 'oldest' | 'title' | 'artist' | 'album' | 'plays';
 
 export const SORTS: { key: SortKey; label: string }[] = [
 	{ key: 'default', label: 'Default' },
@@ -13,7 +13,8 @@ export const SORTS: { key: SortKey; label: string }[] = [
 	{ key: 'oldest', label: 'Oldest first' },
 	{ key: 'title', label: 'Title' },
 	{ key: 'artist', label: 'Artist' },
-	{ key: 'album', label: 'Album' }
+	{ key: 'album', label: 'Album' },
+	{ key: 'plays', label: 'Most played' }
 ];
 
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
@@ -28,18 +29,28 @@ const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'bas
  *
  * `desc` reverses whatever the key ordered, and nothing else: ties still fall back to playlist
  * order, and a track with no album still sorts last rather than jumping to the top.
+ *
+ * `plays` is the local listening history (videoId → count, see `api.getPlayCounts`); a track it
+ * doesn't mention counts as zero. It orders most-played first, so descending means least-played
+ * first, the same way "Newest first" reads.
  */
 export function sortSongs(
 	items: SongItem[],
 	sort: SortKey,
 	baseNewestFirst: boolean,
-	desc = false
+	desc = false,
+	plays: Record<string, number> = {}
 ): SongItem[] {
 	if (items.length < 2) return items;
 	if (sort === 'default') return desc ? items.slice().reverse() : items;
 	if (sort === 'newest' || sort === 'oldest')
 		return ((sort === 'newest') !== desc) === baseNewestFirst ? items : items.slice().reverse();
 	const dir = desc ? -1 : 1;
+	// Ties (everything unplayed, most of a big playlist) keep playlist order.
+	if (sort === 'plays')
+		return items
+			.slice()
+			.sort((a, b) => dir * ((plays[b.video_id] ?? 0) - (plays[a.video_id] ?? 0)));
 	// Album is a grouping, so inside one album the playlist's own order stands (Array#sort is
 	// stable): an album added in one go keeps its track order, which alphabetising would destroy.
 	// Descending reverses the albums, not the tracks within one.

--- a/ui/src/lib/sort.ts
+++ b/ui/src/lib/sort.ts
@@ -1,0 +1,45 @@
+// Playlist sorting. Pure so it can be checked without a DOM (`sort.check.ts`).
+//
+// The playlist page keeps `pl.items` in YouTube's order and treats the sort as a view over it, so
+// every optimistic mutation (add, remove, setVideoId backfill, loadMore) keeps working on the real
+// list and switching back to Default costs nothing.
+import type { SongItem } from './api';
+
+export type SortKey = 'default' | 'newest' | 'oldest' | 'title' | 'artist' | 'album';
+
+export const SORTS: { key: SortKey; label: string }[] = [
+	{ key: 'default', label: 'Default' },
+	{ key: 'newest', label: 'Newest first' },
+	{ key: 'oldest', label: 'Oldest first' },
+	{ key: 'title', label: 'Title' },
+	{ key: 'artist', label: 'Artist' },
+	{ key: 'album', label: 'Album' }
+];
+
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+/**
+ * Sort a playlist's tracks. Returns the input array untouched for `default` (and for anything too
+ * short to reorder), a new array otherwise — the page compares identity to skip re-rendering.
+ *
+ * `baseNewestFirst` says which end of the incoming order is the newest addition. Playlist rows
+ * carry no timestamp, so newest/oldest is add order, i.e. the position YouTube hands them back in:
+ * Liked Music arrives most-recently-liked first, every other playlist arrives oldest-added first.
+ */
+export function sortSongs(
+	items: SongItem[],
+	sort: SortKey,
+	baseNewestFirst: boolean
+): SongItem[] {
+	if (sort === 'default' || items.length < 2) return items;
+	if (sort === 'newest' || sort === 'oldest')
+		return (sort === 'newest') === baseNewestFirst ? items : items.slice().reverse();
+	// '￿' parks albumless tracks at the end rather than the top.
+	const key = (t: SongItem) =>
+		sort === 'title' ? t.title : sort === 'artist' ? t.artists : t.album || '￿';
+	// Array#sort is stable, so ties keep playlist order; the title tiebreak only decides the order
+	// inside one artist's or album's block.
+	return items
+		.slice()
+		.sort((a, b) => collator.compare(key(a), key(b)) || collator.compare(a.title, b.title));
+}

--- a/ui/src/lib/sort.ts
+++ b/ui/src/lib/sort.ts
@@ -19,29 +19,43 @@ export const SORTS: { key: SortKey; label: string }[] = [
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
 /**
- * Sort a playlist's tracks. Returns the input array untouched for `default` (and for anything too
- * short to reorder), a new array otherwise — the page compares identity to skip re-rendering.
+ * Sort a playlist's tracks. Returns the input array untouched when there is nothing to do, a new
+ * array otherwise — the page compares identity to skip re-rendering.
  *
  * `baseNewestFirst` says which end of the incoming order is the newest addition. Playlist rows
  * carry no timestamp, so newest/oldest is add order, i.e. the position YouTube hands them back in:
  * Liked Music arrives most-recently-liked first, every other playlist arrives oldest-added first.
+ *
+ * `desc` reverses whatever the key ordered, and nothing else: ties still fall back to playlist
+ * order, and a track with no album still sorts last rather than jumping to the top.
  */
 export function sortSongs(
 	items: SongItem[],
 	sort: SortKey,
-	baseNewestFirst: boolean
+	baseNewestFirst: boolean,
+	desc = false
 ): SongItem[] {
-	if (sort === 'default' || items.length < 2) return items;
+	if (items.length < 2) return items;
+	if (sort === 'default') return desc ? items.slice().reverse() : items;
 	if (sort === 'newest' || sort === 'oldest')
-		return (sort === 'newest') === baseNewestFirst ? items : items.slice().reverse();
+		return ((sort === 'newest') !== desc) === baseNewestFirst ? items : items.slice().reverse();
+	const dir = desc ? -1 : 1;
 	// Album is a grouping, so inside one album the playlist's own order stands (Array#sort is
 	// stable): an album added in one go keeps its track order, which alphabetising would destroy.
-	// '￿' parks the albumless tracks at the end rather than the top.
+	// Descending reverses the albums, not the tracks within one.
 	if (sort === 'album')
-		return items.slice().sort((a, b) => collator.compare(a.album || '￿', b.album || '￿'));
+		return items
+			.slice()
+			.sort(
+				(a, b) =>
+					Number(!a.album) - Number(!b.album) ||
+					dir * collator.compare(a.album ?? '', b.album ?? '')
+			);
 	// Title orders an artist's block; on a title sort the tiebreak is a no-op.
 	const key = (t: SongItem) => (sort === 'title' ? t.title : t.artists);
 	return items
 		.slice()
-		.sort((a, b) => collator.compare(key(a), key(b)) || collator.compare(a.title, b.title));
+		.sort(
+			(a, b) => dir * (collator.compare(key(a), key(b)) || collator.compare(a.title, b.title))
+		);
 }

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -14,7 +14,8 @@
 		ArrowUpNarrowWideIcon,
 		ArrowDownWideNarrowIcon,
 		DashboardSquare02Icon,
-		ListRestartIcon
+		ListRestartIcon,
+		Sorting01Icon
 	} from '@hugeicons/core-free-icons';
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
@@ -27,6 +28,7 @@
 	import { getCached, putCached, invalidateCached } from '$lib/pagecache';
 	import { rowWindow } from '$lib/rows';
 	import { rowScroller } from '$lib/rows.svelte';
+	import { SORTS, sortSongs, type SortKey } from '$lib/sort';
 	import {
 		addPick,
 		enqueue,
@@ -76,11 +78,62 @@
 			: pl?.subtitle
 	);
 
+	// --- sorting (`$lib/sort`) ---------------------------------------------------------------
+	let sort = $state<SortKey>('default');
+	let sortOpen = $state(false);
+	let preparing = $state(false);
+
+	const sortLabel = $derived(
+		sort === 'default' ? 'Sort' : (SORTS.find((s) => s.key === sort)?.label ?? 'Sort')
+	);
+	// Liked Music is the one playlist YouTube hands back newest-addition-first.
+	const sortedItems = $derived(sortSongs(pl?.items ?? [], sort, isLiked));
+
+	// A sort has to cover the whole playlist, not the pages scrolled so far, so pull the rest in.
+	// Stops on a failed page (`moreError`), on navigation, and on any pass that made no progress.
+	async function loadAll() {
+		const pid = id;
+		while (pl?.continuation && !moreError) {
+			const token = pl.continuation;
+			await loadMore();
+			if (pid !== id) return;
+			if (pl?.continuation === token) return;
+		}
+	}
+
+	// Everything that hands tracks to the queue goes through here first: a sorted queue is only
+	// honest once every page is in.
+	async function ready() {
+		if (sort === 'default' || !pl?.continuation) return;
+		preparing = true;
+		try {
+			await loadAll();
+		} finally {
+			preparing = false;
+		}
+	}
+
+	function chooseSort(key: SortKey) {
+		sortOpen = false;
+		if (key === sort) return;
+		sort = key;
+		if (key !== 'default') loadAll(); // start the walk now so Play rarely has to wait
+	}
+
+	function openSort(e: MouseEvent) {
+		const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+		mx = r.left;
+		my = r.bottom + 4;
+		sortOpen = true;
+	}
+
 	async function load(pid: string) {
 		const key = `playlist:${pid}`;
 		const hit = getCached<PlaylistPage>(key);
 		confirmingDelete = false;
 		editingName = false;
+		sort = 'default';
+		sortOpen = false;
 		if (hit) {
 			pl = hit;
 			bgImage = pickCover(hit.items);
@@ -196,7 +249,7 @@
 	// A Liked Songs list runs to five figures, and `content-visibility` spares the layout and the
 	// paint but not the DOM node, the style or the component.
 	const sc = rowScroller();
-	const win = $derived(rowWindow(sc.scrollTop, sc.viewportPx, pl?.items.length ?? 0, sc.rowPx));
+	const win = $derived(rowWindow(sc.scrollTop, sc.viewportPx, sortedItems.length, sc.rowPx));
 
 	// One page per approach to the bottom: the observer only fires when the sentinel *enters* view,
 	// so an appended page that pushes it back out is required before the next fetch. rootMargin
@@ -225,9 +278,28 @@
 	// the pages scrolled so far, but waiting for it here is what made long playlists take forever
 	// to start: YouTube hands out tracks 100 at a time and the tokens are chained, so the backend
 	// takes the token and walks the rest into the queue while page 1 is already playing.
-	function playAll(start: number | null) {
+	//
+	// Under a sort the queue is the sorted list and the continuation token is dropped: handing the
+	// backend a token would have it walk YouTube's order in behind a sorted queue. `ready()` has
+	// already walked those pages into `pl.items` instead. The queue is a snapshot either way, so a
+	// later sort change never touches a queue that is already playing.
+	async function playAll(start: number | null) {
 		if (!pl) return;
-		playFrom(asItem(), pl.items, start, isOnRepeat ? undefined : id, undefined, pl.continuation);
+		// Resolve the clicked row to a track first: awaiting the walk can grow and re-sort the list
+		// under it, which would leave the index pointing at a different song.
+		const pick = start === null ? null : sortedItems[start];
+		await ready();
+		if (!pl) return;
+		const items = sortedItems;
+		const at = pick ? items.indexOf(pick) : -1;
+		playFrom(
+			asItem(),
+			items,
+			at >= 0 ? at : start,
+			isOnRepeat ? undefined : id,
+			undefined,
+			sort === 'default' ? pl.continuation : undefined
+		);
 	}
 
 	// Random cover from the songs, picked once per load so it stays stable while browsing
@@ -247,11 +319,17 @@
 
 	// Same deal as `playAll` for a long playlist: the loaded pages go in now and the token hands
 	// the rest to the backend to walk in behind them.
-	function queue(next: boolean) {
+	// A "Play next" block stays capped at the loaded tracks either way (see `enqueue`), so only
+	// "Add to queue" is worth waiting on the rest of the playlist for.
+	async function queue(next: boolean) {
 		if (!pl?.items.length) return;
-		enqueue(pl.items, next, pl.title, pl.continuation);
+		if (!next) await ready();
+		if (!pl) return;
+		enqueue(sortedItems, next, pl.title, sort === 'default' ? pl.continuation : undefined);
 	}
 
+	// Untouched by the sort: the backend shuffles the whole playlist (continuation pages included),
+	// so what order it was handed is irrelevant.
 	function shufflePlay() {
 		if (!pl?.items.length) return;
 		// Real order + shuffle flag — the backend owns shuffling, so the shuffle toggle can
@@ -424,9 +502,13 @@
 				{/if}
 				{#if subtitle}<p class="mt-2 text-sm text-muted-foreground">{subtitle}</p>{/if}
 				<div class="mt-4 flex items-center gap-2">
-					<Button class="gap-2" onclick={() => playAll(null)} disabled={!pl.items.length}>
+					<Button
+						class="gap-2"
+						onclick={() => playAll(null)}
+						disabled={!pl.items.length || preparing}
+					>
 						<HugeiconsIcon icon={PlayIcon} class="h-4 w-4" />
-						Play
+						{preparing ? 'Sorting…' : 'Play'}
 					</Button>
 					{#if confirmingDelete}
 						<div class="flex items-center gap-2 rounded-lg border border-destructive/40 px-2 py-1">
@@ -446,6 +528,16 @@
 							<HugeiconsIcon icon={MoreVerticalIcon} class="h-5 w-5 text-muted-foreground" />
 						</Button>
 					{/if}
+					<Button
+						variant="ghost"
+						size="sm"
+						class="gap-2 {sort === 'default' ? 'text-muted-foreground' : ''}"
+						onclick={openSort}
+						disabled={!pl.items.length}
+					>
+						<HugeiconsIcon icon={Sorting01Icon} class="h-4 w-4" />
+						{sortLabel}
+					</Button>
 				</div>
 			</div>
 		</div>
@@ -454,7 +546,7 @@
 				<!-- The padding stands in for the rows outside the window, so the scrollbar is the
 				     length of the whole playlist even though only ~30 rows exist. -->
 				<div style="padding-top:{win.padTop}px;padding-bottom:{win.padBottom}px">
-					{#each pl.items.slice(win.start, win.end) as item, i (item.video_id + (win.start + i))}
+					{#each sortedItems.slice(win.start, win.end) as item, i (item.video_id + (win.start + i))}
 						{@const n = win.start + i}
 						<!-- data-row: what the scroller measures a row's real height from. -->
 						<div data-row>
@@ -497,6 +589,31 @@
 		</div>
 	{/if}
 </div>
+
+{#if sortOpen}
+	<button
+		class="fixed inset-0 z-40 cursor-default"
+		onclick={() => (sortOpen = false)}
+		aria-label="Close menu"
+	></button>
+	<div
+		class="fixed z-50 min-w-44 origin-top-left animate-in rounded-lg border bg-popover p-1 text-popover-foreground shadow-xl duration-150 fade-in-0 zoom-in-95"
+		style="left:{mx}px; top:{my}px;"
+	>
+		{#each SORTS as s (s.key)}
+			<button
+				class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
+				onclick={() => chooseSort(s.key)}
+			>
+				<HugeiconsIcon
+					icon={Tick02Icon}
+					class="h-4 w-4 shrink-0 {sort === s.key ? '' : 'opacity-0'}"
+				/>
+				{s.label}
+			</button>
+		{/each}
+	</div>
+{/if}
 
 {#if menuOpen}
 	<button

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -92,8 +92,21 @@
 	const sortLabel = $derived(
 		sort === 'default' ? 'Sort' : (SORTS.find((s) => s.key === sort)?.label ?? 'Sort')
 	);
+	// The local listening history, fetched once and only if "Most played" is ever picked — it is a
+	// SQLite read the other five sorts have no use for.
+	let plays = $state<Record<string, number>>({});
+	let playsInflight: Promise<void> | null = null;
+	function loadPlays(): Promise<void> {
+		playsInflight ??= api
+			.getPlayCounts()
+			.then((c) => void (plays = c))
+			// An empty map just sorts everything as unplayed, which beats blocking the sort.
+			.catch(() => {});
+		return playsInflight;
+	}
+
 	// Liked Music is the one playlist YouTube hands back newest-addition-first.
-	const sortedItems = $derived(sortSongs(pl?.items ?? [], sort, isLiked, desc));
+	const sortedItems = $derived(sortSongs(pl?.items ?? [], sort, isLiked, desc, plays));
 
 	// A sort has to cover the whole playlist, not the pages scrolled so far, so pull the rest in.
 	// Stops on a failed page (`moreError`), on navigation, and on any pass that made no progress.
@@ -113,7 +126,9 @@
 	// Everything that hands tracks to the queue goes through here first: a sorted queue is only
 	// honest once every page is in.
 	async function ready() {
-		if (!sorting || !pl?.continuation) return;
+		if (!sorting) return;
+		if (sort === 'plays') await loadPlays(); // queueing before they land would sort by nothing
+		if (!pl?.continuation) return;
 		preparing = true;
 		try {
 			await loadAll();
@@ -126,6 +141,7 @@
 		sortOpen = false;
 		if (key === sort) return;
 		sort = key;
+		if (key === 'plays') loadPlays(); // the list re-sorts itself when the counts land
 		if (sorting) loadAll(); // start the walk now so Play rarely has to wait
 	}
 

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -15,7 +15,8 @@
 		ArrowDownWideNarrowIcon,
 		DashboardSquare02Icon,
 		ListRestartIcon,
-		Sorting01Icon
+		Sorting01Icon,
+		ArrowUpDownIcon
 	} from '@hugeicons/core-free-icons';
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
@@ -81,6 +82,7 @@
 
 	// --- sorting (`$lib/sort`) ---------------------------------------------------------------
 	let sort = $state<SortKey>('default');
+	let desc = $state(false);
 	let sortOpen = $state(false);
 	let sx = $state(0);
 	let sy = $state(0);
@@ -91,7 +93,7 @@
 		sort === 'default' ? 'Sort' : (SORTS.find((s) => s.key === sort)?.label ?? 'Sort')
 	);
 	// Liked Music is the one playlist YouTube hands back newest-addition-first.
-	const sortedItems = $derived(sortSongs(pl?.items ?? [], sort, isLiked));
+	const sortedItems = $derived(sortSongs(pl?.items ?? [], sort, isLiked, desc));
 
 	// A sort has to cover the whole playlist, not the pages scrolled so far, so pull the rest in.
 	// Stops on a failed page (`moreError`), on navigation, and on any pass that made no progress.
@@ -105,10 +107,13 @@
 		}
 	}
 
+	// Reversing the default order is a reorder like any other, so it needs the whole playlist too.
+	const sorting = $derived(sort !== 'default' || desc);
+
 	// Everything that hands tracks to the queue goes through here first: a sorted queue is only
 	// honest once every page is in.
 	async function ready() {
-		if (sort === 'default' || !pl?.continuation) return;
+		if (!sorting || !pl?.continuation) return;
 		preparing = true;
 		try {
 			await loadAll();
@@ -121,7 +126,12 @@
 		sortOpen = false;
 		if (key === sort) return;
 		sort = key;
-		if (key !== 'default') loadAll(); // start the walk now so Play rarely has to wait
+		if (sorting) loadAll(); // start the walk now so Play rarely has to wait
+	}
+
+	function toggleDesc() {
+		desc = !desc;
+		if (sorting) loadAll();
 	}
 
 	// Right-anchored, unlike the ⋯ menu: this button sits at the far end of the header, so a menu
@@ -137,6 +147,7 @@
 		confirmingDelete = false;
 		editingName = false;
 		sort = 'default';
+		desc = false;
 		sortOpen = false;
 		if (hit) {
 			pl = hit;
@@ -302,7 +313,7 @@
 			at >= 0 ? at : start,
 			isOnRepeat ? undefined : id,
 			undefined,
-			sort === 'default' ? pl.continuation : undefined
+			sorting ? undefined : pl.continuation
 		);
 	}
 
@@ -329,7 +340,7 @@
 		if (!pl?.items.length) return;
 		if (!next) await ready();
 		if (!pl) return;
-		enqueue(sortedItems, next, pl.title, sort === 'default' ? pl.continuation : undefined);
+		enqueue(sortedItems, next, pl.title, sorting ? undefined : pl.continuation);
 	}
 
 	// Untouched by the sort: the backend shuffles the whole playlist (continuation pages included),
@@ -535,16 +546,28 @@
 						{/if}
 					</div>
 					<!-- Pushed to the far end of the header, away from the play controls. -->
-					<Button
-						variant="ghost"
-						size="sm"
-						class="gap-2 {sort === 'default' ? 'text-muted-foreground' : ''}"
-						onclick={openSort}
-						disabled={!pl.items.length}
-					>
-						<HugeiconsIcon icon={Sorting01Icon} class="h-4 w-4" />
-						{sortLabel}
-					</Button>
+					<div class="flex items-center gap-1">
+						<Button
+							variant="ghost"
+							size="sm"
+							class="gap-2 {sort === 'default' ? 'text-muted-foreground' : ''}"
+							onclick={openSort}
+							disabled={!pl.items.length}
+						>
+							<HugeiconsIcon icon={Sorting01Icon} class="h-4 w-4" />
+							{sortLabel}
+						</Button>
+						<Button
+							variant="ghost"
+							size="icon"
+							class={desc ? '' : 'text-muted-foreground'}
+							aria-label="Sort direction: {desc ? 'descending' : 'ascending'}"
+							onclick={toggleDesc}
+							disabled={!pl.items.length}
+						>
+							<HugeiconsIcon icon={ArrowUpDownIcon} class="h-4 w-4" />
+						</Button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -26,6 +26,7 @@
 	import { ON_REPEAT_ID } from '$lib/api';
 	import type { BrowseItem, PlaylistPage, SongItem } from '$lib/api';
 	import { getCached, putCached, invalidateCached } from '$lib/pagecache';
+	import { anchorMenu } from '$lib/menu';
 	import { rowWindow } from '$lib/rows';
 	import { rowScroller } from '$lib/rows.svelte';
 	import { SORTS, sortSongs, type SortKey } from '$lib/sort';
@@ -81,6 +82,9 @@
 	// --- sorting (`$lib/sort`) ---------------------------------------------------------------
 	let sort = $state<SortKey>('default');
 	let sortOpen = $state(false);
+	let sx = $state(0);
+	let sy = $state(0);
+	let sortUp = $state(false);
 	let preparing = $state(false);
 
 	const sortLabel = $derived(
@@ -120,10 +124,10 @@
 		if (key !== 'default') loadAll(); // start the walk now so Play rarely has to wait
 	}
 
+	// Right-anchored, unlike the ⋯ menu: this button sits at the far end of the header, so a menu
+	// wider than it would run off the page opening leftwards from its left edge.
 	function openSort(e: MouseEvent) {
-		const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
-		mx = r.left;
-		my = r.bottom + 4;
+		({ right: sx, y: sy, openUp: sortUp } = anchorMenu(e.currentTarget as HTMLElement, 240));
 		sortOpen = true;
 	}
 
@@ -501,33 +505,36 @@
 				</h1>
 				{/if}
 				{#if subtitle}<p class="mt-2 text-sm text-muted-foreground">{subtitle}</p>{/if}
-				<div class="mt-4 flex items-center gap-2">
-					<Button
-						class="gap-2"
-						onclick={() => playAll(null)}
-						disabled={!pl.items.length || preparing}
-					>
-						<HugeiconsIcon icon={PlayIcon} class="h-4 w-4" />
-						{preparing ? 'Sorting…' : 'Play'}
-					</Button>
-					{#if confirmingDelete}
-						<div class="flex items-center gap-2 rounded-lg border border-destructive/40 px-2 py-1">
-							<span class="text-xs text-muted-foreground">Delete this playlist?</span>
-							<Button variant="destructive" size="sm" onclick={deleteThisPlaylist}>Delete</Button>
-							<Button variant="ghost" size="sm" onclick={() => (confirmingDelete = false)}>
-								Cancel
-							</Button>
-						</div>
-					{:else}
+				<div class="mt-4 flex items-center justify-between gap-2">
+					<div class="flex items-center gap-2">
 						<Button
-							variant="ghost"
-							size="icon"
-							aria-label="Playlist options"
-							onclick={openMenu}
+							class="gap-2"
+							onclick={() => playAll(null)}
+							disabled={!pl.items.length || preparing}
 						>
-							<HugeiconsIcon icon={MoreVerticalIcon} class="h-5 w-5 text-muted-foreground" />
+							<HugeiconsIcon icon={PlayIcon} class="h-4 w-4" />
+							{preparing ? 'Sorting…' : 'Play'}
 						</Button>
-					{/if}
+						{#if confirmingDelete}
+							<div class="flex items-center gap-2 rounded-lg border border-destructive/40 px-2 py-1">
+								<span class="text-xs text-muted-foreground">Delete this playlist?</span>
+								<Button variant="destructive" size="sm" onclick={deleteThisPlaylist}>Delete</Button>
+								<Button variant="ghost" size="sm" onclick={() => (confirmingDelete = false)}>
+									Cancel
+								</Button>
+							</div>
+						{:else}
+							<Button
+								variant="ghost"
+								size="icon"
+								aria-label="Playlist options"
+								onclick={openMenu}
+							>
+								<HugeiconsIcon icon={MoreVerticalIcon} class="h-5 w-5 text-muted-foreground" />
+							</Button>
+						{/if}
+					</div>
+					<!-- Pushed to the far end of the header, away from the play controls. -->
 					<Button
 						variant="ghost"
 						size="sm"
@@ -597,8 +604,10 @@
 		aria-label="Close menu"
 	></button>
 	<div
-		class="fixed z-50 min-w-44 origin-top-left animate-in rounded-lg border bg-popover p-1 text-popover-foreground shadow-xl duration-150 fade-in-0 zoom-in-95"
-		style="left:{mx}px; top:{my}px;"
+		class="fixed z-50 min-w-44 animate-in rounded-lg border bg-popover p-1 text-popover-foreground shadow-xl duration-150 fade-in-0 zoom-in-95 {sortUp
+			? 'origin-bottom-right'
+			: 'origin-top-right'}"
+		style="right:{sx}px; {sortUp ? 'bottom' : 'top'}:{sy}px;"
 	>
 		{#each SORTS as s (s.key)}
 			<button

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -19,6 +19,7 @@
 		ArrowUpDownIcon
 	} from '@hugeicons/core-free-icons';
 	import { Button } from '$lib/components/ui/button';
+	import * as RadioGroup from '$lib/components/ui/radio-group';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import TrackRow from '$lib/components/TrackRow.svelte';
 	import TrackRowSkeleton from '$lib/components/TrackRowSkeleton.svelte';
@@ -664,18 +665,20 @@
 			: 'origin-top-right'}"
 		style="right:{sx}px; {sortUp ? 'bottom' : 'top'}:{sy}px;"
 	>
-		{#each SORTS as s (s.key)}
-			<button
-				class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
-				onclick={() => chooseSort(s.key)}
-			>
-				<HugeiconsIcon
-					icon={Tick02Icon}
-					class="h-4 w-4 shrink-0 {sort === s.key ? '' : 'opacity-0'}"
-				/>
-				{s.label}
-			</button>
-		{/each}
+		<RadioGroup.Root
+			value={sort}
+			onValueChange={(v) => chooseSort(v as SortKey)}
+			class="gap-0"
+		>
+			{#each SORTS as s (s.key)}
+				<label
+					class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
+				>
+					<RadioGroup.Item value={s.key} />
+					{s.label}
+				</label>
+			{/each}
+		</RadioGroup.Root>
 	</div>
 {/if}
 

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -110,14 +110,18 @@
 
 	// A sort has to cover the whole playlist, not the pages scrolled so far, so pull the rest in.
 	// Stops on a failed page (`moreError`), on navigation, and on any pass that made no progress.
-	async function loadAll() {
+	// Answers whether it got the lot: a queue built from a short list is missing tracks for good,
+	// so the caller has to be able to say so rather than quietly handing over half a playlist.
+	async function loadAll(): Promise<boolean> {
 		const pid = id;
+		moreError = false; // a page that failed earlier gets another go on an explicit action
 		while (pl?.continuation && !moreError) {
 			const token = pl.continuation;
 			await loadMore();
-			if (pid !== id) return;
-			if (pl?.continuation === token) return;
+			if (pid !== id) return false;
+			if (pl?.continuation === token) break; // no progress, and nothing left to try
 		}
+		return !pl?.continuation;
 	}
 
 	// Reversing the default order is a reorder like any other, so it needs the whole playlist too.
@@ -125,16 +129,23 @@
 
 	// Everything that hands tracks to the queue goes through here first: a sorted queue is only
 	// honest once every page is in.
-	async function ready() {
-		if (!sorting) return;
+	async function ready(): Promise<boolean> {
+		if (!sorting) return true;
 		if (sort === 'plays') await loadPlays(); // queueing before they land would sort by nothing
-		if (!pl?.continuation) return;
+		if (!pl?.continuation) return true;
 		preparing = true;
 		try {
-			await loadAll();
+			return await loadAll();
 		} finally {
 			preparing = false;
 		}
+	}
+
+	// Sorted, but a page never arrived. The queue is a snapshot, so the tracks that did not load
+	// are gone from it for good — play them anyway and say so, rather than refusing to play at all
+	// over one failed request. The list's own "Try again" sits at the bottom of the page.
+	function warnPartial(what: string) {
+		toast.error(`Couldn't load all of this playlist, so only what loaded was ${what}.`);
 	}
 
 	function chooseSort(key: SortKey) {
@@ -316,11 +327,14 @@
 	// later sort change never touches a queue that is already playing.
 	async function playAll(start: number | null) {
 		if (!pl) return;
+		const pid = id;
 		// Resolve the clicked row to a track first: awaiting the walk can grow and re-sort the list
 		// under it, which would leave the index pointing at a different song.
 		const pick = start === null ? null : sortedItems[start];
-		await ready();
-		if (!pl) return;
+		const whole = await ready();
+		// Navigating while that walk ran would otherwise play the playlist you left for.
+		if (!pl || pid !== id) return;
+		if (!whole) warnPartial('queued');
 		const items = sortedItems;
 		const at = pick ? items.indexOf(pick) : -1;
 		playFrom(
@@ -354,8 +368,10 @@
 	// "Add to queue" is worth waiting on the rest of the playlist for.
 	async function queue(next: boolean) {
 		if (!pl?.items.length) return;
-		if (!next) await ready();
-		if (!pl) return;
+		const pid = id;
+		const whole = next || (await ready());
+		if (!pl || pid !== id) return;
+		if (!whole) warnPartial('added');
 		enqueue(sortedItems, next, pl.title, sorting ? undefined : pl.continuation);
 	}
 


### PR DESCRIPTION
Closes #33

A Sort button at the right end of the playlist header, with a separate
ascending/descending toggle beside it. Options: Default, Newest first,
Oldest first, Title, Artist, Album, Most played.

`pl.items` stays in YouTube's order and the sort is a view over it, so the
optimistic add/remove/setVideoId paths and loadMore are untouched.

Queue behaviour, which is most of the work here:

- Playing or queueing under a sort hands the backend the sorted list and
  no continuation token, so it cannot walk YouTube's order in behind a
  sorted queue. Picking a sort walks the remaining pages in first instead.
- The queue is a snapshot on the Rust side, so changing the sort while a
  playlist is playing leaves the queue alone.
- Shuffle ignores the sort: the backend shuffles the whole playlist,
  continuation pages included.

Also in here: playlist rows never carried an album at all. `parse_list_item`
only read one out of the subtitle runs, which is the search/next row shape;
a playlist row keeps it in the third flex column, the one an album page
spends on "53M plays". Album sort had nothing to group by until that was
fixed.

`cargo test` green (97 + 55), `sort.check.ts` green, `pnpm check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playlist sorting by default order, newest, oldest, title, artist, album, and play count.
  * Added a playlist sort menu with direction controls.
  * Play counts are loaded automatically when sorting by “Most played.”
  * Sorted playback and queueing now include all playlist tracks.
* **Bug Fixes**
  * Improved album detection in playlist and album rows without confusing play-count columns for album names.
* **Tests**
  * Added coverage for sorting behavior, album extraction, play counts, and date filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->