### PR TITLE
feat(album): show other versions and related releases in the album page

### DIFF
--- a/crates/innertube/src/endpoints.rs
+++ b/crates/innertube/src/endpoints.rs
@@ -369,6 +369,13 @@ impl InnerTube {
                 }
             }
         }
+        for c in &mut page.sections {
+            self.drop_video_cards(&mut c.items);
+            // YouTube lists the album you are already on under "Other versions". A card that
+            // reopens the current page is noise, so drop it.
+            c.items.retain(|i| i.id != browse_id);
+        }
+        page.sections.retain(|c| !c.items.is_empty());
         Ok(page)
     }
 

--- a/crates/innertube/src/models/browse.rs
+++ b/crates/innertube/src/models/browse.rs
@@ -273,6 +273,10 @@ pub struct AlbumPage {
     pub playlist_id: Option<String>,
     /// Whether the album is already saved to the signed-in user's library.
     pub in_library: bool,
+    /// The card shelves YouTube ships under the track list: other versions of this release, more
+    /// from the artist, related albums. Same response as the tracks, so they cost no extra fetch.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sections: Vec<ArtistCarousel>,
 }
 
 /// Parse a `FEmusic_home` response into filter chips + titled carousel sections. context/08.
@@ -626,6 +630,12 @@ pub fn parse_album(root: &Value) -> AlbumPage {
         // Track rows carry the OLAK id; an album with no playable rows still has it on the
         // header's save-to-library button.
         playlist_id: album_playlist_id(root).or_else(|| library_toggle_playlist_id(header)),
+        // Whole-tree, not the section list: an album page splits into two columns and the shelves
+        // sit in the one the tracks don't.
+        sections: find_all(root, "musicCarouselShelfRenderer")
+            .into_iter()
+            .filter_map(parse_artist_carousel)
+            .collect(),
         in_library: library_toggle(header)
             .is_some_and(|t| t.get("isToggled").and_then(Value::as_bool).unwrap_or(false)),
     }
@@ -1451,9 +1461,14 @@ mod tests {
                         } }
                     ] } },
                     // "More from artist" carousel: a DIFFERENT album's OLAK id that must not win.
-                    { "musicCarouselShelfRenderer": { "contents": [
+                    { "musicCarouselShelfRenderer": {
+                      "header": { "musicCarouselShelfBasicHeaderRenderer": {
+                          "title": { "runs": [{ "text": "Other versions" }] }
+                      } },
+                      "contents": [
                         { "musicTwoRowItemRenderer": {
                             "title": { "runs": [{ "text": "Other Album" }] },
+                            "navigationEndpoint": { "browseEndpoint": { "browseId": "MPREother" } },
                             "thumbnailOverlay": { "musicItemThumbnailOverlayRenderer": { "content": {
                                 "musicPlayButtonRenderer": { "playNavigationEndpoint": {
                                     "watchPlaylistEndpoint": { "playlistId": "OLAK5uy_other" }
@@ -1485,6 +1500,12 @@ mod tests {
         // The album's own OLAK id from the track rows — never the carousel's other-album id.
         assert_eq!(a.playlist_id.as_deref(), Some("OLAK5uy_iceman"));
         assert!(!a.in_library); // no save button in this fixture
+
+        // The carousel becomes a shelf under the tracks; its card stays out of the track list.
+        assert_eq!(a.sections.len(), 1);
+        assert_eq!(a.sections[0].title, "Other versions");
+        assert_eq!(a.sections[0].items.len(), 1);
+        assert_eq!(a.sections[0].items[0].title, "Other Album");
     }
 
     /// On a single-artist album YouTube ships the per-track artist column *empty* (`"text": {}`,

--- a/src-tauri/src/local.rs
+++ b/src-tauri/src/local.rs
@@ -563,9 +563,11 @@ fn page_of(title: Option<String>, artist: Option<String>, tracks: &[LocalTrack])
         items: songs_of(&tracks),
         continuation: None,
         explicit: false,
-        // No YouTube playlist behind it: no radio to seed, nothing to save to the library.
+        // No YouTube playlist behind it: no radio to seed, nothing to save to the library, and
+        // nothing to recommend alongside it.
         playlist_id: None,
         in_library: false,
+        sections: Vec::new(),
     }
 }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -226,6 +226,8 @@ export interface AlbumPage {
 	playlistId?: string;
 	/** Already saved to the signed-in user's library. */
 	inLibrary: boolean;
+	/** Card shelves under the tracks: other versions, more from the artist, related releases. */
+	sections?: ArtistCarousel[];
 }
 
 export interface ArtistPage {

--- a/ui/src/routes/album/[id]/+page.svelte
+++ b/ui/src/routes/album/[id]/+page.svelte
@@ -19,6 +19,7 @@
         filterTracks,
     } from "$lib/components/TrackFilter.svelte";
     import TrackRowSkeleton from "$lib/components/TrackRowSkeleton.svelte";
+    import Shelf from "$lib/components/Shelf.svelte";
     import ErrorState from "$lib/components/ErrorState.svelte";
     import ArtistLine from "$lib/components/ArtistLine.svelte";
     import ExplicitIcon from "$lib/components/ExplicitIcon.svelte";
@@ -201,6 +202,13 @@
         if (!album?.items.length) return;
         menuOpen = false;
         openAddManyToPlaylist(album.items);
+    }
+
+    // A shelf's "See all" opens the same grid route the artist page uses.
+    function showMore(s: { title: string; moreBrowseId?: string; moreParams?: string }) {
+        const q = new URLSearchParams({ id: s.moreBrowseId!, title: s.title });
+        if (s.moreParams) q.set("params", s.moreParams);
+        goto(`/list?${q.toString()}`);
     }
 </script>
 
@@ -462,4 +470,21 @@
             </p>
         {/each}
     </div>
+
+    <!-- Other versions of this release, and what sits near it. Ruled off from the tracks so the
+         page reads as the album first and its surroundings second. -->
+    {#if album.sections?.length}
+        <div class="content-in mt-2 flex flex-col gap-8 border-t px-6 pb-8 pt-8">
+            {#each album.sections as section, i (i + ":" + section.title)}
+                <Shelf
+                    title={section.title}
+                    items={section.items}
+                    headingClass="font-heading text-xl font-bold"
+                    onMore={section.moreBrowseId
+                        ? () => showMore(section)
+                        : undefined}
+                />
+            {/each}
+        </div>
+    {/if}
 {/if}


### PR DESCRIPTION
Fixes #54.

The album page stopped at the last track. YouTube's album response already carries two card shelves alongside the track list, so this renders them: "Other versions" (other editions of the same release, e.g. deluxe or clean) and "Releases for you" (related albums and singles).

No extra request: both shelves come out of the same browse response the tracks do.

**What it does**
- `AlbumPage` gained `sections`, parsed by walking the response for `musicCarouselShelfRenderer` through the same carousel parser the artist page uses. An album page is two-column, so the shelves sit in the column the tracks don't.
- The "hide music videos" setting filters these cards like it does everywhere else.
- Cards pointing back at the album you are already on are dropped. YouTube lists the current release among its own other versions, and a card that reopens the page you are on is noise.
- Rendered with the existing `Shelf` and `MediaCard`, ruled off from the track list. Arrows show on hover only when the row actually scrolls, so a one-card "Other versions" shelf doesn't draw a pair of dead arrows the way YouTube Music's does.
- Local albums have no shelves, so the section is hidden entirely.

**Verified**
- `cargo test -p innertube` 60/60 (`parses_album_page` extended to cover the new shelf)
- `cargo check --workspace` clean, `pnpm check` 0 errors
- Live against Rumours, IGOR and Might Delete Later: "Other versions" returns 1-2 editions, "Releases for you" 10 cards