### PR TITLE
feat(search): typeahead preview under the search fields

### DIFF
--- a/ui/src/lib/components/HomeHero.svelte
+++ b/ui/src/lib/components/HomeHero.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
 	import { Search01Icon, UserGroup02Icon } from '@hugeicons/core-free-icons';
-	import { Input } from '$lib/components/ui/input';
+	import SearchSuggest from '$lib/components/SearchSuggest.svelte';
 	import { auth, playback, ui } from '$lib/player.svelte';
 	import { lt } from '$lib/lt.svelte';
 	import { thumb } from '$lib/thumb';
@@ -28,32 +28,36 @@
 	});
 </script>
 
-<div class="relative overflow-hidden border-b">
-	{#if playback.now?.thumbnail && !artFailed}
-		<!-- 96px, not display size: blur-2xl is a 40px blur, so every detail above a handful of
-		     pixels is thrown away anyway. The old 1200px source decoded to 5.7 MiB for this, and
-		     re-decoded on every track change. -->
-		<img
-			src={thumb(playback.now.thumbnail, 96)}
-			alt=""
-			class="pointer-events-none absolute inset-0 h-full w-full scale-110 object-cover opacity-60 blur-2xl"
-			onerror={() => (artFailed = true)}
-		/>
-	{:else}
-		<!-- Nothing playing: without this the header is a bare strip with a greeting in it. An accent
-		     wash keeps it a header. Inline style so it can't be lost to a stale dev stylesheet, and it
-		     rides --primary so every preset theme gets its own. -->
+<!-- overflow-hidden lives on the backdrop wrapper, not the hero: the scaled blur has to be clipped,
+     but the search preview below has to hang out past the bottom edge. -->
+<div class="relative border-b">
+	<div class="pointer-events-none absolute inset-0 overflow-hidden">
+		{#if playback.now?.thumbnail && !artFailed}
+			<!-- 96px, not display size: blur-2xl is a 40px blur, so every detail above a handful of
+			     pixels is thrown away anyway. The old 1200px source decoded to 5.7 MiB for this, and
+			     re-decoded on every track change. -->
+			<img
+				src={thumb(playback.now.thumbnail, 96)}
+				alt=""
+				class="pointer-events-none absolute inset-0 h-full w-full scale-110 object-cover opacity-60 blur-2xl"
+				onerror={() => (artFailed = true)}
+			/>
+		{:else}
+			<!-- Nothing playing: without this the header is a bare strip with a greeting in it. An accent
+			     wash keeps it a header. Inline style so it can't be lost to a stale dev stylesheet, and it
+			     rides --primary so every preset theme gets its own. -->
+			<div
+				class="pointer-events-none absolute inset-0 opacity-[0.18]"
+				style="background:radial-gradient(120% 130% at 12% 0%, var(--primary) 0%, transparent 58%)"
+			></div>
+		{/if}
 		<div
-			class="pointer-events-none absolute inset-0 opacity-[0.18]"
-			style="background:radial-gradient(120% 130% at 12% 0%, var(--primary) 0%, transparent 58%)"
+			class="absolute inset-0 bg-gradient-to-t from-background via-background/70 to-background/40"
 		></div>
-	{/if}
-	<div
-		class="absolute inset-0 bg-gradient-to-t from-background via-background/70 to-background/40"
-	></div>
-	<div
-		class="absolute inset-0 bg-gradient-to-r from-background/80 via-background/30 to-transparent"
-	></div>
+		<div
+			class="absolute inset-0 bg-gradient-to-r from-background/80 via-background/30 to-transparent"
+		></div>
+	</div>
 	<div class="relative p-6 pt-8">
 		<div class="flex items-start justify-between gap-4">
 			<div class="flex min-w-0 items-center gap-3">
@@ -92,9 +96,16 @@
 				<form class="relative w-full max-w-xs" onsubmit={(e) => { e.preventDefault(); goSearch(); }}>
 					<HugeiconsIcon
 						icon={Search01Icon}
-						class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+						class="pointer-events-none absolute left-3 top-1/2 z-10 h-4 w-4 -translate-y-1/2 text-muted-foreground"
 					/>
-					<Input bind:value={searchQuery} placeholder="Search" class="rounded-full pl-9" />
+					<!-- The panel is wider than this field and hangs off its right edge: the rows carry
+					     artwork and two lines of text, which 20rem can't hold. -->
+					<SearchSuggest
+						bind:value={searchQuery}
+						placeholder="Search"
+						inputClass="rounded-full pl-9"
+						panelClass="right-0 w-[26rem]"
+					/>
 				</form>
 			</div>
 		</div>

--- a/ui/src/lib/components/SearchSuggest.svelte
+++ b/ui/src/lib/components/SearchSuggest.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+	// The search field plus its typeahead preview: type, wait 300ms, get a handful of real results
+	// under the input. Runs the same `search_all` the search page runs and writes the same page-cache
+	// key, so submitting a previewed query paints from cache instead of searching twice.
+	//
+	// Must live inside a <form>: Enter with nothing highlighted, and the "All results" row, fall
+	// through to that form's onsubmit, which is where each caller decides what a full search means
+	// (run it in place, or navigate to /search).
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { Search01Icon, MusicNote01Icon, UserIcon } from '@hugeicons/core-free-icons';
+	import { Input } from '$lib/components/ui/input';
+	import { Skeleton } from '$lib/components/ui/skeleton';
+	import ExplicitIcon from './ExplicitIcon.svelte';
+	import * as api from '$lib/api';
+	import type { BrowseItem, SearchResults } from '$lib/api';
+	import { getCached, putCached } from '$lib/pagecache';
+	import { openItem } from '$lib/browse';
+	import { thumb } from '$lib/thumb';
+
+	let {
+		value = $bindable(''),
+		placeholder = 'Search',
+		inputClass = '',
+		/** Panel geometry. Default matches the field; a narrow field wants its own width. */
+		panelClass = 'left-0 right-0',
+		onpick
+	}: {
+		value?: string;
+		placeholder?: string;
+		inputClass?: string;
+		panelClass?: string;
+		/** Fired after a row is taken (played or navigated) — for callers that dismiss themselves. */
+		onpick?: () => void;
+	} = $props();
+
+	let open = $state(false);
+	let items = $state<BrowseItem[]>([]);
+	let loading = $state(false);
+	let active = $state(-1); // keyboard-highlighted row, -1 = none (Enter submits the form)
+	let loadedFor = ''; // query `items` belongs to, so a stale response can't land
+	let debounce: ReturnType<typeof setTimeout> | undefined;
+
+	const KIND = { song: 'Song', album: 'Album', artist: 'Artist', playlist: 'Playlist' };
+
+	/** A few rows across the categories rather than six songs: one top hit, then the mix. */
+	function preview(r: SearchResults): BrowseItem[] {
+		const out: BrowseItem[] = [];
+		const seen = new Set<string>();
+		const take = (from: BrowseItem[], n: number) => {
+			for (const i of from) {
+				if (n <= 0) break;
+				if (seen.has(i.id)) continue;
+				seen.add(i.id);
+				out.push(i);
+				n--;
+			}
+		};
+		take(r.top, 1);
+		take(r.songs, 3);
+		take(r.artists, 1);
+		take(r.albums, 1);
+		take(r.playlists, 1);
+		return out;
+	}
+
+	async function load(q: string) {
+		loadedFor = q;
+		active = -1;
+		const key = `search:${q}`;
+		const hit = getCached<SearchResults>(key);
+		if (hit) {
+			items = preview(hit);
+			loading = false;
+			return;
+		}
+		loading = true;
+		try {
+			const fresh = await api.searchAll(q);
+			if (loadedFor !== q) return;
+			putCached(key, fresh);
+			items = preview(fresh);
+		} catch {
+			if (loadedFor === q) items = [];
+		} finally {
+			if (loadedFor === q) loading = false;
+		}
+	}
+
+	// Reads the element, not `value`: the binding lands on this same event and the order of the two
+	// listeners is not ours to assume.
+	function onType(e: Event & { currentTarget: HTMLInputElement }) {
+		clearTimeout(debounce);
+		const q = e.currentTarget.value.trim();
+		if (q.length < 2) {
+			close();
+			return;
+		}
+		open = true;
+		if (q !== loadedFor) items = [];
+		debounce = setTimeout(() => load(q), 300);
+	}
+
+	function close() {
+		clearTimeout(debounce);
+		open = false;
+		loading = false;
+		active = -1;
+	}
+
+	function choose(item: BrowseItem) {
+		close();
+		openItem(item); // a song plays, everything else opens its page
+		onpick?.();
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && open) {
+			e.preventDefault();
+			close();
+		} else if (e.key === 'Enter') {
+			// Only a highlighted row is ours; a bare Enter is the caller's form submit.
+			if (active >= 0 && items[active]) {
+				e.preventDefault();
+				choose(items[active]);
+			} else {
+				close();
+			}
+		} else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && items.length) {
+			e.preventDefault();
+			open = true;
+			const n = items.length;
+			active = e.key === 'ArrowDown' ? (active + 1) % n : (active <= 0 ? n : active) - 1;
+		}
+	}
+</script>
+
+<!-- Rows preventDefault on mousedown, so focus never leaves the input while one is being clicked:
+     anything that reaches focusout is a real move away from the field. -->
+<div
+	class="relative w-full min-w-0"
+	onfocusout={(e) => {
+		if (!e.currentTarget.contains(e.relatedTarget as Node | null)) close();
+	}}
+>
+	<Input
+		bind:value
+		{placeholder}
+		class={inputClass}
+		autocomplete="off"
+		role="combobox"
+		aria-expanded={open}
+		aria-controls="search-suggest"
+		oninput={onType}
+		onkeydown={onKeydown}
+		onfocus={() => {
+			if (items.length && value.trim() === loadedFor) open = true;
+		}}
+	/>
+	{#if open}
+		<div
+			id="search-suggest"
+			role="listbox"
+			aria-label="Search preview"
+			class="absolute top-full z-50 mt-2 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-xl animate-in fade-in-0 zoom-in-95 duration-150 {panelClass}"
+		>
+			{#if loading && !items.length}
+				{#each Array(4) as _, i (i)}
+					<div class="flex items-center gap-3 px-3 py-2">
+						<Skeleton class="h-10 w-10 shrink-0 rounded-md" />
+						<div class="min-w-0 flex-1">
+							<Skeleton class="h-3 w-40 rounded" />
+							<Skeleton class="mt-2 h-2.5 w-24 rounded" />
+						</div>
+					</div>
+				{/each}
+			{:else if !items.length}
+				<div class="px-4 py-3 text-sm text-muted-foreground">Nothing quick for that.</div>
+			{:else}
+				{#each items as item, i (item.id)}
+					{@const hero = i === 0}
+					<button
+						type="button"
+						role="option"
+						aria-selected={i === active}
+						class="flex w-full cursor-pointer items-center gap-3 px-3 text-left transition-colors {i ===
+						active
+							? 'bg-accent/60'
+							: 'hover:bg-accent/40'} {hero ? 'border-b py-2.5' : 'py-1.5'}"
+						onmousedown={(e) => e.preventDefault()}
+						onmouseenter={() => (active = i)}
+						onclick={() => choose(item)}
+					>
+						{#if item.thumbnail}
+							<!-- 400, the same size the cards ask for: the CDN doesn't serve every rewritten size,
+							     that one is verified, and the row lands on an image the grid already fetched. -->
+							<img
+								src={thumb(item.thumbnail, 400)}
+								alt=""
+								class="shrink-0 object-cover {item.kind === 'artist'
+									? 'rounded-full'
+									: 'rounded-md'} {hero ? 'h-12 w-12' : 'h-10 w-10'}"
+							/>
+						{:else}
+							<div
+								class="flex shrink-0 items-center justify-center bg-muted text-muted-foreground/50 {item.kind ===
+								'artist'
+									? 'rounded-full'
+									: 'rounded-md'} {hero ? 'h-12 w-12' : 'h-10 w-10'}"
+							>
+								<HugeiconsIcon
+									icon={item.kind === 'artist' ? UserIcon : MusicNote01Icon}
+									class="h-5 w-5"
+								/>
+							</div>
+						{/if}
+						<div class="min-w-0 flex-1">
+							<div class="truncate {hero ? 'font-semibold' : 'text-sm'}">{item.title}</div>
+							<div class="flex items-center gap-1 text-xs text-muted-foreground">
+								{#if item.explicit}
+									<ExplicitIcon class="h-3 w-3 shrink-0" />
+								{/if}
+								<span class="truncate">
+									{KIND[item.kind]}{item.subtitle ? ` • ${item.subtitle}` : ''}
+								</span>
+							</div>
+						</div>
+						{#if hero}
+							<span
+								class="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[0.625rem] font-semibold uppercase tracking-wide text-primary"
+							>
+								Top result
+							</span>
+						{/if}
+					</button>
+				{/each}
+			{/if}
+			<!-- submit, so the enclosing form decides what "all results" does. -->
+			<button
+				type="submit"
+				class="flex w-full cursor-pointer items-center gap-2 border-t bg-muted/30 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+				onmousedown={(e) => e.preventDefault()}
+				onmouseenter={() => (active = -1)}
+				onclick={close}
+			>
+				<HugeiconsIcon icon={Search01Icon} class="h-3.5 w-3.5" />
+				All results for “{value.trim()}”
+			</button>
+		</div>
+	{/if}
+</div>

--- a/ui/src/lib/components/SearchSuggest.svelte
+++ b/ui/src/lib/components/SearchSuggest.svelte
@@ -96,7 +96,12 @@
 			return;
 		}
 		open = true;
-		if (q !== loadedFor) items = [];
+		if (q !== loadedFor) {
+			// Loading starts now, not when the timer fires: otherwise the empty panel reads as
+			// "no results" for the whole debounce, on every query.
+			items = [];
+			loading = true;
+		}
 		debounce = setTimeout(() => load(q), 500);
 	}
 

--- a/ui/src/lib/components/SearchSuggest.svelte
+++ b/ui/src/lib/components/SearchSuggest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	// The search field plus its typeahead preview: type, wait 300ms, get a handful of real results
+	// The search field plus its typeahead preview: type, wait 500ms, get a handful of real results
 	// under the input. Runs the same `search_all` the search page runs and writes the same page-cache
 	// key, so submitting a previewed query paints from cache instead of searching twice.
 	//
@@ -97,7 +97,7 @@
 		}
 		open = true;
 		if (q !== loadedFor) items = [];
-		debounce = setTimeout(() => load(q), 300);
+		debounce = setTimeout(() => load(q), 500);
 	}
 
 	function close() {

--- a/ui/src/routes/search/+page.svelte
+++ b/ui/src/routes/search/+page.svelte
@@ -10,7 +10,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
-	import { Search01Icon } from '@hugeicons/core-free-icons';
+	import { Search01Icon, MusicNote01Icon, UserIcon } from '@hugeicons/core-free-icons';
 	import { Input } from '$lib/components/ui/input';
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
@@ -19,11 +19,13 @@
 	import TrackRowSkeleton from '$lib/components/TrackRowSkeleton.svelte';
 	import ErrorState from '$lib/components/ErrorState.svelte';
 	import Shelf from '$lib/components/Shelf.svelte';
+	import ExplicitIcon from '$lib/components/ExplicitIcon.svelte';
 	import * as api from '$lib/api';
-	import type { SearchResults } from '$lib/api';
+	import type { BrowseItem, SearchResults } from '$lib/api';
 	import { getCached, putCached } from '$lib/pagecache';
 	import { openAddToPlaylist, playSong } from '$lib/player.svelte';
-	import { asSong } from '$lib/browse';
+	import { asSong, openItem } from '$lib/browse';
+	import { thumb } from '$lib/thumb';
 
 	let query = $state(lastQuery);
 	let res = $state<SearchResults | null>(null);
@@ -60,6 +62,113 @@
 			if (!hit) error = String(e);
 		} finally {
 			if (latest === q) searching = false;
+		}
+	}
+
+	// --- typeahead preview -----------------------------------------------------------------------
+	//
+	// Same `search_all` the page runs, debounced and cut down to a handful of rows. No separate
+	// suggestions endpoint: this fills the very cache `runSearch` reads, so hitting Enter on a
+	// previewed query paints instantly instead of searching a second time.
+
+	let suggestOpen = $state(false);
+	let suggestions = $state<BrowseItem[]>([]);
+	let suggesting = $state(false);
+	let active = $state(-1); // keyboard-highlighted row, -1 = none (Enter runs the full search)
+	let suggestFor = ''; // query `suggestions` belongs to, so a stale response can't land
+	let debounce: ReturnType<typeof setTimeout> | undefined;
+
+	const KIND = { song: 'Song', album: 'Album', artist: 'Artist', playlist: 'Playlist' };
+
+	/** A few rows across the categories rather than six songs: one top hit, then the mix. */
+	function preview(r: SearchResults): BrowseItem[] {
+		const out: BrowseItem[] = [];
+		const seen = new Set<string>();
+		const take = (items: BrowseItem[], n: number) => {
+			for (const i of items) {
+				if (n <= 0) break;
+				if (seen.has(i.id)) continue;
+				seen.add(i.id);
+				out.push(i);
+				n--;
+			}
+		};
+		take(r.top, 1);
+		take(r.songs, 3);
+		take(r.artists, 1);
+		take(r.albums, 1);
+		take(r.playlists, 1);
+		return out;
+	}
+
+	async function loadSuggest(q: string) {
+		suggestFor = q;
+		active = -1;
+		const key = `search:${q}`;
+		const hit = getCached<SearchResults>(key);
+		if (hit) {
+			suggestions = preview(hit);
+			suggesting = false;
+			return;
+		}
+		suggesting = true;
+		try {
+			const fresh = await api.searchAll(q);
+			if (suggestFor !== q) return;
+			putCached(key, fresh);
+			suggestions = preview(fresh);
+		} catch {
+			if (suggestFor === q) suggestions = [];
+		} finally {
+			if (suggestFor === q) suggesting = false;
+		}
+	}
+
+	// Reads the element, not `query`: the bound value lands on the same event and the order of the
+	// two listeners is not ours to assume.
+	function onType(e: Event & { currentTarget: HTMLInputElement }) {
+		clearTimeout(debounce);
+		const q = e.currentTarget.value.trim();
+		if (q.length < 2) {
+			closeSuggest();
+			return;
+		}
+		suggestOpen = true;
+		if (q !== suggestFor) suggestions = [];
+		debounce = setTimeout(() => loadSuggest(q), 300);
+	}
+
+	function closeSuggest() {
+		clearTimeout(debounce);
+		suggestOpen = false;
+		suggesting = false;
+		active = -1;
+	}
+
+	function chooseSuggestion(item: BrowseItem) {
+		closeSuggest();
+		lastQuery = query;
+		openItem(item); // a song plays, everything else opens its page
+	}
+
+	function submit() {
+		if (active >= 0 && suggestions[active]) {
+			chooseSuggestion(suggestions[active]);
+			return;
+		}
+		closeSuggest();
+		runSearch();
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && suggestOpen) {
+			e.preventDefault();
+			closeSuggest();
+		} else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && suggestions.length) {
+			e.preventDefault();
+			suggestOpen = true;
+			const n = suggestions.length;
+			active = e.key === 'ArrowDown' ? (active + 1) % n : (active <= 0 ? n : active) - 1;
 		}
 	}
 
@@ -107,10 +216,122 @@
 			class="flex max-w-xl gap-2"
 			onsubmit={(e) => {
 				e.preventDefault();
-				runSearch();
+				submit();
+			}}
+			onfocusout={(e) => {
+				// Rows preventDefault on mousedown, so focus never leaves the input while clicking one:
+				// anything that gets here is a real move away from the field.
+				if (!e.currentTarget.contains(e.relatedTarget as Node | null)) closeSuggest();
 			}}
 		>
-			<Input bind:value={query} placeholder="Search songs, albums, artists, playlists…" />
+			<div class="relative flex-1">
+				<Input
+					bind:value={query}
+					placeholder="Search songs, albums, artists, playlists…"
+					autocomplete="off"
+					role="combobox"
+					aria-expanded={suggestOpen}
+					aria-controls="search-suggest"
+					oninput={onType}
+					onkeydown={onKeydown}
+					onfocus={() => {
+						if (suggestions.length && query.trim() === suggestFor) suggestOpen = true;
+					}}
+				/>
+				{#if suggestOpen}
+					<div
+						id="search-suggest"
+						role="listbox"
+						aria-label="Search preview"
+						class="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-xl animate-in fade-in-0 zoom-in-95 duration-150"
+					>
+						{#if suggesting && !suggestions.length}
+							{#each Array(4) as _, i (i)}
+								<div class="flex items-center gap-3 px-3 py-2">
+									<Skeleton class="h-10 w-10 shrink-0 rounded-md" />
+									<div class="min-w-0 flex-1">
+										<Skeleton class="h-3 w-40 rounded" />
+										<Skeleton class="mt-2 h-2.5 w-24 rounded" />
+									</div>
+								</div>
+							{/each}
+						{:else if !suggestions.length}
+							<div class="px-4 py-3 text-sm text-muted-foreground">Nothing quick for that.</div>
+						{:else}
+							{#each suggestions as item, i (item.id)}
+								{@const hero = i === 0}
+								<button
+									type="button"
+									role="option"
+									aria-selected={i === active}
+									class="flex w-full cursor-pointer items-center gap-3 px-3 text-left transition-colors {i ===
+									active
+										? 'bg-accent/60'
+										: 'hover:bg-accent/40'} {hero ? 'border-b py-2.5' : 'py-1.5'}"
+									onmousedown={(e) => e.preventDefault()}
+									onmouseenter={() => (active = i)}
+									onclick={() => chooseSuggestion(item)}
+								>
+									{#if item.thumbnail}
+										<!-- 400, the same size the cards below ask for: the CDN doesn't serve every rewritten
+										     size, that one is verified, and the row lands on an image the grid already fetched. -->
+										<img
+											src={thumb(item.thumbnail, 400)}
+											alt=""
+											class="shrink-0 object-cover {item.kind === 'artist'
+												? 'rounded-full'
+												: 'rounded-md'} {hero ? 'h-12 w-12' : 'h-10 w-10'}"
+										/>
+									{:else}
+										<div
+											class="flex shrink-0 items-center justify-center bg-muted text-muted-foreground/50 {item.kind ===
+											'artist'
+												? 'rounded-full'
+												: 'rounded-md'} {hero ? 'h-12 w-12' : 'h-10 w-10'}"
+										>
+											<HugeiconsIcon
+												icon={item.kind === 'artist' ? UserIcon : MusicNote01Icon}
+												class="h-5 w-5"
+											/>
+										</div>
+									{/if}
+									<div class="min-w-0 flex-1">
+										<div class="truncate {hero ? 'font-semibold' : 'text-sm'}">{item.title}</div>
+										<div class="flex items-center gap-1 text-xs text-muted-foreground">
+											{#if item.explicit}
+												<ExplicitIcon class="h-3 w-3 shrink-0" />
+											{/if}
+											<span class="truncate">
+												{KIND[item.kind]}{item.subtitle ? ` • ${item.subtitle}` : ''}
+											</span>
+										</div>
+									</div>
+									{#if hero}
+										<span
+											class="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[0.625rem] font-semibold uppercase tracking-wide text-primary"
+										>
+											Top result
+										</span>
+									{/if}
+								</button>
+							{/each}
+						{/if}
+						<button
+							type="button"
+							class="flex w-full cursor-pointer items-center gap-2 border-t bg-muted/30 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+							onmousedown={(e) => e.preventDefault()}
+							onmouseenter={() => (active = -1)}
+							onclick={() => {
+								closeSuggest();
+								runSearch();
+							}}
+						>
+							<HugeiconsIcon icon={Search01Icon} class="h-3.5 w-3.5" />
+							All results for “{query.trim()}”
+						</button>
+					</div>
+				{/if}
+			</div>
 			<Button type="submit" class="gap-2" disabled={searching}>
 				<HugeiconsIcon icon={Search01Icon} class="h-4 w-4" />
 				{searching ? 'Searching…' : 'Search'}

--- a/ui/src/routes/search/+page.svelte
+++ b/ui/src/routes/search/+page.svelte
@@ -10,22 +10,20 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
-	import { Search01Icon, MusicNote01Icon, UserIcon } from '@hugeicons/core-free-icons';
-	import { Input } from '$lib/components/ui/input';
+	import { Search01Icon } from '@hugeicons/core-free-icons';
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import MediaCardSkeleton from '$lib/components/MediaCardSkeleton.svelte';
+	import SearchSuggest from '$lib/components/SearchSuggest.svelte';
 	import TrackRow from '$lib/components/TrackRow.svelte';
 	import TrackRowSkeleton from '$lib/components/TrackRowSkeleton.svelte';
 	import ErrorState from '$lib/components/ErrorState.svelte';
 	import Shelf from '$lib/components/Shelf.svelte';
-	import ExplicitIcon from '$lib/components/ExplicitIcon.svelte';
 	import * as api from '$lib/api';
-	import type { BrowseItem, SearchResults } from '$lib/api';
+	import type { SearchResults } from '$lib/api';
 	import { getCached, putCached } from '$lib/pagecache';
 	import { openAddToPlaylist, playSong } from '$lib/player.svelte';
-	import { asSong, openItem } from '$lib/browse';
-	import { thumb } from '$lib/thumb';
+	import { asSong } from '$lib/browse';
 
 	let query = $state(lastQuery);
 	let res = $state<SearchResults | null>(null);
@@ -62,113 +60,6 @@
 			if (!hit) error = String(e);
 		} finally {
 			if (latest === q) searching = false;
-		}
-	}
-
-	// --- typeahead preview -----------------------------------------------------------------------
-	//
-	// Same `search_all` the page runs, debounced and cut down to a handful of rows. No separate
-	// suggestions endpoint: this fills the very cache `runSearch` reads, so hitting Enter on a
-	// previewed query paints instantly instead of searching a second time.
-
-	let suggestOpen = $state(false);
-	let suggestions = $state<BrowseItem[]>([]);
-	let suggesting = $state(false);
-	let active = $state(-1); // keyboard-highlighted row, -1 = none (Enter runs the full search)
-	let suggestFor = ''; // query `suggestions` belongs to, so a stale response can't land
-	let debounce: ReturnType<typeof setTimeout> | undefined;
-
-	const KIND = { song: 'Song', album: 'Album', artist: 'Artist', playlist: 'Playlist' };
-
-	/** A few rows across the categories rather than six songs: one top hit, then the mix. */
-	function preview(r: SearchResults): BrowseItem[] {
-		const out: BrowseItem[] = [];
-		const seen = new Set<string>();
-		const take = (items: BrowseItem[], n: number) => {
-			for (const i of items) {
-				if (n <= 0) break;
-				if (seen.has(i.id)) continue;
-				seen.add(i.id);
-				out.push(i);
-				n--;
-			}
-		};
-		take(r.top, 1);
-		take(r.songs, 3);
-		take(r.artists, 1);
-		take(r.albums, 1);
-		take(r.playlists, 1);
-		return out;
-	}
-
-	async function loadSuggest(q: string) {
-		suggestFor = q;
-		active = -1;
-		const key = `search:${q}`;
-		const hit = getCached<SearchResults>(key);
-		if (hit) {
-			suggestions = preview(hit);
-			suggesting = false;
-			return;
-		}
-		suggesting = true;
-		try {
-			const fresh = await api.searchAll(q);
-			if (suggestFor !== q) return;
-			putCached(key, fresh);
-			suggestions = preview(fresh);
-		} catch {
-			if (suggestFor === q) suggestions = [];
-		} finally {
-			if (suggestFor === q) suggesting = false;
-		}
-	}
-
-	// Reads the element, not `query`: the bound value lands on the same event and the order of the
-	// two listeners is not ours to assume.
-	function onType(e: Event & { currentTarget: HTMLInputElement }) {
-		clearTimeout(debounce);
-		const q = e.currentTarget.value.trim();
-		if (q.length < 2) {
-			closeSuggest();
-			return;
-		}
-		suggestOpen = true;
-		if (q !== suggestFor) suggestions = [];
-		debounce = setTimeout(() => loadSuggest(q), 300);
-	}
-
-	function closeSuggest() {
-		clearTimeout(debounce);
-		suggestOpen = false;
-		suggesting = false;
-		active = -1;
-	}
-
-	function chooseSuggestion(item: BrowseItem) {
-		closeSuggest();
-		lastQuery = query;
-		openItem(item); // a song plays, everything else opens its page
-	}
-
-	function submit() {
-		if (active >= 0 && suggestions[active]) {
-			chooseSuggestion(suggestions[active]);
-			return;
-		}
-		closeSuggest();
-		runSearch();
-	}
-
-	function onKeydown(e: KeyboardEvent) {
-		if (e.key === 'Escape' && suggestOpen) {
-			e.preventDefault();
-			closeSuggest();
-		} else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && suggestions.length) {
-			e.preventDefault();
-			suggestOpen = true;
-			const n = suggestions.length;
-			active = e.key === 'ArrowDown' ? (active + 1) % n : (active <= 0 ? n : active) - 1;
 		}
 	}
 
@@ -216,122 +107,14 @@
 			class="flex max-w-xl gap-2"
 			onsubmit={(e) => {
 				e.preventDefault();
-				submit();
-			}}
-			onfocusout={(e) => {
-				// Rows preventDefault on mousedown, so focus never leaves the input while clicking one:
-				// anything that gets here is a real move away from the field.
-				if (!e.currentTarget.contains(e.relatedTarget as Node | null)) closeSuggest();
+				runSearch();
 			}}
 		>
-			<div class="relative flex-1">
-				<Input
-					bind:value={query}
-					placeholder="Search songs, albums, artists, playlists…"
-					autocomplete="off"
-					role="combobox"
-					aria-expanded={suggestOpen}
-					aria-controls="search-suggest"
-					oninput={onType}
-					onkeydown={onKeydown}
-					onfocus={() => {
-						if (suggestions.length && query.trim() === suggestFor) suggestOpen = true;
-					}}
-				/>
-				{#if suggestOpen}
-					<div
-						id="search-suggest"
-						role="listbox"
-						aria-label="Search preview"
-						class="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-xl animate-in fade-in-0 zoom-in-95 duration-150"
-					>
-						{#if suggesting && !suggestions.length}
-							{#each Array(4) as _, i (i)}
-								<div class="flex items-center gap-3 px-3 py-2">
-									<Skeleton class="h-10 w-10 shrink-0 rounded-md" />
-									<div class="min-w-0 flex-1">
-										<Skeleton class="h-3 w-40 rounded" />
-										<Skeleton class="mt-2 h-2.5 w-24 rounded" />
-									</div>
-								</div>
-							{/each}
-						{:else if !suggestions.length}
-							<div class="px-4 py-3 text-sm text-muted-foreground">Nothing quick for that.</div>
-						{:else}
-							{#each suggestions as item, i (item.id)}
-								{@const hero = i === 0}
-								<button
-									type="button"
-									role="option"
-									aria-selected={i === active}
-									class="flex w-full cursor-pointer items-center gap-3 px-3 text-left transition-colors {i ===
-									active
-										? 'bg-accent/60'
-										: 'hover:bg-accent/40'} {hero ? 'border-b py-2.5' : 'py-1.5'}"
-									onmousedown={(e) => e.preventDefault()}
-									onmouseenter={() => (active = i)}
-									onclick={() => chooseSuggestion(item)}
-								>
-									{#if item.thumbnail}
-										<!-- 400, the same size the cards below ask for: the CDN doesn't serve every rewritten
-										     size, that one is verified, and the row lands on an image the grid already fetched. -->
-										<img
-											src={thumb(item.thumbnail, 400)}
-											alt=""
-											class="shrink-0 object-cover {item.kind === 'artist'
-												? 'rounded-full'
-												: 'rounded-md'} {hero ? 'h-12 w-12' : 'h-10 w-10'}"
-										/>
-									{:else}
-										<div
-											class="flex shrink-0 items-center justify-center bg-muted text-muted-foreground/50 {item.kind ===
-											'artist'
-												? 'rounded-full'
-												: 'rounded-md'} {hero ? 'h-12 w-12' : 'h-10 w-10'}"
-										>
-											<HugeiconsIcon
-												icon={item.kind === 'artist' ? UserIcon : MusicNote01Icon}
-												class="h-5 w-5"
-											/>
-										</div>
-									{/if}
-									<div class="min-w-0 flex-1">
-										<div class="truncate {hero ? 'font-semibold' : 'text-sm'}">{item.title}</div>
-										<div class="flex items-center gap-1 text-xs text-muted-foreground">
-											{#if item.explicit}
-												<ExplicitIcon class="h-3 w-3 shrink-0" />
-											{/if}
-											<span class="truncate">
-												{KIND[item.kind]}{item.subtitle ? ` • ${item.subtitle}` : ''}
-											</span>
-										</div>
-									</div>
-									{#if hero}
-										<span
-											class="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[0.625rem] font-semibold uppercase tracking-wide text-primary"
-										>
-											Top result
-										</span>
-									{/if}
-								</button>
-							{/each}
-						{/if}
-						<button
-							type="button"
-							class="flex w-full cursor-pointer items-center gap-2 border-t bg-muted/30 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-							onmousedown={(e) => e.preventDefault()}
-							onmouseenter={() => (active = -1)}
-							onclick={() => {
-								closeSuggest();
-								runSearch();
-							}}
-						>
-							<HugeiconsIcon icon={Search01Icon} class="h-3.5 w-3.5" />
-							All results for “{query.trim()}”
-						</button>
-					</div>
-				{/if}
-			</div>
+			<SearchSuggest
+				bind:value={query}
+				placeholder="Search songs, albums, artists, playlists…"
+				onpick={() => (lastQuery = query)}
+			/>
 			<Button type="submit" class="gap-2" disabled={searching}>
 				<HugeiconsIcon icon={Search01Icon} class="h-4 w-4" />
 				{searching ? 'Searching…' : 'Search'}


### PR DESCRIPTION
Part of #35 (the search suggestions part of it, not the play counts).

Typing in either search field (the Search page and the home hero) drops a preview panel under the input after a 500ms pause: top result on its own row, then a few songs, an artist, an album, a playlist. Clicking a song plays it, anything else opens its page.

Arrow keys move through the rows, Enter takes the highlighted one or falls through to the full search, Escape closes.

No new backend endpoint. The preview runs the same `search_all` command and writes the same page-cache key the search page reads, so Enter on a previewed query paints from cache instead of searching twice.

Both fields share `SearchSuggest.svelte`. The hero's `overflow-hidden` moved onto a wrapper around the blurred backdrop, which still needs clipping, so the panel can hang past the bottom edge.

Verified: `pnpm check` clean, UI checked in `cargo tauri dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added search suggestions to the home hero and search page.
  - Suggestions appear as users type, with loading, empty, and error states.
  - Added keyboard navigation, result selection, and an “All results” option.
  - Search suggestions can extend beyond the hero area without being clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->