### PR TITLE
feat(library): save playlists and albums without an account

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -386,7 +386,13 @@ pub async fn get_home_more(state: St<'_>, token: String) -> Result<HomePage, Str
 #[tauri::command]
 pub async fn get_library(state: St<'_>) -> Result<Vec<BrowseItem>, String> {
     let client = metadata_client(&state)?;
-    let mut items = state.it.library_playlists(client).await.map_err(|e| e.to_string())?;
+    // Signed out there is no YouTube library to ask for (the browse would come back as a sign-in
+    // shell), but On Repeat is built from this machine's play history and is still real.
+    let mut items = if state.it.is_logged_in() {
+        state.it.library_playlists(client).await.map_err(|e| e.to_string())?
+    } else {
+        Vec::new()
+    };
     // On Repeat leads the library once there's anything in it. Hidden while empty rather than
     // shown as a dead tile on a fresh install.
     let songs = on_repeat_songs(&state);
@@ -409,14 +415,22 @@ pub async fn get_library(state: St<'_>) -> Result<Vec<BrowseItem>, String> {
     Ok(items)
 }
 
+/// Empty rather than an error when signed out: the Library page merges the user's local saves into
+/// these grids, so "nothing of yours on YouTube" is an answer, not a failure.
 #[tauri::command]
 pub async fn get_library_albums(state: St<'_>) -> Result<Vec<BrowseItem>, String> {
+    if !state.it.is_logged_in() {
+        return Ok(Vec::new());
+    }
     let client = metadata_client(&state)?;
     state.it.library_albums(client).await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn get_library_artists(state: St<'_>) -> Result<Vec<BrowseItem>, String> {
+    if !state.it.is_logged_in() {
+        return Ok(Vec::new());
+    }
     let client = metadata_client(&state)?;
     state.it.library_artists(client).await.map_err(|e| e.to_string())
 }

--- a/ui/src/lib/components/PlaylistMenu.svelte
+++ b/ui/src/lib/components/PlaylistMenu.svelte
@@ -10,13 +10,22 @@
 		Radio02Icon,
 		ArrowUpNarrowWideIcon,
 		ArrowDownWideNarrowIcon,
+		BookmarkMinus02Icon,
 		DashboardSquare02Icon
 	} from '@hugeicons/core-free-icons';
 	import * as api from '$lib/api';
 	import type { BrowseItem } from '$lib/api';
 	import { enqueueItem } from '$lib/browse';
 	import { anchorMenu, toBody } from '$lib/menu';
-	import { addPick, personal, startRadio, togglePin } from '$lib/player.svelte';
+	import {
+		addPick,
+		isSaved,
+		personal,
+		startRadio,
+		toast,
+		togglePin,
+		toggleSaved
+	} from '$lib/player.svelte';
 
 	let {
 		item,
@@ -35,6 +44,7 @@
 	} = $props();
 
 	const pinned = $derived(personal.pins.includes(item.id));
+	const savedHere = $derived(isSaved(item.id));
 	// Radio needs a YouTube item behind it: local folders and the locally-built On Repeat have none.
 	const hasRadio = $derived(!api.isLocalId(item.id) && item.id !== api.ON_REPEAT_ID);
 	// An artist isn't a track list — there's nothing unambiguous to queue. Songs, albums and
@@ -152,5 +162,19 @@
 		>
 			<HugeiconsIcon icon={DashboardSquare02Icon} class="h-4 w-4" /> Add to shortcuts
 		</button>
+		<!-- Only for cards saved on this machine: YouTube's own library rows are unsaved from their
+		     page, where the button knows which write action to send. -->
+		{#if savedHere}
+			<button
+				class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
+				onclick={(e) =>
+					run(e, () => {
+						toggleSaved(item);
+						toast.success('Removed from library');
+					})}
+			>
+				<HugeiconsIcon icon={BookmarkMinus02Icon} class="h-4 w-4" /> Remove from library
+			</button>
+		{/if}
 	</div>
 {/if}

--- a/ui/src/lib/components/ShortcutPicker.svelte
+++ b/ui/src/lib/components/ShortcutPicker.svelte
@@ -9,12 +9,16 @@
 	import { Cancel01Icon, Tick02Icon, Add01Icon } from '@hugeicons/core-free-icons';
 	import { thumb } from '$lib/thumb';
 	import { addPick, library, loadLibrary, personal } from '$lib/player.svelte';
+	import { mergeSaved } from '$lib/personal';
 
 	let { onclose }: { onclose: () => void } = $props();
 
 	let filter = $state('');
+	// Playlists saved on this machine count as library too: signed out they're all there is.
 	const matches = $derived(
-		library.items.filter((i) => i.title.toLowerCase().includes(filter.trim().toLowerCase()))
+		mergeSaved(personal, library.items, 'playlist').filter((i) =>
+			i.title.toLowerCase().includes(filter.trim().toLowerCase())
+		)
 	);
 	const already = (id: string) => personal.picks.some((p) => p.id === id);
 
@@ -86,7 +90,9 @@
 			</div>
 		{:else}
 			<p class="p-2 text-sm text-muted-foreground">
-				{library.items.length ? 'Nothing matches that.' : 'No playlists yet — create one in your Library.'}
+				{filter.trim()
+					? 'Nothing matches that.'
+					: 'No playlists yet. Save one from its page, or create one in your Library.'}
 			</p>
 		{/if}
 	</div>

--- a/ui/src/lib/components/Sidebar.svelte
+++ b/ui/src/lib/components/Sidebar.svelte
@@ -32,7 +32,7 @@
 		toggleSidebar,
 		toast
 	} from '$lib/player.svelte';
-	import { orderLibrary } from '$lib/personal';
+	import { mergeSaved, orderLibrary } from '$lib/personal';
 
 	const nav = [
 		{ href: '/', label: 'Home', icon: Home01Icon },
@@ -43,8 +43,11 @@
 		href === '/' ? page.url.pathname === '/' : page.url.pathname.startsWith(href);
 
 	// Pinned first (in pin order), then everything else by last played. Derived here rather than in
-	// the shared `library` store so the Library page keeps YouTube's own ordering.
-	const playlists = $derived(orderLibrary(library.items, personal));
+	// the shared `library` store so the Library page keeps YouTube's own ordering. Playlists saved
+	// on this machine sit in the same list: signed out they are the only ones there.
+	const playlists = $derived(
+		orderLibrary(mergeSaved(personal, library.items, 'playlist'), personal)
+	);
 	// How many of the leading rows are pinned — a rule under the last one explains the split.
 	const pinnedCount = $derived(playlists.filter((p) => personal.pins.includes(p.id)).length);
 
@@ -171,18 +174,22 @@
 		</button>
 	</nav>
 
-	<!-- Playlists (signed in). Hidden on the icon rail — needs labels; matches YTM's collapsed rail.
-	     flex-1 lets the list fill the space and scroll. -->
-	{#if auth.account?.signedIn}
+	<!-- Playlists. Hidden on the icon rail (needs labels; matches YTM's collapsed rail). flex-1 lets
+	     the list fill the space and scroll. Signed out the section still appears once there is
+	     something in it: On Repeat, or a playlist saved on this machine. -->
+	{#if auth.account?.signedIn || playlists.length}
 		<div class="mt-3 hidden min-h-0 flex-1 flex-col border-t pt-3 {wide('lg:flex')}">
-			<Button
-				variant="outline"
-				size="sm"
-				class="mb-2 w-full gap-2"
-				onclick={() => (dialogOpen = true)}
-			>
-				<HugeiconsIcon icon={Add01Icon} class="h-4 w-4" /> New playlist
-			</Button>
+			<!-- Creating one is a YouTube write action, so it needs an account. -->
+			{#if auth.account?.signedIn}
+				<Button
+					variant="outline"
+					size="sm"
+					class="mb-2 w-full gap-2"
+					onclick={() => (dialogOpen = true)}
+				>
+					<HugeiconsIcon icon={Add01Icon} class="h-4 w-4" /> New playlist
+				</Button>
+			{/if}
 			<div class="min-h-0 flex-1 overflow-y-auto">
 				{#each playlists as pl, i (pl.id)}
 					<!-- The ⋯ is a sibling of the link, not a child: a <button> inside an <a> is invalid

--- a/ui/src/lib/personal.check.ts
+++ b/ui/src/lib/personal.check.ts
@@ -16,6 +16,8 @@ import {
 	hiddenSections,
 	hydrate,
 	interleave,
+	isSaved,
+	mergeSaved,
 	noteRecent,
 	orderLibrary,
 	placePick,
@@ -23,6 +25,7 @@ import {
 	removePick,
 	seedPick,
 	togglePin,
+	toggleSaved,
 	topArtistIds,
 	touchPick
 } from './personal.ts';
@@ -286,6 +289,36 @@ const range = (n: number, prefix: string) => Array.from({ length: n }, (_, i) =>
 	);
 	ok(hydrate({}).home.order.length === 0, 'a blob from before the feature reads as unarranged');
 	ok(hydrate({ home: { order: [1, 'a'], hidden: 'nope' } }).home.order.join() === 'a,@familiar', 'junk is dropped');
+}
+
+// --- the saved library: local saves merge with YouTube's without duplicating anything ------------
+{
+	const p = empty();
+	const album = (id: string): BrowseItem => ({ kind: 'album', id, title: id });
+
+	ok(toggleSaved(p, item('VL1')), 'saving reports it saved');
+	ok(isSaved(p, 'VL1'), 'and it reads back as saved');
+	ok(!toggleSaved(p, item('VL1')), 'saving the same card again unsaves it');
+	ok(!isSaved(p, 'VL1'), 'and it is gone');
+
+	toggleSaved(p, item('VL1'));
+	toggleSaved(p, album('MPRE1'));
+	toggleSaved(p, album('MPRE2'));
+	// Newest first, and only the asked-for kind: the Library page's tabs are built from these.
+	ok(ids(mergeSaved(p, [], 'album')).join() === 'MPRE2,MPRE1', 'newest saved first, albums only');
+	ok(ids(mergeSaved(p, [], 'playlist')).join() === 'VL1', 'playlists are their own tab');
+	ok(mergeSaved(p, [], 'artist').length === 0, 'nothing saved of that kind is empty, not an error');
+
+	// An album saved here and also in the YouTube library is one tile, not two.
+	const remote = [album('MPRE1'), album('MPRE9')];
+	ok(ids(mergeSaved(p, remote, 'album')).join() === 'MPRE2,MPRE1,MPRE9', 'deduped by id');
+	ok(mergeSaved(empty(), remote, 'album') === remote, 'no local saves returns the input untouched');
+
+	// Saves are not account-scoped, so signing in later must not drop them (hydrate is the only
+	// thing that ever rebuilds this list).
+	ok(ids(hydrate(JSON.parse(JSON.stringify(p))).saved).join() === 'MPRE2,MPRE1,VL1', 'saves persist');
+	ok(hydrate({}).saved.length === 0, 'a blob from before the feature reads as nothing saved');
+	ok(hydrate({ saved: [{ id: 'x' }, 'junk'] }).saved.length === 0, 'junk rows are dropped');
 }
 
 // --- familiar artists: play counts, but only the ones with a channel to open --------------------

--- a/ui/src/lib/personal.ts
+++ b/ui/src/lib/personal.ts
@@ -27,6 +27,12 @@ export type RecentEntry = BrowseItem & { at: number };
 
 export type Personal = {
 	picks: Pick[];
+	/**
+	 * Playlists, albums and artists saved to the library from this machine, newest first. This is
+	 * the whole library for a signed-out user, and it sits alongside YouTube's own for a signed-in
+	 * one: nothing here is account-scoped, so saves made before signing in stay put afterwards.
+	 */
+	saved: BrowseItem[];
 	/** Pinned sidebar playlists, at most MAX_PINS; array order is display order. */
 	pins: string[];
 	/** Last time each playlist/album/artist was played from, keyed by browseId. */
@@ -45,6 +51,7 @@ export type Personal = {
 export function empty(): Personal {
 	return {
 		picks: [],
+		saved: [],
 		pins: [],
 		recent: {},
 		artists: {},
@@ -65,6 +72,9 @@ export function hydrate(raw: unknown): Personal {
 		base.picks = o.picks.filter(
 			(p) => p && typeof p.id === 'string' && (p as { manual?: boolean }).manual !== false
 		);
+	}
+	if (Array.isArray(o.saved)) {
+		base.saved = o.saved.filter((s) => s && typeof s.id === 'string' && typeof s.kind === 'string');
 	}
 	if (Array.isArray(o.pins)) {
 		base.pins = o.pins.filter((p) => typeof p === 'string').slice(0, MAX_PINS);
@@ -179,6 +189,38 @@ export function touchPick(p: Personal, id: string, now = Date.now()): boolean {
 	if (!hit) return false;
 	hit.lastUsedAt = now;
 	return true;
+}
+
+// --- Saved library ------------------------------------------------------------------------------
+
+/** Save or unsave a playlist/album/artist. Returns whether it is saved now. */
+export function toggleSaved(p: Personal, item: BrowseItem): boolean {
+	if (p.saved.some((s) => s.id === item.id)) {
+		p.saved = p.saved.filter((s) => s.id !== item.id);
+		return false;
+	}
+	// The card as it was on screen: opening it refetches everything anyway, so a stale subtitle is
+	// the worst this can go wrong, and storing it is what makes the grid render offline.
+	p.saved = [{ ...item }, ...p.saved];
+	return true;
+}
+
+export const isSaved = (p: Personal, id: string): boolean => p.saved.some((s) => s.id === id);
+
+/**
+ * One kind's saved cards followed by YouTube's own, minus anything in both. Deduped by id, which
+ * matches across the two: a library grid and a search card come out of the same parser, so an album
+ * saved here and liked on YouTube is one `MPRE…` either way.
+ */
+export function mergeSaved(
+	p: Personal,
+	items: BrowseItem[],
+	kind: BrowseItem['kind']
+): BrowseItem[] {
+	const local = p.saved.filter((s) => s.kind === kind);
+	if (!local.length) return items;
+	const have = new Set(items.map((i) => i.id));
+	return [...local.filter((s) => !have.has(s.id)), ...items];
 }
 
 // --- Sidebar pins + ordering -------------------------------------------------------------------

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -312,6 +312,60 @@ export function toggleSaved(item: BrowseItem): boolean {
 
 export const isSaved = (id: string): boolean => pl.isSaved(personal, id);
 
+/**
+ * Push everything saved on this machine into the signed-in account, then drop the local rows: the
+ * same cards come back through `loadLibrary`, so keeping both copies is what would duplicate them.
+ * Sequential, like every other bulk write here (a library is a handful of requests, don't hammer).
+ * Anything that fails stays local, so pressing the button again retries exactly what's left.
+ */
+export async function syncSavedToYouTube(): Promise<{ synced: number; failed: number }> {
+	// Fresh: "is this already in the account" is the whole duplicate check.
+	await loadLibrary(true);
+	const known = new Set(library.items.map((i) => i.id));
+	const done: string[] = [];
+	let failed = 0;
+	for (const item of personal.saved) {
+		try {
+			if (item.kind === 'album') {
+				// YouTube's own answer, so it can't be liked twice. The album's audio playlist is the
+				// like target and only its page carries it, which is what this fetch is for.
+				const album = await api.getAlbum(item.id);
+				if (!album.inLibrary) {
+					if (!album.playlistId) throw new Error('no album playlist');
+					await api.setAlbumSaved(album.playlistId, true);
+				}
+			} else if (item.kind === 'artist') {
+				// Subscribing twice is the same subscription. No pre-check: the library's artist grid
+				// is built from the songs in your library, not from subscriptions, so it can't answer.
+				await api.subscribe(item.id, true);
+			} else if (item.kind === 'playlist') {
+				// A playlist is liked by its browseId (Rust strips the `VL`), and it lands in the same
+				// grid `known` was built from, so a hit there means it is already saved.
+				if (!known.has(item.id)) await api.setAlbumSaved(item.id, true);
+			} else {
+				continue; // ponytail: songs can't be saved today, so there is nothing to push
+			}
+			done.push(item.id);
+		} catch {
+			failed++;
+		}
+	}
+	if (done.length) {
+		// Moved across rather than refetched: YouTube's library browse is eventually consistent and
+		// won't list a just-liked album for a few seconds, so a refresh here would blank the tiles
+		// that were on screen a moment ago (same reason `createLibraryPlaylist` prepends). The next
+		// forced refresh replaces these with YouTube's own rows. `mergeSaved` is the same dedupe the
+		// grids already use, so nothing lands twice; only what actually synced comes across.
+		const moved = { ...pl.empty(), saved: personal.saved.filter((s) => done.includes(s.id)) };
+		personal.saved = personal.saved.filter((s) => !done.includes(s.id));
+		savePersonal();
+		library.items = pl.mergeSaved(moved, library.items, 'playlist');
+		library.albums = pl.mergeSaved(moved, library.albums, 'album');
+		library.artists = pl.mergeSaved(moved, library.artists, 'artist');
+	}
+	return { synced: done.length, failed };
+}
+
 export function togglePin(id: string) {
 	const result = pl.togglePin(personal, id);
 	if (result === 'full') toast.error(`Unpin one first — ${pl.MAX_PINS} pins max`);

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -299,6 +299,19 @@ export function touchPick(id: string) {
 	if (pl.touchPick(personal, id)) savePersonal();
 }
 
+/**
+ * Save a playlist/album/artist to the library from this machine, or take it back out. Returns the
+ * new state. Not account-scoped and never cleared on sign-in: what a signed-out user saved is still
+ * theirs afterwards, sitting next to whatever YouTube says their library holds.
+ */
+export function toggleSaved(item: BrowseItem): boolean {
+	const saved = pl.toggleSaved(personal, item);
+	savePersonal();
+	return saved;
+}
+
+export const isSaved = (id: string): boolean => pl.isSaved(personal, id);
+
 export function togglePin(id: string) {
 	const result = pl.togglePin(personal, id);
 	if (result === 'full') toast.error(`Unpin one first — ${pl.MAX_PINS} pins max`);
@@ -608,9 +621,10 @@ export function initApp(mini = false): () => void {
 		api.onAuthChanged((a) => {
 			auth.account = a;
 			resetLibraryForAccount();
-			if (a.signedIn) {
-				if (!mini) loadLibrary(true);
-			} else {
+			// Signing out doesn't empty the library: On Repeat and anything saved on this machine
+			// are still there, and the backend answers both without touching YouTube.
+			if (!mini) loadLibrary(true);
+			if (!a.signedIn) {
 				ui.channelPickerOpen = false;
 				ui.channelPickerRequired = false;
 				ui.channelIdentities = [];
@@ -657,8 +671,8 @@ export function initApp(mini = false): () => void {
 				openChannelPicker(true);
 				return;
 			}
+			loadLibrary();
 			if (a.signedIn) {
-				loadLibrary();
 				// Only when the stored answer might be the provisional one: databases that predate
 				// `canSwitch` default it to true so the action stays discoverable, and this is what
 				// demotes single-channel users back to no switcher. A stored `false` is already

--- a/ui/src/routes/album/[id]/+page.svelte
+++ b/ui/src/routes/album/[id]/+page.svelte
@@ -29,11 +29,13 @@
         addPick,
         auth,
         enqueue,
+        isSaved,
         playback,
         openAddManyToPlaylist,
         playFrom,
         startRadio,
         toast,
+        toggleSaved,
     } from "$lib/player.svelte";
     import { getCached, putCached } from "$lib/pagecache";
     import { thumb } from "$lib/thumb";
@@ -151,14 +153,31 @@
         // Real order + shuffle flag — the backend shuffles (fresh each time, restorable).
         playFrom(asItem(), album.items, null, album.playlistId, true);
     }
-    // Saving an album to the library is a "like" on its audio playlist. Optimistic: the button
-    // flips now and reverts if YouTube rejects it. Mutating `album` also updates the page cache,
-    // which holds this same object.
+    // Saved on YouTube (signed in) or on this machine (signed out, and anything saved before the
+    // user ever signed in). The button reads both, so a local save can't show as "Save to library"
+    // while its tile sits in the library.
+    const savedHere = $derived(isSaved(id));
+    const inLibrary = $derived((album?.inLibrary ?? false) || savedHere);
+
+    // Signed in, saving an album is a "like" on its audio playlist: optimistic, the button flips now
+    // and reverts if YouTube rejects it (mutating `album` updates the page cache, which holds this
+    // same object). Signed out there is nobody to tell, so it goes in the local library instead.
     let savingLibrary = $state(false);
     async function toggleLibrary() {
         const a = album;
-        if (!a?.playlistId || savingLibrary) return;
-        const next = !a.inLibrary;
+        if (!a || savingLibrary) return;
+        const next = !inLibrary;
+        if (!auth.account?.signedIn || !a.playlistId) {
+            toggleSaved(asItem());
+            toast.success(next ? "Saved to library" : "Removed from library");
+            return;
+        }
+        // Signed in: YouTube owns it from here, so drop any local row left from before signing in.
+        if (savedHere) toggleSaved(asItem());
+        if (a.inLibrary === next) {
+            toast.success(next ? "Saved to library" : "Removed from library");
+            return; // YouTube already agrees; only the local row had to go
+        }
         a.inLibrary = next;
         savingLibrary = true;
         try {
@@ -326,11 +345,13 @@
                 >
                     <HugeiconsIcon icon={ShuffleIcon} class="h-4 w-4" /> Shuffle
                 </button>
-                {#if auth.account?.signedIn && album.playlistId}
+                <!-- Local albums are already in the Local tab; everything else is savable, signed
+                     in or not. -->
+                {#if !isLocal}
                     <button
                         class="flex cursor-pointer items-center gap-2 rounded-full border px-5 py-2.5 text-sm font-semibold transition hover:bg-accent/10 disabled:opacity-50"
-                        class:border-primary={album.inLibrary}
-                        class:text-primary={album.inLibrary}
+                        class:border-primary={inLibrary}
+                        class:text-primary={inLibrary}
                         onclick={toggleLibrary}
                         disabled={savingLibrary}
                     >
@@ -338,10 +359,10 @@
                         <HugeiconsIcon
                             icon={BookmarkAdd02Icon}
                             altIcon={BookmarkCheck02Icon}
-                            showAlt={album.inLibrary}
+                            showAlt={inLibrary}
                             class="h-4 w-4"
                         />
-                        {album.inLibrary ? "In library" : "Save to library"}
+                        {inLibrary ? "In library" : "Save to library"}
                     </button>
                 {/if}
                 <button

--- a/ui/src/routes/artist/[id]/+page.svelte
+++ b/ui/src/routes/artist/[id]/+page.svelte
@@ -9,6 +9,8 @@
 		Tick02Icon,
 		MoreVerticalIcon,
 		DashboardSquare02Icon,
+		BookmarkAdd02Icon,
+		BookmarkCheck02Icon,
 		ArrowRight01Icon
 	} from '@hugeicons/core-free-icons';
 	import MediaCardSkeleton from '$lib/components/MediaCardSkeleton.svelte';
@@ -21,11 +23,14 @@
 	import type { ArtistPage, BrowseItem, PlaylistPage } from '$lib/api';
 	import {
 		addPick,
+		auth,
+		isSaved,
 		playback,
 		openAddToPlaylist,
 		playFrom,
 		startRadio,
-		toast
+		toast,
+		toggleSaved
 	} from '$lib/player.svelte';
 	import { getCached, putCached } from '$lib/pagecache';
 
@@ -39,6 +44,8 @@
 
 	const id = $derived(page.params.id ?? '');
 	const nowId = $derived(playback.now?.videoId);
+	// Saved to the library on this machine (the signed-out counterpart of subscribing).
+	const savedHere = $derived(isSaved(id));
 
 	async function load(cid: string) {
 		const key = `artist:${cid}`;
@@ -219,16 +226,38 @@
 				>
 					<HugeiconsIcon icon={Radio02Icon} class="h-4 w-4" /> Radio
 				</button>
-				<button
-					class="flex items-center gap-2 rounded-full border px-5 py-2.5 text-sm font-semibold transition hover:bg-accent/10 disabled:opacity-60 {subscribed
-						? 'border-primary text-primary'
-						: ''}"
-					onclick={toggleSub}
-					disabled={subBusy}
-				>
-					<HugeiconsIcon icon={Add01Icon} altIcon={Tick02Icon} showAlt={subscribed} class="h-4 w-4" />
-					{subscribed ? 'Subscribed' : 'Subscribe'}
-				</button>
+				<!-- Subscribing is a YouTube write action. Signed out, the same slot saves the artist to
+				     the local library instead of offering a button that can only fail. -->
+				{#if auth.account?.signedIn}
+					<button
+						class="flex items-center gap-2 rounded-full border px-5 py-2.5 text-sm font-semibold transition hover:bg-accent/10 disabled:opacity-60 {subscribed
+							? 'border-primary text-primary'
+							: ''}"
+						onclick={toggleSub}
+						disabled={subBusy}
+					>
+						<HugeiconsIcon icon={Add01Icon} altIcon={Tick02Icon} showAlt={subscribed} class="h-4 w-4" />
+						{subscribed ? 'Subscribed' : 'Subscribe'}
+					</button>
+				{:else}
+					<button
+						class="flex cursor-pointer items-center gap-2 rounded-full border px-5 py-2.5 text-sm font-semibold transition hover:bg-accent/10 {savedHere
+							? 'border-primary text-primary'
+							: ''}"
+						onclick={() =>
+							toast.success(
+								toggleSaved(asItem()) ? 'Saved to library' : 'Removed from library'
+							)}
+					>
+						<HugeiconsIcon
+							icon={BookmarkAdd02Icon}
+							altIcon={BookmarkCheck02Icon}
+							showAlt={savedHere}
+							class="h-4 w-4"
+						/>
+						{savedHere ? 'In library' : 'Save to library'}
+					</button>
+				{/if}
 				<button
 					class="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border text-muted-foreground transition hover:bg-accent/10 hover:text-foreground"
 					onclick={openMenu}

--- a/ui/src/routes/library/+page.svelte
+++ b/ui/src/routes/library/+page.svelte
@@ -10,6 +10,7 @@
 	import { HugeiconsIcon } from '@hugeicons/svelte';
 	import {
 		Add01Icon,
+		CloudSyncIcon,
 		DriveIcon,
 		MusicNoteSquare02Icon,
 		Playlist02Icon,
@@ -32,7 +33,8 @@
 		library,
 		loadLibrary,
 		loadLibraryExtras,
-		createLibraryPlaylist
+		createLibraryPlaylist,
+		syncSavedToYouTube
 	} from '$lib/player.svelte';
 	import { mergeSaved } from '$lib/personal';
 
@@ -63,6 +65,23 @@
 	function load() {
 		loadLibrary(true);
 		loadLibraryExtras(true);
+	}
+
+	let syncing = $state(false);
+	async function sync() {
+		if (syncing) return;
+		syncing = true;
+		const n = personal.saved.length;
+		try {
+			const { synced, failed } = await syncSavedToYouTube();
+			if (failed && synced) toast(`Synced ${synced} of ${n}. ${failed} failed, still saved here.`);
+			else if (failed) toast.error(`Nothing synced. ${failed} failed, still saved here.`);
+			else toast.success(`Synced ${synced} to YouTube Music`);
+		} catch (e) {
+			toast.error(String(e));
+		} finally {
+			syncing = false;
+		}
 	}
 
 	async function createNew() {
@@ -98,9 +117,27 @@
 	<div class="mb-6 flex items-center justify-between">
 		<h1 class="font-heading text-2xl font-bold">Library</h1>
 		{#if auth.account?.signedIn}
-			<Button variant="outline" size="sm" class="gap-2" onclick={() => (dialogOpen = true)}>
-				<HugeiconsIcon icon={Add01Icon} class="h-4 w-4" /> New playlist
-			</Button>
+			<div class="flex items-center gap-2">
+				<!-- Only with something to push: saves made before signing in, which live on this
+				     machine until this button puts them on the account. -->
+				{#if personal.saved.length}
+					<Button
+						variant="outline"
+						size="sm"
+						class="gap-2"
+						onclick={sync}
+						disabled={syncing}
+						title="Add everything saved on this device to YouTube Music"
+						aria-label="Sync saved items to YouTube Music"
+					>
+						<HugeiconsIcon icon={CloudSyncIcon} class="h-4 w-4" />
+						{syncing ? 'Syncing…' : `Sync ${personal.saved.length} to YT Music`}
+					</Button>
+				{/if}
+				<Button variant="outline" size="sm" class="gap-2" onclick={() => (dialogOpen = true)}>
+					<HugeiconsIcon icon={Add01Icon} class="h-4 w-4" /> New playlist
+				</Button>
+			</div>
 		{/if}
 	</div>
 

--- a/ui/src/routes/library/+page.svelte
+++ b/ui/src/routes/library/+page.svelte
@@ -130,14 +130,10 @@
 						aria-label="Sync {personal.saved.length} saved items to YouTube Music"
 					>
 						<span class="relative">
-							<HugeiconsIcon
-								icon={CloudSyncIcon}
-								strokeWidth={2.2}
-								class="h-4 w-4 {syncing ? 'animate-pulse' : ''}"
-							/>
+							<HugeiconsIcon icon={CloudSyncIcon} class="h-4 w-4 {syncing ? 'animate-pulse' : ''}" />
 							<!-- ring-background so the count reads over the icon's stroke (as in Titlebar). -->
 							<span
-								class="absolute -right-2.5 -top-2 min-w-4 rounded-full bg-accent px-1 text-[10px] font-semibold leading-4 text-accent-foreground ring-2 ring-background"
+								class="absolute -right-2 -top-1.5 min-w-3.5 rounded-full bg-accent px-[3px] text-[9px] font-semibold leading-[0.875rem] text-accent-foreground ring-[1.5px] ring-background"
 							>
 								{personal.saved.length}
 							</span>

--- a/ui/src/routes/library/+page.svelte
+++ b/ui/src/routes/library/+page.svelte
@@ -123,15 +123,25 @@
 				{#if personal.saved.length}
 					<Button
 						variant="outline"
-						size="sm"
-						class="gap-2"
+						size="icon-sm"
 						onclick={sync}
 						disabled={syncing}
-						title="Add everything saved on this device to YouTube Music"
-						aria-label="Sync saved items to YouTube Music"
+						title="Add the {personal.saved.length} saved on this device to YouTube Music"
+						aria-label="Sync {personal.saved.length} saved items to YouTube Music"
 					>
-						<HugeiconsIcon icon={CloudSyncIcon} class="h-4 w-4" />
-						{syncing ? 'Syncing…' : `Sync ${personal.saved.length} to YT Music`}
+						<span class="relative">
+							<HugeiconsIcon
+								icon={CloudSyncIcon}
+								strokeWidth={2.2}
+								class="h-4 w-4 {syncing ? 'animate-pulse' : ''}"
+							/>
+							<!-- ring-background so the count reads over the icon's stroke (as in Titlebar). -->
+							<span
+								class="absolute -right-2.5 -top-2 min-w-4 rounded-full bg-accent px-1 text-[10px] font-semibold leading-4 text-accent-foreground ring-2 ring-background"
+							>
+								{personal.saved.length}
+							</span>
+						</span>
 					</Button>
 				{/if}
 				<Button variant="outline" size="sm" class="gap-2" onclick={() => (dialogOpen = true)}>

--- a/ui/src/routes/library/+page.svelte
+++ b/ui/src/routes/library/+page.svelte
@@ -27,12 +27,14 @@
 	import type { BrowseItem } from '$lib/api';
 	import {
 		auth,
+		personal,
 		toast,
 		library,
 		loadLibrary,
 		loadLibraryExtras,
 		createLibraryPlaylist
 	} from '$lib/player.svelte';
+	import { mergeSaved } from '$lib/personal';
 
 	let dialogOpen = $state(false);
 	let newTitle = $state('');
@@ -45,14 +47,18 @@
 	});
 
 	// Everything here lives in the shared `library` store, so a revisit renders the cached grid
-	// immediately and the forced refresh below swaps in fresh data behind it.
-	const all = $derived([...library.items, ...library.albums, ...library.artists]);
+	// immediately and the forced refresh below swaps in fresh data behind it. What was saved on this
+	// machine merges in per tab (`mergeSaved`), which is the whole library when signed out.
+	const playlists = $derived(mergeSaved(personal, library.items, 'playlist'));
+	const albums = $derived(mergeSaved(personal, library.albums, 'album'));
+	const artists = $derived(mergeSaved(personal, library.artists, 'artist'));
+	const all = $derived([...playlists, ...albums, ...artists]);
 	const loading = $derived((library.loading || library.extrasLoading) && !all.length);
 	const error = $derived(library.error ?? library.extrasError);
+	// Only the empty states differ: signed out there is no account library to be missing yet.
+	const signedOut = $derived(!auth.account?.signedIn);
 
-	onMount(() => {
-		if (auth.account?.signedIn) load();
-	});
+	onMount(load);
 
 	function load() {
 		loadLibrary(true);
@@ -151,11 +157,6 @@
 		<Tabs.Content value="local">{#if tab === 'local'}<LocalMusic />{/if}</Tabs.Content>
 		{#if tab === 'local'}
 			<!-- nothing else: the YouTube states below have no bearing on files on this disk -->
-		{:else if !auth.account?.signedIn}
-			<p class="text-sm text-muted-foreground">
-				Sign in to see your playlists and liked songs, or open the Local tab for music on this
-				device.
-			</p>
 		{:else if loading}
 			<div class="card-grid">
 				{#each Array(12) as _, i (i)}
@@ -168,24 +169,35 @@
 			<ErrorState message={error} onRetry={load} />
 		{:else}
 			<Tabs.Content value="all">
-				{#if tab === 'all'}{@render grid(all, 'Your library is empty.')}{/if}
+				{#if tab === 'all'}
+					{@render grid(
+						all,
+						signedOut
+							? 'Nothing saved yet. Open a playlist or album and hit Save to library, or sign in for the one on your account.'
+							: 'Your library is empty.'
+					)}
+				{/if}
 			</Tabs.Content>
 			<Tabs.Content value="playlists">
-				{#if tab === 'playlists'}{@render grid(library.items, 'No playlists yet.')}{/if}
+				{#if tab === 'playlists'}
+					{@render grid(
+						playlists,
+						'No playlists yet. Open one and hit Save to library to keep it here.'
+					)}
+				{/if}
 			</Tabs.Content>
 			<Tabs.Content value="albums">
 				{#if tab === 'albums'}
-					{@render grid(
-						library.albums,
-						'No saved albums yet. Open an album and hit Save to library.'
-					)}
+					{@render grid(albums, 'No saved albums yet. Open an album and hit Save to library.')}
 				{/if}
 			</Tabs.Content>
 			<Tabs.Content value="artists">
 				{#if tab === 'artists'}
 					{@render grid(
-						library.artists,
-						'No artists yet. They show up once you save their songs or albums.'
+						artists,
+						signedOut
+							? 'No artists yet. Save one from its page to keep it here.'
+							: 'No artists yet. They show up once you save their songs or albums.'
 					)}
 				{/if}
 			</Tabs.Content>

--- a/ui/src/routes/library/+page.svelte
+++ b/ui/src/routes/library/+page.svelte
@@ -21,6 +21,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Tabs from '$lib/components/ui/tabs';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import LocalMusic from '$lib/components/LocalMusic.svelte';
 	import MediaCard from '$lib/components/MediaCard.svelte';
 	import MediaCardSkeleton from '$lib/components/MediaCardSkeleton.svelte';
@@ -121,24 +122,45 @@
 				<!-- Only with something to push: saves made before signing in, which live on this
 				     machine until this button puts them on the account. -->
 				{#if personal.saved.length}
-					<Button
-						variant="outline"
-						size="icon-sm"
-						onclick={sync}
-						disabled={syncing}
-						title="Add the {personal.saved.length} saved on this device to YouTube Music"
-						aria-label="Sync {personal.saved.length} saved items to YouTube Music"
-					>
-						<span class="relative">
-							<HugeiconsIcon icon={CloudSyncIcon} class="h-4 w-4 {syncing ? 'animate-pulse' : ''}" />
-							<!-- ring-background so the count reads over the icon's stroke (as in Titlebar). -->
-							<span
-								class="absolute -right-2 -top-1.5 min-w-3.5 rounded-full bg-accent px-[3px] text-[9px] font-semibold leading-[0.875rem] text-accent-foreground ring-[1.5px] ring-background"
-							>
-								{personal.saved.length}
-							</span>
-						</span>
-					</Button>
+					<!-- A cloud glyph with a number on it says nothing about what pressing it does, and
+					     that's a write to someone's YouTube account. Hence a real tooltip rather than the
+					     `title` this app uses elsewhere: it has to be read before the click, not after a
+					     second of hovering. `child` keeps our own Button as the trigger element. -->
+					<Tooltip.Provider delayDuration={150}>
+						<Tooltip.Root>
+							<Tooltip.Trigger>
+								{#snippet child({ props })}
+									<Button
+										{...props}
+										variant="outline"
+										size="icon-sm"
+										onclick={sync}
+										disabled={syncing}
+										aria-label="Sync {personal.saved.length} saved items to YouTube Music"
+									>
+										<span class="relative">
+											<HugeiconsIcon
+												icon={CloudSyncIcon}
+												class="h-4 w-4 {syncing ? 'animate-pulse' : ''}"
+											/>
+											<!-- ring-background so the count reads over the icon's stroke (as in
+											     Titlebar). -->
+											<span
+												class="absolute -right-2 -top-1.5 min-w-3.5 rounded-full bg-accent px-[3px] text-[9px] font-semibold leading-[0.875rem] text-accent-foreground ring-[1.5px] ring-background"
+											>
+												{personal.saved.length}
+											</span>
+										</span>
+									</Button>
+								{/snippet}
+							</Tooltip.Trigger>
+							<Tooltip.Content side="bottom">
+								{syncing
+									? 'Adding them to YouTube Music…'
+									: `Add the ${personal.saved.length} saved on this device to your YouTube Music library`}
+							</Tooltip.Content>
+						</Tooltip.Root>
+					</Tooltip.Provider>
 				{/if}
 				<Button variant="outline" size="sm" class="gap-2" onclick={() => (dialogOpen = true)}>
 					<HugeiconsIcon icon={Add01Icon} class="h-4 w-4" /> New playlist

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -14,6 +14,8 @@
 		ArrowUpNarrowWideIcon,
 		ArrowDownWideNarrowIcon,
 		DashboardSquare02Icon,
+		BookmarkAdd02Icon,
+		BookmarkMinus02Icon,
 		ListRestartIcon,
 		Sorting01Icon,
 		ArrowUpDownIcon
@@ -36,11 +38,13 @@
 	import {
 		addPick,
 		enqueue,
+		isSaved,
 		playback,
 		openAddToPlaylist,
 		playFrom,
 		startRadio,
 		toast,
+		toggleSaved,
 		bumpLibraryTrackCount,
 		lastPlaylistAdd
 	} from '$lib/player.svelte';
@@ -76,6 +80,11 @@
 	// Only offer rename/delete on playlists the signed-in user actually owns (backend `owned` flag).
 	// Liked Music reports owned but can't be renamed/deleted, so exclude it explicitly.
 	const editable = $derived((pl?.owned ?? false) && !isLiked);
+	// Saving someone else's playlist keeps it on this machine, signed in or not: YouTube has no
+	// "save" for a playlist that doesn't cost an account, and the local one works offline. Your own
+	// playlists, Liked Music and On Repeat are in the library already by definition.
+	const savable = $derived(!isOnRepeat && !isLiked && !editable);
+	const savedHere = $derived(isSaved(id));
 	// YouTube's header count includes rows that never make it into the list (unavailable or
 	// region-blocked tracks), so it reads high. Once every page is in, we know the real number, so
 	// swap it in. Until then the header's own count is the only estimate of the total there is.
@@ -765,6 +774,26 @@
 		>
 			<HugeiconsIcon icon={DashboardSquare02Icon} class="h-4 w-4" /> Add to shortcuts
 		</button>
+		{#if savable}
+			<button
+				class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
+				onclick={() =>
+					run(() =>
+						toast.success(
+							toggleSaved(asItem()) ? 'Saved to library' : 'Removed from library'
+						)
+					)}
+			>
+				<!-- altIcon/showAlt, not a ternary: `icon` is read once at mount. -->
+				<HugeiconsIcon
+					icon={BookmarkAdd02Icon}
+					altIcon={BookmarkMinus02Icon}
+					showAlt={savedHere}
+					class="h-4 w-4"
+				/>
+				{savedHere ? 'Remove from library' : 'Save to library'}
+			</button>
+		{/if}
 		{#if editable}
 			<button
 				class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"


### PR DESCRIPTION
Closes #38, which asked for a way to save albums to the library without signing
into Google, the way Metrolist does it.

Saving to the library was a YouTube write action, so a signed-out user got a
Library page that offered nothing but a sign-in prompt. Playlists, albums and
artists can now be saved without an account, and a sync button pushes them up
once you do sign in.

Based on #37, so the diff shows only the library commits until that one merges.

Notes:

- Saves live in the `personal` localStorage blob that already holds the
  Shortcuts grid and sidebar pins, not a new SQLite table: nothing outside the
  webview reads them, and the store already named that as its job. `personal.ts`
  gains `toggleSaved` / `isSaved` / `mergeSaved`, all covered in
  `personal.check.ts`.
- Nothing is account-scoped, so what you save before signing in is still there
  afterwards. `mergeSaved` puts local saves ahead of the account's own per kind
  and dedupes by browseId: a library card and a search card come out of the same
  parser, so an album is one `MPRE…` either way.
- The album page's Save button lost its sign-in gate and now reads
  `youtube || local`, so a local save can't sit in the library grid while its own
  page offers to save it again. The playlist ⋯ menu gained one, the artist page's
  Subscribe becomes "Save to library" when signed out instead of a button that
  can only fail, and any locally saved card can be removed from its ⋯ menu.
- Rust is three guards: `get_library` skips the YouTube fetch when logged out,
  and the album/artist library commands answer empty. That also puts On Repeat
  and the Library page in front of signed-out users for the first time, which the
  sign-in gate had been hiding.
- The sync button (Library header, left of New playlist, with a count badge and
  the app's first real tooltip) pushes each saved card to the account and then
  drops the local row. Duplicate guards differ per kind: albums against a freshly
  fetched `AlbumPage.inLibrary`, and liked through their `OLAK5uy_` audio
  playlist, which is why each one costs a browse; playlists against a forced
  library refresh; artists not at all, because subscribing twice is one
  subscription and the library's artist grid is a corpus list rather than a
  subscription list. Synced cards are moved into the library store rather than
  refetched, since `FEmusic_liked_albums` won't list a just-liked album for a few
  seconds. Anything that fails stays local and the button retries exactly that.
- One way and on demand: nothing syncs back down, and nothing runs by itself.
  Saving a playlist stays local even when signed in, since the sync button is the
  tested way up.

`cargo test -p limusic-app --lib` (97), `personal.check.ts` and `pnpm check` all
pass. Not yet clicked through in `cargo tauri dev`.
