### PR TITLE
Add .deb package build support

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,7 +1,8 @@
 name: Linux release binaries
 
-# Builds and signs the Linux AppImage for a release that ALREADY EXISTS, attaches it, adds the
-# `linux-x86_64` entry to latest.json, and finally marks the release "Latest".
+# Builds and signs the Linux AppImage and builds the .deb for a release that ALREADY EXISTS,
+# attaches both, adds the `linux-x86_64` entry to latest.json, and finally marks the release
+# "Latest".
 #
 # WHY THIS EXISTS: an AppImage bundles the *build host's* system libraries but cannot bundle glibc,
 # so it inherits the build host's glibc floor. Built on Fedora (glibc 2.43) the 0.2.9 AppImage
@@ -12,6 +13,12 @@ name: Linux release binaries
 # `runs-on` is PINNED ON PURPOSE. Never change it to `ubuntu-latest` — that tracks the newest
 # Ubuntu and would silently reintroduce exactly the bug this workflow exists to fix. The
 # "Check the glibc floor" step below fails the build if someone does it anyway.
+#
+# The .deb is here for exactly the same reason, and needs it more. Tauri writes a deb's Depends
+# verbatim from tauri.conf.json and never runs dpkg-shlibdeps, so nothing in the package records a
+# glibc floor at all: a Fedora-built deb installs cleanly on Debian and then dies at startup on a
+# missing GLIBC symbol. Built here it matches the AppImage's 2.39, which is what the hand-written
+# `libc6 (>= 2.39)` in tauri.conf.json claims.
 #
 # scripts/release.sh (run on Fedora) still builds and publishes the .rpm — an rpm links against the
 # host's system libs, so Fedora is the correct place to build it.
@@ -34,7 +41,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag to build the Linux AppImage for (e.g. v0.2.9)
+        description: Existing release tag to build the Linux AppImage + deb for (e.g. v0.2.9)
         required: true
         type: string
       dry_run:
@@ -110,7 +117,8 @@ jobs:
         run: |
           nohup docker pull debian:sid      > /tmp/pull-debian.log 2>&1 &
           nohup docker pull archlinux:latest > /tmp/pull-arch.log  2>&1 &
-          echo "pulling debian:sid and archlinux:latest in the background"
+          nohup docker pull ubuntu:24.04     > /tmp/pull-ubuntu.log 2>&1 &
+          echo "pulling debian:sid, archlinux:latest and ubuntu:24.04 in the background"
 
       # Bake a snapshot of the community player-cipher registry into src-tauri/cipher_configs.json,
       # which is `include_str!`d into the binary. Nothing needing a deciphered stream URL plays
@@ -205,7 +213,7 @@ jobs:
             echo "::warning::LASTFM_API_KEY / LASTFM_API_SECRET secrets not set — this Linux build ships without Last.fm scrobbling"
           fi
 
-      - name: Build + sign the AppImage
+      - name: Build + sign the AppImage, build the deb
         env:
           # Scoped to this step only — no other step (or third-party action) sees the signing key.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -227,7 +235,7 @@ jobs:
           # frontend packages (ui/, website/) pnpm picks is up to the filesystem: Windows resolved
           # it to ui, Linux to website, whose deps this job never installs. It only works locally
           # because you run it from ui/.
-          tauri build --bundles appimage --config '{"build":{"beforeBuildCommand":""}}'
+          tauri build --bundles appimage,deb --config '{"build":{"beforeBuildCommand":""}}'
           # Strip the bundled TLS trust stack + gio modules out of the AppDir and repack: they are
           # coupled to the build host's config and leave the webview with no TLS backend anywhere
           # else. Repacking invalidates the bundler's signature, so the script re-signs — which is
@@ -328,11 +336,35 @@ jobs:
             exit 1
           fi
 
+      # The .deb gets no dependency detection whatsoever: Tauri copies Depends straight out of
+      # tauri.conf.json and never runs dpkg-shlibdeps, so a library the binary links but the config
+      # forgets installs perfectly and then fails at startup. dpkg is the only thing that can tell
+      # us that list is right, so let it: install the real package on the oldest release the floor
+      # claims to support and resolve every DT_NEEDED against whatever apt pulled in. This catches a
+      # too-new glibc too, since ldd reports a missing GLIBC_x.yz the same way.
+      - name: Verify the .deb installs and resolves its libraries
+        run: |
+          set -euo pipefail
+          DEB="$(ls target/release/bundle/deb/limusic_${VERSION}_*.deb | head -1)"
+          docker run --rm -v "$PWD/$DEB:/limusic.deb:ro" ubuntu:24.04 bash -c '
+            set -eu
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq
+            apt-get install -y --no-install-recommends /limusic.deb
+            BIN="$(dpkg -L limusic | grep "^/usr/bin/" | head -1)"
+            echo "installed $BIN, declared: $(dpkg-query -f "\${Depends}" -W limusic)"
+            if ldd "$BIN" | grep "not found"; then
+              echo "the deb declares nothing that provides the libraries above"
+              exit 1
+            fi
+            echo "every library the binary needs came from the declared Depends"
+          '
+
       - name: Dry run — built and verified, attaching nothing
         if: ${{ inputs.dry_run }}
         run: echo "dry_run - every build step and guard passed; release assets left untouched."
 
-      - name: Attach the AppImage + teach latest.json about Linux
+      - name: Attach the AppImage + deb, teach latest.json about Linux
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -370,6 +402,15 @@ jobs:
           fi
 
           retry 3 gh release upload "$TAG" "$APPIMAGE" "$SIG" --clobber --repo "$GITHUB_REPOSITORY"
+
+          # The deb rides along unsigned and stays out of latest.json: Tauri's updater has no deb
+          # support, so there is nothing for a signature to be checked by. Debian users update by
+          # downloading the next one.
+          DEB="$(ls target/release/bundle/deb/limusic_${VERSION}_*.deb 2>/dev/null | head -1 || true)"
+          if [ -z "$DEB" ]; then
+            echo "::error::no deb for $VERSION"; find target/release/bundle -maxdepth 2; exit 1
+          fi
+          retry 3 gh release upload "$TAG" "$DEB" --clobber --repo "$GITHUB_REPOSITORY"
 
           # latest.json is the one thing both release workflows write, and they now run in parallel.
           # There is no compare-and-swap on release assets, so: merge, upload, read back, and retry

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -342,7 +342,12 @@ jobs:
       # us that list is right, so let it: install the real package on the oldest release the floor
       # claims to support and resolve every DT_NEEDED against whatever apt pulled in. This catches a
       # too-new glibc too, since ldd reports a missing GLIBC_x.yz the same way.
+      # continue-on-error, and the attach step below skips the upload if this failed. The AppImage
+      # is how every Linux user gets updates; the deb is a convenience. A broken deb must not take
+      # the release down with it, so a failure here costs the deb and nothing else.
       - name: Verify the .deb installs and resolves its libraries
+        id: deb_check
+        continue-on-error: true
         run: |
           set -euo pipefail
           DEB="$(ls target/release/bundle/deb/limusic_${VERSION}_*.deb | head -1)"
@@ -405,12 +410,16 @@ jobs:
 
           # The deb rides along unsigned and stays out of latest.json: Tauri's updater has no deb
           # support, so there is nothing for a signature to be checked by. Debian users update by
-          # downloading the next one.
+          # downloading the next one. Skipped entirely if it failed its check, which is a warning
+          # rather than an error: the release is complete without it.
           DEB="$(ls target/release/bundle/deb/limusic_${VERSION}_*.deb 2>/dev/null | head -1 || true)"
-          if [ -z "$DEB" ]; then
-            echo "::error::no deb for $VERSION"; find target/release/bundle -maxdepth 2; exit 1
+          if [ "${{ steps.deb_check.outcome }}" != "success" ]; then
+            echo "::warning::the deb failed its install check and was NOT attached — fix bundle.linux.deb.depends and re-dispatch"
+          elif [ -z "$DEB" ]; then
+            echo "::warning::no deb for $VERSION in target/release/bundle/deb — nothing attached"
+          else
+            retry 3 gh release upload "$TAG" "$DEB" --clobber --repo "$GITHUB_REPOSITORY"
           fi
-          retry 3 gh release upload "$TAG" "$DEB" --clobber --repo "$GITHUB_REPOSITORY"
 
           # latest.json is the one thing both release workflows write, and they now run in parallel.
           # There is no compare-and-swap on release assets, so: merge, upload, read back, and retry

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ YouTube Music client, and grew from there.
 | Platform | File | Notes |
 |---|---|---|
 | Linux | `.AppImage` | Self-updating, libmpv bundled. Needs glibc 2.39+ (Ubuntu 24.04+, Debian 13+, Fedora 40+) |
-| Linux (Ubuntu/Debian) | `.deb` | Needs `libmpv2` or `libmpv1` installed (`sudo apt install libmpv2` or `libmpv1`) |
+| Linux (Ubuntu/Debian) | `.deb` | No self-update. Needs Ubuntu 24.04+ / Debian 13+; apt pulls libmpv and webkit2gtk in for you |
 | Linux (Fedora/RHEL) | `.rpm` | Needs `mpv-libs` installed (`sudo dnf install mpv-libs`) |
 | Windows | `-setup.exe` | Self-updating |
 | Windows | `.msi` | Plain installer, no auto-update |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ YouTube Music client, and grew from there.
 | Platform | File | Notes |
 |---|---|---|
 | Linux | `.AppImage` | Self-updating, libmpv bundled. Needs glibc 2.39+ (Ubuntu 24.04+, Debian 13+, Fedora 40+) |
+| Linux (Ubuntu/Debian) | `.deb` | Needs `libmpv2` or `libmpv1` installed (`sudo apt install libmpv2` or `libmpv1`) |
 | Linux (Fedora/RHEL) | `.rpm` | Needs `mpv-libs` installed (`sudo dnf install mpv-libs`) |
 | Windows | `-setup.exe` | Self-updating |
 | Windows | `.msi` | Plain installer, no auto-update |

--- a/docs/BUILD-PLATFORMS.md
+++ b/docs/BUILD-PLATFORMS.md
@@ -6,7 +6,7 @@ step just emits `cargo:rustc-link-lib=mpv` (via `libmpv2-sys`), so "getting it t
 "putting libmpv's import library on the linker's search path"; "getting it to run" is "shipping the
 matching shared library next to the app."
 
-Bundle targets are set per platform: `tauri.conf.json` → `rpm` (Linux), `tauri.windows.conf.json` →
+Bundle targets are set per platform: `tauri.conf.json` → `deb` + `rpm` (Linux), `tauri.windows.conf.json` →
 `nsis` + `msi`, `tauri.macos.conf.json` → `app` + `dmg`. Tauri auto-merges the platform file over
 the base for the current OS.
 
@@ -19,13 +19,21 @@ the base for the current OS.
 
 ---
 
-## Fedora / Linux (primary, dev target)
+## Linux (Fedora / Debian / Ubuntu)
 
+### Fedora / RHEL
 ```bash
 sudo dnf install mpv-libs mpv-libs-devel webkit2gtk4.1-devel \
   gcc gcc-c++ make openssl-devel librsvg2-devel   # + standard Tauri build deps
 cd ui && pnpm install && pnpm build
-cargo tauri build            # → target/release/bundle/rpm/limusic-*.rpm
+cargo tauri build            # → target/release/bundle/rpm/limusic-*.rpm & deb/limusic_*.deb
+```
+
+### Ubuntu / Debian
+```bash
+sudo apt install libmpv-dev libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+cd ui && pnpm install && pnpm build
+cargo tauri build            # → target/release/bundle/deb/limusic_*.deb
 ```
 
 - libmpv is system-provided (`mpv-libs`), found on the default linker path — no bundling needed.

--- a/docs/BUILD-PLATFORMS.md
+++ b/docs/BUILD-PLATFORMS.md
@@ -6,9 +6,9 @@ step just emits `cargo:rustc-link-lib=mpv` (via `libmpv2-sys`), so "getting it t
 "putting libmpv's import library on the linker's search path"; "getting it to run" is "shipping the
 matching shared library next to the app."
 
-Bundle targets are set per platform: `tauri.conf.json` → `deb` + `rpm` (Linux), `tauri.windows.conf.json` →
-`nsis` + `msi`, `tauri.macos.conf.json` → `app` + `dmg`. Tauri auto-merges the platform file over
-the base for the current OS.
+Bundle targets are set per platform: `tauri.conf.json` → `deb` + `rpm` + `appimage` (Linux),
+`tauri.windows.conf.json` → `nsis` + `msi`, `tauri.macos.conf.json` → `app` + `dmg`. Tauri
+auto-merges the platform file over the base for the current OS.
 
 ## Common prerequisites (all platforms)
 
@@ -26,23 +26,33 @@ the base for the current OS.
 sudo dnf install mpv-libs mpv-libs-devel webkit2gtk4.1-devel \
   gcc gcc-c++ make openssl-devel librsvg2-devel   # + standard Tauri build deps
 cd ui && pnpm install && pnpm build
-cargo tauri build            # → target/release/bundle/rpm/limusic-*.rpm & deb/limusic_*.deb
+cargo tauri build            # → target/release/bundle/rpm/limusic-*.rpm (plus a test-only .deb)
 ```
 
 ### Ubuntu / Debian
 ```bash
-sudo apt install libmpv-dev libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+sudo apt install libmpv-dev libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
+  libssl-dev libdbus-1-dev
 cd ui && pnpm install && pnpm build
-cargo tauri build            # → target/release/bundle/deb/limusic_*.deb
+cargo tauri build --bundles deb   # → target/release/bundle/deb/limusic_*.deb
 ```
 
 - libmpv is system-provided (`mpv-libs`), found on the default linker path — no bundling needed.
 - Media keys use **MPRIS** over D-Bus (needs a running session bus — normal on a desktop session).
-- **The release AppImage is not built here.** An AppImage inherits its build host's glibc floor, and
-  Fedora's is the newest that exists — one built on this machine starts on almost nothing else.
-  `.github/workflows/linux-release.yml` builds it on a pinned `ubuntu-24.04` runner (glibc 2.39) and
-  fails the build if anything bundled needs newer. A local `cargo tauri build` still emits one into
-  `target/release/bundle/appimage/` for testing; never upload that to a release.
+- **Neither the release AppImage nor the release .deb is built here.** Both inherit their build
+  host's glibc floor, and Fedora's is the newest that exists, so one built on this machine starts on
+  almost nothing else. `.github/workflows/linux-release.yml` builds both on a pinned `ubuntu-24.04`
+  runner (glibc 2.39) and fails the build if anything bundled needs newer. A local
+  `cargo tauri build` still emits them into `target/release/bundle/` for testing; never upload those
+  to a release.
+- **A .deb declares only what `bundle.linux.deb.depends` in `tauri.conf.json` says it does.** Tauri
+  copies that list verbatim and never runs `dpkg-shlibdeps`, so nothing about the package is derived
+  from the binary: not the libraries it links, not its glibc floor. That is why the list is
+  `libwebkit2gtk-4.1-0` (which drags in gtk3, glib, cairo, libsoup and JavaScriptCore), `libmpv2`,
+  and a hand-written `libc6 (>= 2.39)` matching the CI runner. If a future build links something
+  new, add it there by hand. A forgotten entry produces a package that installs cleanly and then
+  refuses to start, so the workflow's `Verify the .deb installs and resolves its libraries` step
+  installs it on a clean Ubuntu 24.04 and fails on the first unresolved `ldd` line.
 - A freshly bundled AppDir is **not portable** until `scripts/fix-appdir-tls.sh` has run over it —
   linuxdeploy bundles the host's TLS trust stack (whose CA anchors live outside the bundle) and
   writes a `GIO_EXTRA_MODULES` containing a literal newline and a path into your own `target/` dir,

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Cut a signed release: publish the tag with an empty updater manifest, start the three CI builds,
-# build the .rpm locally while they run, then wait and verify the whole thing landed.
+# build the .deb and .rpm locally while they run, then wait and verify the whole thing landed.
 #
-# ORDER MATTERS. The release is created and every workflow is dispatched BEFORE the local rpm
+# ORDER MATTERS. The release is created and every workflow is dispatched BEFORE the local deb/rpm
 # build, not after: CI's ~15 minutes and this machine's ~5 minutes then overlap instead of queueing.
-# The rpm is uploaded to the already-published release afterwards. The cost of that ordering is that
-# a failed rpm build leaves a published release with no rpm on it, recoverable with one
+# The deb and rpm are uploaded to the already-published release afterwards. The cost of that ordering is that
+# a failed deb/rpm build leaves a published release with no deb/rpm on it, recoverable with one
 # `gh release upload`, and the script tells you the exact command if it happens.
 #
 # The AppImage is NOT built here. An AppImage inherits its build host's glibc floor, and this
@@ -164,13 +164,13 @@ RUN_WIN="$(wait_for_run "Windows release binaries" "$BEFORE_WIN" || true)"
 RUN_MAC="$(wait_for_run "macOS release binaries" "$BEFORE_MAC" || true)"
 echo "    linux run ${RUN_LINUX:-?}, windows run ${RUN_WIN:-?}, macos run ${RUN_MAC:-?}"
 
-echo "==> Building the rpm locally while CI runs…"
-if ! cargo tauri build --bundles rpm; then
+echo "==> Building the deb and rpm locally while CI runs…"
+if ! cargo tauri build --bundles deb,rpm; then
   echo >&2
-  echo "ERROR: the rpm build failed, but $TAG is already published and CI is building the rest." >&2
-  echo "       Fix it, then attach the rpm by hand:" >&2
-  echo "         cargo tauri build --bundles rpm" >&2
-  echo "         gh release upload $TAG target/release/bundle/rpm/limusic-$VERSION-*.rpm --clobber --repo $REPO" >&2
+  echo "ERROR: the deb/rpm build failed, but $TAG is already published and CI is building the rest." >&2
+  echo "       Fix it, then attach the packages by hand:" >&2
+  echo "         cargo tauri build --bundles deb,rpm" >&2
+  echo "         gh release upload $TAG target/release/bundle/rpm/limusic-$VERSION-*.rpm target/release/bundle/deb/limusic_*_*.deb --clobber --repo $REPO" >&2
   exit 1
 fi
 
@@ -180,6 +180,11 @@ RPM="$(ls target/release/bundle/rpm/limusic-${VERSION}-*.rpm 2>/dev/null | head 
 [ -n "$RPM" ] || die "no rpm for $VERSION in target/release/bundle/rpm"
 gh release upload "$TAG" "$RPM" --clobber --repo "$REPO"
 echo "    attached $(basename "$RPM")"
+
+DEB="$(ls target/release/bundle/deb/limusic_${VERSION}_*.deb target/release/bundle/deb/limusic-${VERSION}-*.deb 2>/dev/null | head -1)"
+[ -n "$DEB" ] || die "no deb for $VERSION in target/release/bundle/deb"
+gh release upload "$TAG" "$DEB" --clobber --repo "$REPO"
+echo "    attached $(basename "$DEB")"
 
 # ---------------------------------------------------------------------------
 # Wait for CI and check the release is actually complete. Without this the
@@ -211,7 +216,7 @@ has_platform windows-x86_64 || { echo "    MISSING: latest.json has no windows-x
 has_platform darwin-aarch64 || { echo "    MISSING: latest.json has no darwin-aarch64 entry (Mac users get no update)"; OK=0; }
 
 if [ "$OK" = 1 ] && [ "$CI_OK" = 1 ]; then
-  echo "==> $TAG is live and complete: rpm + AppImage + Windows installers + macOS dmg, all three"
+  echo "==> $TAG is live and complete: deb + rpm + AppImage + Windows installers + macOS dmg, all three"
   echo "    platforms in latest.json, marked Latest. Installed users will be prompted."
 else
   echo >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 # Cut a signed release: publish the tag with an empty updater manifest, start the three CI builds,
-# build the .deb and .rpm locally while they run, then wait and verify the whole thing landed.
+# build the .rpm locally while they run, then wait and verify the whole thing landed.
 #
-# ORDER MATTERS. The release is created and every workflow is dispatched BEFORE the local deb/rpm
+# ORDER MATTERS. The release is created and every workflow is dispatched BEFORE the local rpm
 # build, not after: CI's ~15 minutes and this machine's ~5 minutes then overlap instead of queueing.
-# The deb and rpm are uploaded to the already-published release afterwards. The cost of that ordering is that
-# a failed deb/rpm build leaves a published release with no deb/rpm on it, recoverable with one
+# The rpm is uploaded to the already-published release afterwards. The cost of that ordering is that
+# a failed rpm build leaves a published release with no rpm on it, recoverable with one
 # `gh release upload`, and the script tells you the exact command if it happens.
 #
-# The AppImage is NOT built here. An AppImage inherits its build host's glibc floor, and this
-# machine is Fedora (newest glibc in existence) — one built here starts nowhere else. It is built by
-# .github/workflows/linux-release.yml on a pinned older runner, which also attaches it, adds the
-# linux-x86_64 entry to latest.json and marks the release "Latest". Windows and macOS do the same
-# for their own entries. So this script publishes the release NOT-latest on purpose: until CI has
-# attached the binaries, the updater endpoint (.../releases/latest/download/latest.json) keeps
-# resolving to the previous, complete manifest instead of one with no platforms in it.
+# Neither the AppImage nor the .deb is built here, and for the same reason: both inherit their
+# build host's glibc floor, and this machine is Fedora (the newest glibc in existence), so one built
+# here starts nowhere else. The deb is the worse of the two, because Tauri writes its Depends
+# verbatim from tauri.conf.json and never emits a libc6 constraint: a Fedora-built deb installs
+# cleanly on Debian and then dies at startup on a missing GLIBC symbol. Both are built by
+# .github/workflows/linux-release.yml on a pinned ubuntu-24.04 runner, which also attaches them,
+# adds the linux-x86_64 entry to latest.json and marks the release "Latest". Windows and macOS do
+# the same for their own entries. So this script publishes the release NOT-latest on purpose: until
+# CI has attached the binaries, the updater endpoint (.../releases/latest/download/latest.json)
+# keeps resolving to the previous, complete manifest instead of one with no platforms in it.
 #
 # Usage:  scripts/release.sh ["release notes"]
 # Bump "version" in src-tauri/tauri.conf.json AND Cargo.toml BEFORE running (tauri.conf.json is the
@@ -164,13 +167,13 @@ RUN_WIN="$(wait_for_run "Windows release binaries" "$BEFORE_WIN" || true)"
 RUN_MAC="$(wait_for_run "macOS release binaries" "$BEFORE_MAC" || true)"
 echo "    linux run ${RUN_LINUX:-?}, windows run ${RUN_WIN:-?}, macos run ${RUN_MAC:-?}"
 
-echo "==> Building the deb and rpm locally while CI runs…"
-if ! cargo tauri build --bundles deb,rpm; then
+echo "==> Building the rpm locally while CI runs…"
+if ! cargo tauri build --bundles rpm; then
   echo >&2
-  echo "ERROR: the deb/rpm build failed, but $TAG is already published and CI is building the rest." >&2
-  echo "       Fix it, then attach the packages by hand:" >&2
-  echo "         cargo tauri build --bundles deb,rpm" >&2
-  echo "         gh release upload $TAG target/release/bundle/rpm/limusic-$VERSION-*.rpm target/release/bundle/deb/limusic_*_*.deb --clobber --repo $REPO" >&2
+  echo "ERROR: the rpm build failed, but $TAG is already published and CI is building the rest." >&2
+  echo "       Fix it, then attach the rpm by hand:" >&2
+  echo "         cargo tauri build --bundles rpm" >&2
+  echo "         gh release upload $TAG target/release/bundle/rpm/limusic-$VERSION-*.rpm --clobber --repo $REPO" >&2
   exit 1
 fi
 
@@ -180,11 +183,6 @@ RPM="$(ls target/release/bundle/rpm/limusic-${VERSION}-*.rpm 2>/dev/null | head 
 [ -n "$RPM" ] || die "no rpm for $VERSION in target/release/bundle/rpm"
 gh release upload "$TAG" "$RPM" --clobber --repo "$REPO"
 echo "    attached $(basename "$RPM")"
-
-DEB="$(ls target/release/bundle/deb/limusic_${VERSION}_*.deb target/release/bundle/deb/limusic-${VERSION}-*.deb 2>/dev/null | head -1)"
-[ -n "$DEB" ] || die "no deb for $VERSION in target/release/bundle/deb"
-gh release upload "$TAG" "$DEB" --clobber --repo "$REPO"
-echo "    attached $(basename "$DEB")"
 
 # ---------------------------------------------------------------------------
 # Wait for CI and check the release is actually complete. Without this the
@@ -216,8 +214,8 @@ has_platform windows-x86_64 || { echo "    MISSING: latest.json has no windows-x
 has_platform darwin-aarch64 || { echo "    MISSING: latest.json has no darwin-aarch64 entry (Mac users get no update)"; OK=0; }
 
 if [ "$OK" = 1 ] && [ "$CI_OK" = 1 ]; then
-  echo "==> $TAG is live and complete: deb + rpm + AppImage + Windows installers + macOS dmg, all three"
-  echo "    platforms in latest.json, marked Latest. Installed users will be prompted."
+  echo "==> $TAG is live and complete: rpm + deb + AppImage + Windows installers + macOS dmg, all"
+  echo "    three platforms in latest.json, marked Latest. Installed users will be prompted."
 else
   echo >&2
   echo "==> $TAG IS PUBLISHED BUT INCOMPLETE. Check what failed, then re-dispatch that workflow:" >&2

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["rpm", "appimage"],
+    "targets": ["deb", "rpm", "appimage"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/icon.png",
@@ -51,6 +51,9 @@
       "debugApplicationIdSuffix": ".debug"
     },
     "linux": {
+      "deb": {
+        "depends": ["libayatana-appindicator3-1 | libappindicator3-1", "libmpv2 | libmpv1"]
+      },
       "rpm": {
         "depends": ["libappindicator-gtk3", "mpv-libs"]
       }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
     },
     "linux": {
       "deb": {
-        "depends": ["libayatana-appindicator3-1 | libappindicator3-1", "libmpv2 | libmpv1"]
+        "depends": ["libwebkit2gtk-4.1-0", "libmpv2", "libc6 (>= 2.39)"]
       },
       "rpm": {
         "depends": ["libappindicator-gtk3", "mpv-libs"]

--- a/ui/src/lib/updater.svelte.ts
+++ b/ui/src/lib/updater.svelte.ts
@@ -1,6 +1,6 @@
 // Auto-update via Tauri's updater plugin. Checks a signed latest.json on GitHub Releases; the
 // startup check is silent unless an update exists, the Settings check always reports a result.
-// Only self-updates the AppImage build on Linux (Tauri limitation) — the .rpm can't self-update.
+// Only self-updates the AppImage build on Linux (Tauri limitation) — .deb and .rpm packages can't self-update.
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { toast } from './player.svelte';

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -294,6 +294,7 @@ function Download({ info, os }: { info: ReturnType<typeof useGitHub>; os: string
       detected: os === 'linux',
       links: [
         { label: '.AppImage — any distro', href: info.appimage },
+        { label: '.deb — Ubuntu / Debian', href: info.deb },
         { label: '.rpm — Fedora / RHEL', href: info.rpm },
       ],
       note: 'The AppImage updates itself automatically.',

--- a/website/src/lib/github.ts
+++ b/website/src/lib/github.ts
@@ -7,13 +7,14 @@ export const RELEASES_URL = `${REPO_URL}/releases/latest`
 export interface RepoInfo {
   version: string | null
   stars: number | null
+  deb: string | null
   rpm: string | null
   appimage: string | null
   exe: string | null
   msi: string | null
 }
 
-const empty: RepoInfo = { version: null, stars: null, rpm: null, appimage: null, exe: null, msi: null }
+const empty: RepoInfo = { version: null, stars: null, deb: null, rpm: null, appimage: null, exe: null, msi: null }
 
 /* Fetches the latest release + star count once on mount. Everything degrades to the
    GitHub releases page if the API is unreachable or rate-limited. */
@@ -30,6 +31,7 @@ export function useGitHub(): RepoInfo {
         setInfo(prev => ({
           ...prev,
           version: d.tag_name,
+          deb: find(d.assets, n => n.endsWith('.deb')),
           rpm: find(d.assets, n => n.endsWith('.rpm')),
           appimage: find(d.assets, n => n.endsWith('.AppImage')),
           exe: find(d.assets, n => n.endsWith('.exe')),


### PR DESCRIPTION
Adds .deb package bundling alongside .rpm and .AppImage for Linux releases, updating release scripts, website download links, and docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux Debian/Ubuntu `.deb` packages alongside RPM and AppImage downloads.
  * Added a Debian package download option to the website.
  * Release builds now publish signed AppImage and `.deb` packages.

* **Documentation**
  * Added installation guidance, supported platform versions, and runtime dependency details.
  * Updated Linux build instructions for Fedora, RHEL, Debian, and Ubuntu.

* **Bug Fixes**
  * Clarified that Linux `.deb` and `.rpm` packages do not support automatic self-updates.
  * Added automated verification that Debian package runtime dependencies are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->