### PR TITLE
Listening to Artist instead of Limusic

### DIFF
--- a/src-tauri/src/discord.rs
+++ b/src-tauri/src/discord.rs
@@ -420,6 +420,7 @@ impl Presence {
         }
         let mut act = activity::Activity::new()
             .activity_type(activity::ActivityType::Listening)
+            .status_display_type(activity::StatusDisplayType::State)
             .details(field(&track.title))
             .timestamps(ts);
         // A local file has no YouTube page to link, and its id is a path — never put it in a URL.


### PR DESCRIPTION
Fixes #85 
I added a line of code that makes Discord display the name of the artist currently playing (just like the Spotify integration) instead of showing "Limusic".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord activity presence updates by ensuring status text displays consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->