### PR TITLE
perf: cut avoidable work in queue IPC, playlist sorting and card grids

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -175,9 +175,9 @@ pub async fn get_queue(state: St<'_>) -> Result<serde_json::Value, String> {
 
 /// Settings the UI is allowed to read *and write*. Session/auth material (`session_cookie`,
 /// `selected_identity_json`, `data_sync_id`, `account_json`, `account_selection_pending`,
-/// `visitor_data`) and internal blobs (`queue_json`, `queue_position`) never cross into the webview
-/// — they'd otherwise ship the login credential to the renderer on every open — and the webview
-/// can't overwrite them either.
+/// `visitor_data`) and internal blobs (`queue_json`, `queue_index`, `queue_position`) never cross
+/// into the webview: they'd otherwise ship the login credential to the renderer on every open, and
+/// the webview can't overwrite them either.
 const UI_SETTINGS: [&str; 13] = [
     "volume",
     "proxy",

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -71,7 +71,7 @@ pub struct AppState {
     /// a Tauri event inlines its payload into a JavaScript source string, so a 5,000-track queue
     /// costs ~26 ms of parse in the webview every time it crosses.
     last_queue_fingerprint: AtomicU64,
-    /// Fingerprint of the item list last written to `queue_json`. Same trick as
+    /// Dirty key (`persist_fingerprint`) last written to `queue_json`. Same trick as
     /// `last_queue_fingerprint`, for the persistence side: an advance rewrites 40 bytes rather
     /// than the whole blob.
     last_persisted_fingerprint: AtomicU64,
@@ -1893,8 +1893,9 @@ impl AppState {
                 "fp": fingerprint.to_string(),
             })
             .to_string();
+            let persist_fp = persist_fingerprint(&q);
             let changed =
-                self.last_persisted_fingerprint.swap(fingerprint, Ordering::Relaxed) != fingerprint;
+                self.last_persisted_fingerprint.swap(persist_fp, Ordering::Relaxed) != persist_fp;
             let blob = changed.then(|| {
                 serde_json::json!({
                     "items": &q.items,
@@ -3040,16 +3041,41 @@ fn loudness_gain(loudness_db: Option<f64>) -> Option<f64> {
 const TARGET_LUFS: f64 = -7.0;
 
 /// Fingerprint of a queue's track list: what `emit_queue` compares to decide whether the UI
-/// already has these rows. Video ids and length only, which is exactly what identifies a row for
-/// the panel (`queue.ts` keys on videoId plus occurrence). A metadata backfill on an existing row
-/// deliberately does not change it: the row it repairs is the playing one, and that one rides
-/// along on the index event.
+/// already has these rows. Hashes length, `video_id`, and every field the panel renders
+/// differently per row (`set_video_id`, `queued`, `queued_end`, `queued_from`, `queued_by`,
+/// `autoplay`): two rows identical in all of those are interchangeable in the panel, so staying
+/// quiet about a swap between them is correct. Deliberately excludes `duration`, `artists`,
+/// `title`, `thumbnail` and `rating`: those are exactly the fields `backfill_metadata` repairs on
+/// the playing row, and that repair rides along on the `queue-index` event's `current` field on
+/// purpose. Hashing them would send the whole queue on every track start and undo the point of
+/// that split.
 fn queue_fingerprint(items: &[SongItem]) -> u64 {
     let mut hasher = DefaultHasher::new();
     items.len().hash(&mut hasher);
     for item in items {
         item.video_id.hash(&mut hasher);
+        item.set_video_id.hash(&mut hasher);
+        item.queued.hash(&mut hasher);
+        item.queued_end.hash(&mut hasher);
+        item.queued_from.hash(&mut hasher);
+        item.queued_by.hash(&mut hasher);
+        item.autoplay.hash(&mut hasher);
     }
+    hasher.finish()
+}
+
+/// Dirty key for `queue_json`, which stores more than the rows. `queue_index` carries
+/// current/playedFrom/repeat, so anything else the blob holds has to force a blob rewrite by
+/// itself. `shuffle_upcoming` only touches rows after `current`, so toggling shuffle while the
+/// last track plays leaves `items` byte-identical and the row fingerprint alone would skip the
+/// write, losing the shuffle state across a restart.
+fn persist_fingerprint(q: &QueueState) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    queue_fingerprint(&q.items).hash(&mut hasher);
+    q.shuffle_orig.is_some().hash(&mut hasher);
+    q.radio_seed.hash(&mut hasher);
+    q.source_name.hash(&mut hasher);
+    q.radio.hash(&mut hasher);
     hasher.finish()
 }
 
@@ -3058,8 +3084,8 @@ mod tests {
     use super::{
         append_page, backfill_metadata, drop_duplicates, enqueue_at, format_duration,
         guest_insert_index, is_mix, loudness_gain, merge_radio, next_index, parse_duration_ms,
-        queue_fingerprint, radio_seed_for, shuffle_new_queue, shuffle_upcoming, splice_radio_into,
-        unshuffled, upcoming_queued, QueueState, RepeatMode,
+        persist_fingerprint, queue_fingerprint, radio_seed_for, shuffle_new_queue,
+        shuffle_upcoming, splice_radio_into, unshuffled, upcoming_queued, QueueState, RepeatMode,
     };
 
     #[test]
@@ -3086,6 +3112,51 @@ mod tests {
             queue_fingerprint(&a).to_string(),
             queue_fingerprint(&[row("a"), row("b")]).to_string()
         );
+    }
+
+    // `move_in_queue` can drag one occurrence of a repeated videoId past the other (a track queued
+    // twice from two different playlists, say). The panel tells the two rows apart by the fields
+    // that differ between them, not by videoId alone, so the fingerprint has to as well: otherwise
+    // the swap is invisible, `emit_queue` stays on the small `queue-index` event, and the drag
+    // looks like it did nothing.
+    #[test]
+    fn queue_fingerprint_distinguishes_same_video_id_rows_by_queue_metadata() {
+        let row = |queued_from: Option<&str>| innertube::SongItem {
+            video_id: "x".into(),
+            queued_from: queued_from.map(Into::into),
+            ..Default::default()
+        };
+        let a = vec![row(Some("Chill Mix")), row(None)];
+        let b = vec![row(None), row(Some("Chill Mix"))];
+        assert_ne!(queue_fingerprint(&a), queue_fingerprint(&b));
+
+        // Same story for `set_video_id`, the other field that tells apart two occurrences of the
+        // same videoId (one came from a playlist page, so it carries a playlistSetVideoId; a
+        // second copy queued manually doesn't).
+        let row2 = |set_video_id: Option<&str>| innertube::SongItem {
+            video_id: "x".into(),
+            set_video_id: set_video_id.map(Into::into),
+            ..Default::default()
+        };
+        let c = vec![row2(Some("1")), row2(Some("2"))];
+        let d = vec![row2(Some("2")), row2(Some("1"))];
+        assert_ne!(queue_fingerprint(&c), queue_fingerprint(&d));
+    }
+
+    // `shuffle_upcoming` only reorders rows after `current`, so toggling shuffle while the last
+    // track is playing leaves `items` byte-identical: the rows-only `queue_fingerprint` can't see
+    // it, and `persist_queue`'s dirty check has to cover the rest of what `queue_json` stores or
+    // the toggle is lost across a restart.
+    #[test]
+    fn persist_fingerprint_changes_when_shuffle_toggles_with_identical_items() {
+        let mut q = QueueState {
+            items: vec![innertube::SongItem { video_id: "a".into(), ..Default::default() }],
+            ..QueueState::default()
+        };
+        let off = persist_fingerprint(&q);
+        q.shuffle_orig = Some(q.items.clone());
+        let on = persist_fingerprint(&q);
+        assert_ne!(off, on);
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -66,6 +66,15 @@ pub struct AppState {
     last_pos_persist: AtomicU64,
     /// Wall-clock secs of the last position push to the OS media controls (throttled ~1s).
     last_media_push: AtomicU64,
+    /// Fingerprint of the item list the UI was last sent (see `queue_fingerprint`). When it is
+    /// unchanged, `emit_queue` sends the small `queue-index` event instead of megabytes of JSON:
+    /// a Tauri event inlines its payload into a JavaScript source string, so a 5,000-track queue
+    /// costs ~26 ms of parse in the webview every time it crosses.
+    last_queue_fingerprint: AtomicU64,
+    /// Fingerprint of the item list last written to `queue_json`. Same trick as
+    /// `last_queue_fingerprint`, for the persistence side: an advance rewrites 40 bytes rather
+    /// than the whole blob.
+    last_persisted_fingerprint: AtomicU64,
 }
 
 /// Repeat mode for the queue. Serialized lowercase for the UI + `queue_json`.
@@ -319,6 +328,8 @@ impl AppState {
             latest_position: AtomicU64::new(0),
             last_pos_persist: AtomicU64::new(0),
             last_media_push: AtomicU64::new(0),
+            last_queue_fingerprint: AtomicU64::new(0),
+            last_persisted_fingerprint: AtomicU64::new(0),
         }
     }
 
@@ -1031,6 +1042,11 @@ impl AppState {
         const MAX_PAGES: usize = 50;
         let Some(client) = self.clients.get(innertube::METADATA_CLIENT) else { return };
         let mut pages = 0;
+        // The first page goes out at once so the panel visibly starts filling; after that the
+        // walk emits at most once a second. Every page is a *full* payload (the rows changed),
+        // and a 50-page walk of a 5,000-track playlist sends ~67 MB of JSON through
+        // `webview.eval` if each one is announced. The final state is emitted after the loop.
+        let mut last_emit: Option<std::time::Instant> = None;
         for _ in 0..MAX_PAGES {
             let page = match self.it.playlist_continuation(client, &token).await {
                 Ok(page) => page,
@@ -1069,7 +1085,10 @@ impl AppState {
                 }
             }
             pages += 1;
-            self.emit_queue().await;
+            if last_emit.is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(1)) {
+                last_emit = Some(std::time::Instant::now());
+                self.emit_queue().await;
+            }
             self.prime_lookahead(gen).await;
             match page.continuation {
                 Some(next) => token = next,
@@ -1080,6 +1099,7 @@ impl AppState {
         // nothing else reads it mid-walk.
         if pages > 0 {
             tracing::info!(pages, "playlist fill appended pages");
+            self.emit_queue().await; // whatever the throttle above held back
             self.persist_queue().await;
             self.lt_broadcast_queue().await;
         }
@@ -1632,10 +1652,31 @@ impl AppState {
         self.play_index(i).await;
     }
 
+    /// Tell the UI the queue changed.
+    ///
+    /// A Tauri event is delivered by inlining its JSON into a JavaScript source string and
+    /// `eval`ing it in every listening webview, so the payload is *parsed as source*: 2.6 MB and
+    /// ~26 ms for a 5,000-track queue, twice over with the mini player open. The play pointer
+    /// moving is by far the most common reason this is called and it does not need the rows at
+    /// all, so when the track list is unchanged this sends a few hundred bytes instead. The UI
+    /// keeps the array it already holds (`player.svelte.ts`, `onQueueIndex`).
     async fn emit_queue(&self) {
         let q = self.queue.lock().await;
-        let _ = self.app.emit(
-            "queue-changed",
+        let fingerprint = queue_fingerprint(&q.items);
+        let unchanged =
+            self.last_queue_fingerprint.swap(fingerprint, Ordering::Relaxed) == fingerprint;
+        let payload = if unchanged {
+            serde_json::json!({
+                "currentIndex": q.current,
+                "playedFrom": q.played_from,
+                "shuffle": q.shuffle_orig.is_some(),
+                "repeat": q.repeat,
+                "sourceName": &q.source_name,
+                // The playing row, so `start_current`'s duration/artists backfill still reaches
+                // the panel without shipping the other 4,999 rows to carry it.
+                "current": q.items.get(q.current),
+            })
+        } else {
             serde_json::json!({
                 "items": &q.items,
                 "currentIndex": q.current,
@@ -1643,8 +1684,9 @@ impl AppState {
                 "shuffle": q.shuffle_orig.is_some(),
                 "repeat": q.repeat,
                 "sourceName": &q.source_name,
-            }),
-        );
+            })
+        };
+        let _ = self.app.emit(if unchanged { "queue-index" } else { "queue-changed" }, payload);
     }
 
     fn emit_error(&self, video_id: &str, message: &str) {
@@ -1827,24 +1869,51 @@ impl AppState {
         added
     }
 
-    /// Persist the queue (items + current index) as a JSON blob so a restart can restore it
-    /// losslessly (context/11 §state). Called whenever the queue changes or advances.
+    /// Persist the queue so a restart can restore it losslessly (context/11 §state). Called
+    /// whenever the queue changes or advances.
+    ///
+    /// The blob is 526 bytes per track (measured), so a 5,000-track queue is a ~2.6 MB
+    /// synchronous write, and the advance path calls this on every single track. On an advance
+    /// the rows are identical and only the pointer moved, so that case writes ~40 bytes to
+    /// `queue_index` instead. `queue_index` is written every time, blob or not, and carries the
+    /// fingerprint of the rows it was true for, so `restore_queue` can tell a fresher pointer from
+    /// one left over from a different item list.
     async fn persist_queue(&self) {
-        let json = {
+        let (index_json, blob) = {
             let q = self.queue.lock().await;
-            serde_json::json!({
-                "items": &q.items,
+            let fingerprint = queue_fingerprint(&q.items);
+            let index_json = serde_json::json!({
                 "current": q.current,
                 "playedFrom": q.played_from,
                 "repeat": q.repeat,
-                "shuffleOrig": &q.shuffle_orig,
-                "radioSeed": &q.radio_seed,
-                "sourceName": &q.source_name,
-                "radio": q.radio,
+                // Which item list these numbers were true for. `queue_json` and `queue_index` are
+                // two separate writes, so a kill between them, or two `persist_queue` calls
+                // landing out of order, can pair a pointer with rows it was never valid for.
+                // `restore_queue` checks this before trusting any of it.
+                "fp": fingerprint.to_string(),
             })
-            .to_string()
+            .to_string();
+            let changed =
+                self.last_persisted_fingerprint.swap(fingerprint, Ordering::Relaxed) != fingerprint;
+            let blob = changed.then(|| {
+                serde_json::json!({
+                    "items": &q.items,
+                    "current": q.current,
+                    "playedFrom": q.played_from,
+                    "repeat": q.repeat,
+                    "shuffleOrig": &q.shuffle_orig,
+                    "radioSeed": &q.radio_seed,
+                    "sourceName": &q.source_name,
+                    "radio": q.radio,
+                })
+                .to_string()
+            });
+            (index_json, blob)
         };
-        self.db.set_setting("queue_json", &json);
+        if let Some(blob) = blob {
+            self.db.set_setting("queue_json", &blob);
+        }
+        self.db.set_setting("queue_index", &index_json);
     }
 
     /// Restore the last session's queue on startup — paused, not autoplaying (context/11). The
@@ -1860,15 +1929,15 @@ impl AppState {
         if items.is_empty() {
             return;
         }
-        let current = (saved.get("current").and_then(|v| v.as_u64()).unwrap_or(0) as usize)
+        let mut current = (saved.get("current").and_then(|v| v.as_u64()).unwrap_or(0) as usize)
             .min(items.len() - 1);
         // Absent in blobs written before "Previously played" existed: those restore with an empty
         // played run rather than claiming the whole prefix was heard.
-        let played_from =
+        let mut played_from =
             (saved.get("playedFrom").and_then(|v| v.as_u64()).unwrap_or(current as u64) as usize)
                 .min(current);
         // Shuffle/repeat ride the same blob; read tolerantly — old blobs lack them.
-        let repeat: RepeatMode = saved
+        let mut repeat: RepeatMode = saved
             .get("repeat")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or_default();
@@ -1879,6 +1948,34 @@ impl AppState {
         let source_name: Option<String> =
             saved.get("sourceName").and_then(|v| v.as_str()).map(str::to_owned);
         let radio = saved.get("radio").and_then(|v| v.as_bool()).unwrap_or(false);
+        // `queue_index` is rewritten on every persist while `queue_json` is only rewritten when
+        // the rows change, so on an advance it is the fresher of the two. But the two are separate
+        // writes: a kill between them, or two `persist_queue` calls landing out of order (a
+        // background playlist fill racing a track advance), can leave a `queue_index` on disk that
+        // was computed against a different item list than the one in `queue_json` now. Trusting it
+        // blindly would pair a pointer with rows it was never valid for and `.min(items.len() - 1)`
+        // would turn that into a plausible-looking wrong track instead of anything visible. The
+        // `fp` stamp is what the index was true for; only apply it when it still matches what we
+        // just parsed. A mismatch (or a database written before the stamp existed) falls back to
+        // the blob's own current/playedFrom/repeat, which is exactly today's behaviour.
+        let items_fp = queue_fingerprint(&items).to_string();
+        if let Some(idx) = self
+            .db
+            .get_setting("queue_index")
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .filter(|idx| idx.get("fp").and_then(|v| v.as_str()) == Some(items_fp.as_str()))
+        {
+            if let Some(c) = idx.get("current").and_then(|v| v.as_u64()) {
+                current = (c as usize).min(items.len() - 1);
+            }
+            if let Some(p) = idx.get("playedFrom").and_then(|v| v.as_u64()) {
+                played_from = (p as usize).min(current);
+            }
+            if let Some(r) = idx.get("repeat").and_then(|v| serde_json::from_value(v.clone()).ok())
+            {
+                repeat = r;
+            }
+        }
         let pos = self.db.get_setting("queue_position").and_then(|s| s.parse::<f64>().ok());
         if let Some(p) = pos.filter(|p| *p > 0.0) {
             *self.pending_seek.lock().unwrap() = Some((items[current].video_id.clone(), p));
@@ -2942,14 +3039,54 @@ fn loudness_gain(loudness_db: Option<f64>) -> Option<f64> {
 /// Loudness target, matching YouTube Music's own player rather than the video site's -14.
 const TARGET_LUFS: f64 = -7.0;
 
+/// Fingerprint of a queue's track list: what `emit_queue` compares to decide whether the UI
+/// already has these rows. Video ids and length only, which is exactly what identifies a row for
+/// the panel (`queue.ts` keys on videoId plus occurrence). A metadata backfill on an existing row
+/// deliberately does not change it: the row it repairs is the playing one, and that one rides
+/// along on the index event.
+fn queue_fingerprint(items: &[SongItem]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    items.len().hash(&mut hasher);
+    for item in items {
+        item.video_id.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         append_page, backfill_metadata, drop_duplicates, enqueue_at, format_duration,
         guest_insert_index, is_mix, loudness_gain, merge_radio, next_index, parse_duration_ms,
-        radio_seed_for, shuffle_new_queue, shuffle_upcoming, splice_radio_into, unshuffled,
-        upcoming_queued, QueueState, RepeatMode,
+        queue_fingerprint, radio_seed_for, shuffle_new_queue, shuffle_upcoming, splice_radio_into,
+        unshuffled, upcoming_queued, QueueState, RepeatMode,
     };
+
+    #[test]
+    fn queue_fingerprint_tracks_the_rows_not_their_metadata() {
+        let row = |id: &str| innertube::SongItem { video_id: id.into(), ..Default::default() };
+        let a = vec![row("a"), row("b"), row("c")];
+        // Same rows in the same order: the UI already has them.
+        assert_eq!(queue_fingerprint(&a), queue_fingerprint(&[row("a"), row("b"), row("c")]));
+        // A reorder, an append and a removal all have to be visible.
+        assert_ne!(queue_fingerprint(&a), queue_fingerprint(&[row("a"), row("c"), row("b")]));
+        assert_ne!(queue_fingerprint(&a), queue_fingerprint(&[row("a"), row("b")]));
+        assert_ne!(
+            queue_fingerprint(&a),
+            queue_fingerprint(&[row("a"), row("b"), row("c"), row("d")])
+        );
+        // A metadata repair on an existing row does not: it rides on the index event instead.
+        let mut patched = a.clone();
+        patched[0].duration = Some("3:11".into());
+        assert_eq!(queue_fingerprint(&a), queue_fingerprint(&patched));
+        // `restore_queue` compares these as strings off disk, not as numbers, so the string form
+        // has to discriminate as well as the hash does: a stamp that matched everything would
+        // silently re-open the wrong-track gap the stamp exists to close.
+        assert_ne!(
+            queue_fingerprint(&a).to_string(),
+            queue_fingerprint(&[row("a"), row("b")]).to_string()
+        );
+    }
 
     #[test]
     fn durations_round_trip_past_an_hour() {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -412,6 +412,23 @@ export const onNowPlaying = (cb: (n: NowPlaying) => void): Promise<UnlistenFn> =
 	listen<NowPlaying>('now-playing', (e) => cb(e.payload));
 export const onQueueChanged = (cb: (q: QueueState) => void): Promise<UnlistenFn> =>
 	listen<QueueState>('queue-changed', (e) => cb(e.payload));
+/**
+ * The queue moved but its track list did not: only the play pointer and the flags changed.
+ * Emitted instead of `queue-changed` on every advance and skip, because the full item list is
+ * megabytes on a big playlist and a Tauri event delivers its payload as JavaScript *source*.
+ * `current` carries the playing row so a metadata backfill (duration, artists) still lands.
+ */
+export interface QueueIndex {
+	currentIndex: number;
+	playedFrom?: number;
+	shuffle?: boolean;
+	repeat?: RepeatMode;
+	sourceName?: string | null;
+	current: SongItem | null;
+}
+
+export const onQueueIndex = (cb: (q: QueueIndex) => void): Promise<UnlistenFn> =>
+	listen<QueueIndex>('queue-index', (e) => cb(e.payload));
 export const onPosition = (cb: (p: number) => void): Promise<UnlistenFn> =>
 	listen<{ position: number }>('position', (e) => cb(e.payload.position));
 export const onDuration = (cb: (d: number) => void): Promise<UnlistenFn> =>

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -660,6 +660,22 @@ export function initApp(mini = false): () => void {
 			savePersonal();
 		}),
 		api.onQueueChanged((q) => (playback.queue = q)),
+		// The items did not change, so keep the array we already hold and patch the rest. Splice
+		// the playing row back in: `start_current` backfills its duration and artists after the
+		// stream resolves, and that repair rides on this event rather than a whole new queue.
+		api.onQueueIndex((q) => {
+			const items = playback.queue.items;
+			if (q.current && items[q.currentIndex]) items[q.currentIndex] = q.current;
+			playback.queue = {
+				...playback.queue,
+				items,
+				currentIndex: q.currentIndex,
+				playedFrom: q.playedFrom,
+				shuffle: q.shuffle,
+				repeat: q.repeat,
+				sourceName: q.sourceName
+			};
+		}),
 		api.onPosition((p) => (playback.position = p)),
 		api.onDuration((d) => (playback.duration = d)),
 		api.onPlaybackState((s) => (playback.paused = s === 'paused')),

--- a/ui/src/lib/reveal.svelte.ts
+++ b/ui/src/lib/reveal.svelte.ts
@@ -1,0 +1,48 @@
+// Chunked reveal for open-ended card grids.
+//
+// `.card-grid` already sets `content-visibility: auto`, so a card the user has not scrolled to
+// costs no layout and no paint. What it still costs is the mount: a `MediaCard` carries a menu
+// component with several deriveds of its own, and a large library builds every one of them in one
+// synchronous pass on the tab click. So render a chunk, and reveal the next when a sentinel below
+// the grid comes into range. Same shape as the playlist page's continuation sentinel, minus the
+// network.
+//
+// Below `MIN_TO_CHUNK` nothing is held back: a grid you can see the end of gains nothing from this
+// and a sentinel is one more observer for no reason. Same call the queue panel makes
+// (`QueueList.svelte`, WINDOW_ABOVE).
+
+/** Grids at or below this render whole, exactly as they always did. */
+const MIN_TO_CHUNK = 200;
+/** How many more cards each approach to the bottom reveals. */
+const CHUNK = 120;
+
+export function reveal() {
+	let shown = $state(CHUNK);
+
+	return {
+		/** How many cards to render. Pass the full list's length. */
+		count(total: number): number {
+			return total <= MIN_TO_CHUNK ? total : Math.min(shown, total);
+		},
+		/** True when a sentinel is worth rendering under the grid. */
+		more(total: number): boolean {
+			return total > MIN_TO_CHUNK && shown < total;
+		},
+		/** Back to one chunk: a different list, or a different tab, starts over. */
+		reset() {
+			shown = CHUNK;
+		},
+		/**
+		 * Sentinel attachment. The observer only fires on *entering* view, so the chunk it reveals
+		 * has to push it back out before the next one can be asked for. rootMargin starts the
+		 * reveal early enough that the cards are usually there by the time you reach them.
+		 */
+		sentinel(node: HTMLElement) {
+			const io = new IntersectionObserver(([e]) => e.isIntersecting && (shown += CHUNK), {
+				rootMargin: '600px 0px'
+			});
+			io.observe(node);
+			return () => io.disconnect();
+		}
+	};
+}

--- a/ui/src/routes/library/+page.svelte
+++ b/ui/src/routes/library/+page.svelte
@@ -38,6 +38,7 @@
 		syncSavedToYouTube
 	} from '$lib/player.svelte';
 	import { mergeSaved, unsynced } from '$lib/personal';
+	import { reveal } from '$lib/reveal.svelte';
 
 	let dialogOpen = $state(false);
 	let newTitle = $state('');
@@ -56,6 +57,14 @@
 	const albums = $derived(mergeSaved(personal, library.albums, 'album'));
 	const artists = $derived(mergeSaved(personal, library.artists, 'artist'));
 	const all = $derived([...playlists, ...albums, ...artists]);
+	// One per tab rather than one shared instance reset on switch: an `$effect` reset lands
+	// after the render it is meant to govern, so switching tabs would build the new tab's grid
+	// against the old tab's count and immediately tear the excess back down. A tab keeping its
+	// own depth also means coming back to one lands where you left it.
+	const rvAll = reveal();
+	const rvPlaylists = reveal();
+	const rvAlbums = reveal();
+	const rvArtists = reveal();
 	const loading = $derived((library.loading || library.extrasLoading) && !all.length);
 	const error = $derived(library.error ?? library.extrasError);
 	// Only the empty states differ: signed out there is no account library to be missing yet.
@@ -105,13 +114,15 @@
 	}
 </script>
 
-{#snippet grid(items: BrowseItem[], empty: string)}
+{#snippet grid(items: BrowseItem[], empty: string, rv: ReturnType<typeof reveal>)}
 	{#if items.length}
 		<div class="card-grid content-in">
-			{#each items as item (item.kind + item.id)}
+			{#each items.slice(0, rv.count(items.length)) as item (item.kind + item.id)}
 				<MediaCard {item} />
 			{/each}
 		</div>
+		<!-- Outside the grid, or it would be laid out as a cell. -->
+		{#if rv.more(items.length)}<div {@attach rv.sentinel}></div>{/if}
 	{:else}
 		<p class="text-sm text-muted-foreground">{empty}</p>
 	{/if}
@@ -242,7 +253,8 @@
 						all,
 						signedOut
 							? 'Nothing saved yet. Open a playlist or album and hit Save to library, or sign in for the one on your account.'
-							: 'Your library is empty.'
+							: 'Your library is empty.',
+						rvAll
 					)}
 				{/if}
 			</Tabs.Content>
@@ -250,13 +262,18 @@
 				{#if tab === 'playlists'}
 					{@render grid(
 						playlists,
-						'No playlists yet. Open one and hit Save to library to keep it here.'
+						'No playlists yet. Open one and hit Save to library to keep it here.',
+						rvPlaylists
 					)}
 				{/if}
 			</Tabs.Content>
 			<Tabs.Content value="albums">
 				{#if tab === 'albums'}
-					{@render grid(albums, 'No saved albums yet. Open an album and hit Save to library.')}
+					{@render grid(
+						albums,
+						'No saved albums yet. Open an album and hit Save to library.',
+						rvAlbums
+					)}
 				{/if}
 			</Tabs.Content>
 			<Tabs.Content value="artists">
@@ -265,7 +282,8 @@
 						artists,
 						signedOut
 							? 'No artists yet. Save one from its page to keep it here.'
-							: 'No artists yet. They show up once you save their songs or albums.'
+							: 'No artists yet. They show up once you save their songs or albums.',
+						rvArtists
 					)}
 				{/if}
 			</Tabs.Content>

--- a/ui/src/routes/list/+page.svelte
+++ b/ui/src/routes/list/+page.svelte
@@ -6,10 +6,14 @@
 	import * as api from '$lib/api';
 	import type { BrowseItem } from '$lib/api';
 	import { getCached, putCached } from '$lib/pagecache';
+	import { reveal } from '$lib/reveal.svelte';
 
 	let items = $state<BrowseItem[]>([]);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
+	// A browse grid is however many things YouTube sends; reveal it in chunks past a couple of
+	// hundred rather than mounting the lot when the page opens.
+	const rv = reveal();
 
 	const id = $derived(page.url.searchParams.get('id') ?? '');
 	const params = $derived(page.url.searchParams.get('params') ?? undefined);
@@ -20,16 +24,19 @@
 		const hit = getCached<BrowseItem[]>(key);
 		if (hit) {
 			items = hit;
+			rv.reset();
 			loading = false;
 		} else {
 			loading = true;
 			items = [];
+			rv.reset();
 		}
 		error = null;
 		try {
 			const fresh = await api.getBrowseGrid(browseId, p);
 			if (browseId !== id || p !== params) return; // superseded by navigation
 			items = fresh;
+			rv.reset();
 			putCached(key, fresh);
 		} catch (e) {
 			if (browseId !== id || p !== params) return;
@@ -56,10 +63,12 @@
 		<ErrorState message={error} onRetry={() => load(id, params)} />
 	{:else if items.length}
 		<div class="card-grid content-in">
-			{#each items as item (item.id + item.title)}
+			{#each items.slice(0, rv.count(items.length)) as item (item.id + item.title)}
 				<MediaCard {item} />
 			{/each}
 		</div>
+		<!-- Outside the grid, or it would be laid out as a cell. -->
+		{#if rv.more(items.length)}<div {@attach rv.sentinel}></div>{/if}
 	{:else}
 		<p class="text-sm text-muted-foreground">Nothing here.</p>
 	{/if}

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -59,7 +59,13 @@
 		lastPlaylistAdd
 	} from '$lib/player.svelte';
 
-	let pl = $state<PlaylistPage | null>(null);
+	// `$state.raw`, not `$state`: a deep proxy makes every read of a row go through a trap and
+	// create a signal, and this list runs to five figures. Measured at 5,000 rows, one filter pass
+	// is 0.6ms over a plain array and 6.4ms through the proxy, and both the filter box and a local
+	// sort do that pass on every keystroke and on every continuation page that lands. Raw is safe
+	// here because every write below reassigns the whole object (`pl = { ...pl, … }`); nothing
+	// mutates `pl` in place. Keep it that way, or the page stops updating.
+	let pl = $state.raw<PlaylistPage | null>(null);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let loadingMore = $state(false);
@@ -79,7 +85,28 @@
 	let nameDraft = $state('');
 
 	// Header filter box: matches title / artist / album over the rows loaded so far.
+	//
+	// Two values, not one. `query` is what the input holds, so typing never waits on anything.
+	// `applied` is what the list is actually narrowed by, and it lags by `FILTER_DEBOUNCE_MS`,
+	// because the two things a query sets off are both expensive: a pass over every loaded row
+	// (five figures on Liked Music), and `loadAll()`, which is up to 50 sequential requests for
+	// the pages a filter has to cover. Typing "beat" should not start that walk at "b".
+	const FILTER_DEBOUNCE_MS = 300;
 	let query = $state('');
+	let applied = $state('');
+	let filterTimer: ReturnType<typeof setTimeout> | undefined;
+	$effect(() => {
+		const q = query;
+		// Clearing the box is instant: there is nothing to compute and nothing to fetch, and a
+		// list that stays narrowed for a third of a second after you hit the ✕ reads as broken.
+		if (!q.trim()) {
+			clearTimeout(filterTimer);
+			applied = '';
+			return;
+		}
+		filterTimer = setTimeout(() => (applied = q), FILTER_DEBOUNCE_MS);
+		return () => clearTimeout(filterTimer);
+	});
 
 	const id = $derived(page.params.id ?? '');
 	const nowId = $derived(playback.now?.videoId);
@@ -155,8 +182,8 @@
 
 	// The rows actually on screen: the sorted list, narrowed by the header's filter box. Identical
 	// to `sortedItems` with no query typed.
-	const shown = $derived(filterTracks(sortedItems, query));
-	const filtering = $derived(!!query.trim());
+	const shown = $derived(filterTracks(sortedItems, applied));
+	const filtering = $derived(!!applied.trim());
 
 	// A sort has to cover the whole playlist, not the pages scrolled so far, so pull the rest in.
 	// Stops on a failed page (`moreError`), on navigation, and on any pass that made no progress.
@@ -322,6 +349,8 @@
 		editingName = false;
 		sortOpen = false;
 		query = '';
+		applied = '';
+		clearTimeout(filterTimer);
 		// A page that failed on the last playlist would otherwise keep this one's retry state
 		// showing, and block the filter's own walk (`loadAll` bails while it's set).
 		moreError = false;
@@ -813,7 +842,7 @@
 				</div>
 			{:else if filtering}
 				<p class="p-4 text-sm text-muted-foreground">
-					No tracks match “{query.trim()}”{pl.continuation && !moreError
+					No tracks match “{applied.trim()}”{pl.continuation && !moreError
 						? ' yet, still loading'
 						: ''}.
 				</p>

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -498,11 +498,25 @@
 	// back out of view, so the observer fires once and stops. Same walk a sort needs, for the same
 	// reason: the search has to cover the whole playlist, not the pages scrolled so far. The flag
 	// keeps one walk running rather than starting a fresh one on every page it lands.
-	let walking = false;
+	//
+	// Keyed on the playlist id rather than a bare boolean because this component is reused across
+	// playlist-to-playlist navigation (that's why `load` above is itself driven by an `$effect` on
+	// `id`, not a fresh mount). A walk started on playlist A can still be in flight when you
+	// navigate to B and filter there; a plain `walking` flag would still read true from A, block
+	// B's walk from ever starting, and then A's `finally` would clear a flag B never got to set,
+	// so B's filter would search only whatever it happened to have loaded and could wrongly show
+	// "No tracks match" with real matches still unfetched. Comparing against the current `id`
+	// means a different playlist is never blocked by someone else's walk, and capturing the id a
+	// walk started for (`pid`) into its own `finally` means a stale walk can only ever clear its
+	// own marker, never a fresher walk's.
+	let walkingFor: string | null = null;
 	$effect(() => {
-		if (!filtering || !pl?.continuation || walking) return;
-		walking = true;
-		loadAll().finally(() => (walking = false));
+		if (!filtering || !pl?.continuation || walkingFor === id) return;
+		const pid = id;
+		walkingFor = pid;
+		loadAll().finally(() => {
+			if (walkingFor === pid) walkingFor = null;
+		});
 	});
 
 	// This playlist as a card, for the sidebar's last-played sort and the Shortcuts grid.


### PR DESCRIPTION
Three independent performance changes. No behaviour changes intended.

## Queue events stopped shipping the whole queue on every advance (`ede6cf9`)

A Tauri event is delivered by inlining its JSON into a JavaScript source string and `eval`ing it in
every listening webview, so the payload is parsed as source rather than as JSON. Command results do
not take that path on Linux. The queue blob measures 526 bytes per track (from a real `queue_json`
row: 56,299 bytes for 107 tracks), which puts a 5,000-track queue at ~2.6 MB, crossing on every
track change, every skip, and once per continuation page while a long playlist walks in. With the
mini player open, twice over.

`emit_queue` now fingerprints the track list and sends a small `queue-index` event when only the
pointer moved, carrying the playing row so the metadata backfill still lands. The continuation walk
emits at most once a second instead of once per page. `persist_queue` got the same split, with the
index stamped with the fingerprint of the rows it was true for so `restore_queue` can reject a
pointer left over from a different item list.

## Playlist page holds its rows outside the reactive proxy (`4c03444`)

`$state` deeply proxies, so every read of a row went through a trap and created a signal, on a list
that runs to five figures. Every write here already reassigns the whole object, so `$state.raw` is a
drop-in. The filter box also started the continuation walk on the first keystroke; it now narrows by
a debounced copy of the query, so typing "beat" no longer starts that walk at "b". Clearing the box
stays instant.

## Large card grids reveal in chunks (`234b694`)

`.card-grid` already skips layout and paint offscreen, so what was left is mount cost: each card
carries a menu component, and a large account built all of them synchronously on the tab click.
Grids at or below 200 items render whole and behave exactly as before.

## Measurement provenance

The numbers above come from reading Tauri's event delivery path plus Node/V8 microbenchmarks
(2.6 MB as JS source 26.4 ms vs `JSON.parse` 10.4 ms; a 5,000-row filter pass 0.6 ms plain vs 6.4 ms
through a Svelte state proxy). They are not profiles of the running app on WebKitGTK, where
JavaScriptCore is slower at both, so treat them as floors rather than as the app's own figures.

## Verified

`cargo fmt --check`, `cargo test -p limusic-app` (98), `cargo test -p innertube` (60), `pnpm check`
(0 errors), and the four `*.check.ts` self-checks. Behaviour dev-verified by hand: queue restore
after quit, mini player, playlist filter and optimistic mutations, library tab switching and
scrolling a large grid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Large library, browse, and playlist grids now load progressively as you scroll, improving responsiveness.
  - Queue updates use lighter refreshes, reducing unnecessary loading during playback and playlist changes.
  - Playlist filling provides smoother updates while loading.

- **Playback**
  - Playback state, shuffle, repeat, source, and current-track details stay synchronized without refreshing the full queue.

- **Usability**
  - Playlist filtering responds immediately while applying results smoothly, with instant clearing and improved empty-result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->