### PR TITLE
feat(browse): search a playlist or album from its header

### DIFF
--- a/ui/src/lib/components/TrackFilter.svelte
+++ b/ui/src/lib/components/TrackFilter.svelte
@@ -1,0 +1,58 @@
+<!--
+	Filter box for a track list (playlist / album header).
+
+	Purely client-side, over the rows already loaded. A long playlist arrives a page at a time, so
+	the pages the sentinel hasn't fetched yet can't match; scrolling loads them as usual.
+-->
+<script module lang="ts">
+	import type { SongItem } from '$lib/api';
+
+	/** Substring match over title, artist and album. Empty query returns the list untouched. */
+	export function filterTracks<T extends SongItem>(items: T[], query: string): T[] {
+		const q = query.trim().toLowerCase();
+		if (!q) return items;
+		return items.filter(
+			(t) =>
+				t.title?.toLowerCase().includes(q) ||
+				t.artists?.toLowerCase().includes(q) ||
+				t.album?.toLowerCase().includes(q)
+		);
+	}
+</script>
+
+<script lang="ts">
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { SearchList01Icon, Cancel01Icon } from '@hugeicons/core-free-icons';
+
+	let {
+		value = $bindable(''),
+		placeholder = 'Search this list'
+	}: { value?: string; placeholder?: string } = $props();
+</script>
+
+<div
+	class="flex items-center gap-2 rounded-full border bg-background/80 py-1.5 pl-3 pr-2 shadow-sm backdrop-blur focus-within:border-accent"
+>
+	<HugeiconsIcon
+		icon={SearchList01Icon}
+		strokeWidth={2.5}
+		class="h-4 w-4 shrink-0 text-muted-foreground"
+	/>
+	<input
+		bind:value
+		{placeholder}
+		aria-label={placeholder}
+		class="w-48 min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+		onkeydown={(e) => e.key === 'Escape' && (value = '')}
+	/>
+	<!-- Holds its 1rem either way, so typing doesn't resize the box. -->
+	<button
+		class="w-4 shrink-0 cursor-pointer text-muted-foreground transition hover:text-foreground"
+		class:invisible={!value}
+		onclick={() => (value = '')}
+		aria-label="Clear search"
+		tabindex={value ? 0 : -1}
+	>
+		<HugeiconsIcon icon={Cancel01Icon} strokeWidth={2.5} class="h-4 w-4" />
+	</button>
+</div>

--- a/ui/src/routes/album/[id]/+page.svelte
+++ b/ui/src/routes/album/[id]/+page.svelte
@@ -15,6 +15,9 @@
         BookmarkCheck02Icon,
     } from "@hugeicons/core-free-icons";
     import TrackRow from "$lib/components/TrackRow.svelte";
+    import TrackFilter, {
+        filterTracks,
+    } from "$lib/components/TrackFilter.svelte";
     import TrackRowSkeleton from "$lib/components/TrackRowSkeleton.svelte";
     import ErrorState from "$lib/components/ErrorState.svelte";
     import ArtistLine from "$lib/components/ArtistLine.svelte";
@@ -41,8 +44,12 @@
     let error = $state<string | null>(null);
     let expanded = $state(false);
     let menuOpen = $state(false);
+    // Header filter box: matches title / artist / album.
+    let query = $state("");
 
     const id = $derived(page.params.id ?? "");
+    // The rows actually on screen. Identical to `album.items` with no query typed.
+    const shown = $derived(filterTracks(album?.items ?? [], query));
     // A local album has no YouTube playlist behind it: nothing to save, add to a playlist, or
     // fetch an artist hero for. Playing, shuffling and Shortcuts all work exactly the same.
     const isLocal = $derived(api.isLocalId(id));
@@ -62,6 +69,7 @@
         }
         error = null;
         expanded = false;
+        query = "";
         try {
             const fresh = await api.getAlbum(aid);
             if (aid !== id) return; // superseded by navigation — drop the stale response
@@ -124,8 +132,13 @@
         explicit: album?.explicit,
     });
 
+    // `start` indexes the rows on screen, which a filter narrows. The queue is always the whole
+    // album: the search box finds a track, it doesn't decide what plays after it, so playing a
+    // match has to leave the same queue behind as scrolling to that row would.
     function playAll(start: number | null) {
-        if (album) playFrom(asItem(), album.items, start, album.playlistId);
+        if (!album) return;
+        const at = start === null ? null : album.items.indexOf(shown[start]);
+        playFrom(asItem(), album.items, at === -1 ? null : at, album.playlistId);
     }
     function radio() {
         if (!album?.playlistId) return;
@@ -215,6 +228,10 @@
         <div
             class="absolute inset-0 bg-gradient-to-t from-background via-background/75 to-background/40"
         ></div>
+
+        <div class="absolute right-6 top-6 z-10">
+            <TrackFilter bind:value={query} placeholder="Search this album" />
+        </div>
 
         <div class="relative flex flex-col gap-5 p-6 pt-10">
             <div class="flex items-end gap-5">
@@ -406,7 +423,7 @@
 
     <!-- Numbered track list -->
     <div class="content-in p-6 pt-2">
-        {#each album.items as item, i (item.video_id + i)}
+        {#each shown as item, i (item.video_id + i)}
             <TrackRow
                 song={item}
                 index={i}
@@ -418,7 +435,9 @@
             />
         {:else}
             <p class="p-4 text-sm text-muted-foreground">
-                This album is empty.
+                {query.trim()
+                    ? `No tracks match “${query.trim()}”.`
+                    : "This album is empty."}
             </p>
         {/each}
     </div>

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -22,6 +22,7 @@
 	import * as RadioGroup from '$lib/components/ui/radio-group';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import TrackRow from '$lib/components/TrackRow.svelte';
+	import TrackFilter, { filterTracks } from '$lib/components/TrackFilter.svelte';
 	import TrackRowSkeleton from '$lib/components/TrackRowSkeleton.svelte';
 	import ErrorState from '$lib/components/ErrorState.svelte';
 	import * as api from '$lib/api';
@@ -63,6 +64,9 @@
 	let editingName = $state(false);
 	let nameDraft = $state('');
 
+	// Header filter box: matches title / artist / album over the rows loaded so far.
+	let query = $state('');
+
 	const id = $derived(page.params.id ?? '');
 	const nowId = $derived(playback.now?.videoId);
 	// The liked-music auto-playlist isn't a user playlist — no rename/delete, but shuffle is fine.
@@ -80,7 +84,6 @@
 			? (pl.subtitle ?? '').replace(/^[\d,.]+ songs?/i, `${pl.items.length} songs`)
 			: pl?.subtitle
 	);
-
 	// --- sorting (`$lib/sort`) ---------------------------------------------------------------
 	let sort = $state<SortKey>('default');
 	let desc = $state(false);
@@ -108,6 +111,11 @@
 
 	// Liked Music is the one playlist YouTube hands back newest-addition-first.
 	const sortedItems = $derived(sortSongs(pl?.items ?? [], sort, isLiked, desc, plays));
+
+	// The rows actually on screen: the sorted list, narrowed by the header's filter box. Identical
+	// to `sortedItems` with no query typed.
+	const shown = $derived(filterTracks(sortedItems, query));
+	const filtering = $derived(!!query.trim());
 
 	// A sort has to cover the whole playlist, not the pages scrolled so far, so pull the rest in.
 	// Stops on a failed page (`moreError`), on navigation, and on any pass that made no progress.
@@ -177,6 +185,10 @@
 		sort = 'default';
 		desc = false;
 		sortOpen = false;
+		query = '';
+		// A page that failed on the last playlist would otherwise keep this one's retry state
+		// showing, and block the filter's own walk (`loadAll` bails while it's set).
+		moreError = false;
 		if (hit) {
 			pl = hit;
 			bgImage = pickCover(hit.items);
@@ -292,7 +304,7 @@
 	// A Liked Songs list runs to five figures, and `content-visibility` spares the layout and the
 	// paint but not the DOM node, the style or the component.
 	const sc = rowScroller();
-	const win = $derived(rowWindow(sc.scrollTop, sc.viewportPx, sortedItems.length, sc.rowPx));
+	const win = $derived(rowWindow(sc.scrollTop, sc.viewportPx, shown.length, sc.rowPx));
 
 	// One page per approach to the bottom: the observer only fires when the sentinel *enters* view,
 	// so an appended page that pushes it back out is required before the next fetch. rootMargin
@@ -304,6 +316,17 @@
 		io.observe(node);
 		return () => io.disconnect();
 	}
+
+	// A filter can only match rows that have arrived, and a narrowed list never pushes the sentinel
+	// back out of view, so the observer fires once and stops. Same walk a sort needs, for the same
+	// reason: the search has to cover the whole playlist, not the pages scrolled so far. The flag
+	// keeps one walk running rather than starting a fresh one on every page it lands.
+	let walking = false;
+	$effect(() => {
+		if (!filtering || !pl?.continuation || walking) return;
+		walking = true;
+		loadAll().finally(() => (walking = false));
+	});
 
 	// This playlist as a card, for the sidebar's last-played sort and the Shortcuts grid.
 	const asItem = (): BrowseItem => ({
@@ -326,12 +349,16 @@
 	// backend a token would have it walk YouTube's order in behind a sorted queue. `ready()` has
 	// already walked those pages into `pl.items` instead. The queue is a snapshot either way, so a
 	// later sort change never touches a queue that is already playing.
+	//
+	// A filter narrows which rows are on screen but never what gets queued: it finds a track, it
+	// doesn't decide what plays after it, so playing a match leaves the same queue behind as
+	// scrolling to that row would.
 	async function playAll(start: number | null) {
 		if (!pl) return;
 		const pid = id;
 		// Resolve the clicked row to a track first: awaiting the walk can grow and re-sort the list
 		// under it, which would leave the index pointing at a different song.
-		const pick = start === null ? null : sortedItems[start];
+		const pick = start === null ? null : shown[start];
 		const whole = await ready();
 		// Navigating while that walk ran would otherwise play the playlist you left for.
 		if (!pl || pid !== id) return;
@@ -341,7 +368,7 @@
 		playFrom(
 			asItem(),
 			items,
-			at >= 0 ? at : start,
+			at >= 0 ? at : null,
 			isOnRepeat ? undefined : id,
 			undefined,
 			sorting ? undefined : pl.continuation
@@ -603,13 +630,16 @@
 					</div>
 				</div>
 			</div>
+			<div class="absolute right-6 top-6">
+				<TrackFilter bind:value={query} placeholder="Search this playlist" />
+			</div>
 		</div>
 		<div class="content-in min-h-0 flex-1 overflow-y-auto p-4" {@attach sc.attach}>
-			{#if pl.items.length}
+			{#if shown.length}
 				<!-- The padding stands in for the rows outside the window, so the scrollbar is the
 				     length of the whole playlist even though only ~30 rows exist. -->
 				<div style="padding-top:{win.padTop}px;padding-bottom:{win.padBottom}px">
-					{#each sortedItems.slice(win.start, win.end) as item, i (item.video_id + (win.start + i))}
+					{#each shown.slice(win.start, win.end) as item, i (item.video_id + (win.start + i))}
 						{@const n = win.start + i}
 						<!-- data-row: what the scroller measures a row's real height from. -->
 						<div data-row>
@@ -626,6 +656,12 @@
 						</div>
 					{/each}
 				</div>
+			{:else if filtering}
+				<p class="p-4 text-sm text-muted-foreground">
+					No tracks match “{query.trim()}”{pl.continuation && !moreError
+						? ' yet, still loading'
+						: ''}.
+				</p>
 			{:else}
 				<p class="p-4 text-sm text-muted-foreground">This playlist is empty.</p>
 			{/if}


### PR DESCRIPTION
Part of #35 (the "search songs inside a playlist" half of it, not the play
counts or the search suggestions, so this leaves the issue open).

A filter box in the top right of the playlist and album headers. It matches
track title, artist and album, so typing an artist narrows a playlist to their
songs and typing an album name narrows it to that album's tracks.

Notes:

- The queue is not affected by the filter. Playing a match maps the row back to
  its real index and queues the whole list from there, so it leaves the same
  queue behind as scrolling to that row and playing it would. Same for Play,
  Shuffle and the queue actions in the header, which always act on the full
  list.
- A narrowed list never pushes the scroll sentinel out of view, so the playlist
  page walks its remaining pages itself while a query is typed. A search covers
  the whole playlist, not just the first page.
- Playlist rows carry the album name in the third flex column rather than the
  subtitle, so `parse_list_item` was leaving `album` empty on all of them and
  there was nothing for an album search to match. It now reads that column,
  telling it apart from the "53M plays" / "1.2M views" an album or video row
  puts in the same place. That name also feeds MPRIS, Discord rich presence and
  the scrobbler, which were all getting a blank album for anything played from
  a playlist.

`cargo test -p innertube` and `pnpm check` pass; verified in `cargo tauri dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added track search and filtering to album and playlist pages by title, artist, or album.
  * Added clearable search controls with keyboard support and configurable placeholders.
  * Preserved full album and playlist playback queues when starting playback from filtered results.
  * Playlist searches continue loading tracks as needed to find all matching results.

* **Bug Fixes**
  * Improved album name detection when metadata subtitles omit the album name.
  * Prevented play and view counts from being mistaken for album names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->