### PR TITLE
Feat: add now playing sidebar

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-﻿[build]
-rustflags = ["-L", "native=C:/Users/Amritanshu Praveen/nocturne-music/.libmpv"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,2 @@
-# Fedora/WebKitGTK-on-Wayland fix. Without this the window dies at startup with
-#   Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display
-# and DMABUF/GBM buffer errors. Primary target is Fedora/WebKitGTK (CLAUDE.md), so default the
-# workaround here. Not `force`d — set GDK_BACKEND=wayland in your shell to override and experiment.
-# Ignored on macOS/Windows (no GDK). ponytail: drop this once WebKitGTK/Wayland stops needing it.
-[env]
-GDK_BACKEND = "x11"
-WEBKIT_DISABLE_DMABUF_RENDERER = "1"
+﻿[build]
+rustflags = ["-L", "native=C:/Users/Amritanshu Praveen/nocturne-music/.libmpv"]

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -51,6 +51,9 @@ env:
   # AVX2 and would crash on older CPUs. libmpv2 needs mpv >= 0.35 (client API 2.x). Bump
   # deliberately: a new mpv is a new 117 MB DLL in the installer.
   MPV_DEV_URL: https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260610/mpv-dev-x86_64-20260610-git-304426c.7z
+  # The release asset's own digest, pinning MPV_DEV_URL. setup-windows-mpv.ps1 carries the same
+  # pair for local builds, so a URL bump has to move both.
+  MPV_DEV_SHA256: 8cbb25ea784f01afbb3f904217cab1317430a8bcfd5680fd827a866367f71cc9
   MPV_DIR: ${{ github.workspace }}\.libmpv
 
 jobs:
@@ -199,8 +202,15 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           New-Item -ItemType Directory -Force -Path "$env:MPV_DIR" | Out-Null
-          curl.exe -fsSL -o "$env:MPV_DIR\mpv-dev.7z" "$env:MPV_DEV_URL"
+          curl.exe -fSL --retry 3 -o "$env:MPV_DIR\mpv-dev.7z" "$env:MPV_DEV_URL"
+          # A native exe's non-zero exit does not trip $ErrorActionPreference.
+          if ($LASTEXITCODE -ne 0) { throw "curl exited $LASTEXITCODE fetching MPV_DEV_URL" }
+          # This DLL ends up in the installer, so the bytes are checked before anything unpacks them.
+          $sha = (Get-FileHash "$env:MPV_DIR\mpv-dev.7z" -Algorithm SHA256).Hash
+          if ($sha -ne $env:MPV_DEV_SHA256) { throw "mpv-dev.7z SHA-256 is $sha, expected $env:MPV_DEV_SHA256" }
           7z x "$env:MPV_DIR\mpv-dev.7z" -o"$env:MPV_DIR" -y | Out-Null
+          # 7-Zip exits 1 on a non-fatal warning; 2 and up are the real failures.
+          if ($LASTEXITCODE -gt 1) { throw "7z exited $LASTEXITCODE extracting mpv-dev.7z" }
           if (-not (Test-Path "$env:MPV_DIR\libmpv-2.dll")) { throw "libmpv-2.dll not found in the dev package — did MPV_DEV_URL change shape?" }
 
           # dumpbin/lib live in the MSVC toolchain. (cargo itself finds MSVC on its own; this is
@@ -217,6 +227,7 @@ jobs:
           if ($names.Count -lt 50) { throw "parsed only $($names.Count) exports from libmpv-2.dll — dumpbin output format changed?" }
           @("EXPORTS") + ($names | ForEach-Object { "    $_" }) | Set-Content -Path mpv.def -Encoding ascii
           & lib /def:mpv.def /name:libmpv-2.dll /out:mpv.lib /machine:x64
+          if ($LASTEXITCODE -ne 0) { throw "lib.exe exited $LASTEXITCODE generating mpv.lib" }
           if (-not (Test-Path "$env:MPV_DIR\mpv.lib")) { throw "lib.exe did not produce mpv.lib" }
           Write-Host "mpv.lib built from $($names.Count) exports"
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ rustypipe_reports/
 # Windows build artifacts — libmpv is fetched at build time (117 MB DLL), never committed.
 /src-tauri/libmpv-2.dll
 /.libmpv/
+/.cargo/config.toml
 
 # Last.fm API credentials — read by src-tauri/build.rs, never committed (public repo).
 /src-tauri/lastfm.keys

--- a/setup-windows-mpv.ps1
+++ b/setup-windows-mpv.ps1
@@ -1,0 +1,87 @@
+$ErrorActionPreference = "Stop"
+
+$workspace = Get-Location
+$mpvDir = Join-Path $workspace ".libmpv"
+$srcTauriDir = Join-Path $workspace "src-tauri"
+
+Write-Host "Setting up libmpv in $mpvDir..."
+New-Item -ItemType Directory -Force -Path $mpvDir | Out-Null
+New-Item -ItemType Directory -Force -Path $srcTauriDir | Out-Null
+
+$zipPath = Join-Path $mpvDir "mpv-dev.7z"
+$url = "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260610/mpv-dev-x86_64-20260610-git-304426c.7z"
+
+if (-not (Test-Path (Join-Path $mpvDir "libmpv-2.dll"))) {
+    Write-Host "Downloading mpv dev package..."
+    curl.exe -fsSL -o $zipPath $url
+    Write-Host "Extracting..."
+    tar.exe -xf $zipPath -C $mpvDir
+    Remove-Item $zipPath -ErrorAction SilentlyContinue
+}
+
+$dllPath = Join-Path $mpvDir "libmpv-2.dll"
+if (-not (Test-Path $dllPath)) {
+    throw "libmpv-2.dll not found in $mpvDir"
+}
+
+# Copy DLL to src-tauri so Tauri bundle includes it
+Copy-Item $dllPath (Join-Path $srcTauriDir "libmpv-2.dll") -Force
+Write-Host "Copied libmpv-2.dll to src-tauri/libmpv-2.dll"
+
+# Locate MSVC toolchain for dumpbin and lib.exe
+$msvcBin = ""
+$dumpbin = Get-Command "dumpbin.exe" -ErrorAction SilentlyContinue
+$libExe = Get-Command "lib.exe" -ErrorAction SilentlyContinue
+
+if ($dumpbin -and $libExe) {
+    $dumpbinPath = $dumpbin.Source
+    $libPath = $libExe.Source
+} else {
+    $msvcTools = Get-ChildItem "C:\Program Files (x86)\Microsoft Visual Studio" -Recurse -Filter "dumpbin.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($msvcTools) {
+        $msvcBin = $msvcTools.DirectoryName
+        $dumpbinPath = Join-Path $msvcBin "dumpbin.exe"
+        $libPath = Join-Path $msvcBin "lib.exe"
+    } else {
+        throw "Could not find Visual Studio MSVC tools (dumpbin.exe / lib.exe)"
+    }
+}
+
+Write-Host "Using dumpbin at: $dumpbinPath"
+Write-Host "Using lib at: $libPath"
+
+# Extract exports and generate mpv.def
+Set-Location $mpvDir
+$exports = & $dumpbinPath /exports libmpv-2.dll |
+    Select-String -Pattern '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\w+)' |
+    ForEach-Object { $_.Matches[0].Groups[1].Value }
+
+if ($exports.Count -lt 50) {
+    throw "Parsed only $($exports.Count) exports from libmpv-2.dll"
+}
+
+@("EXPORTS") + ($exports | ForEach-Object { "    $_" }) | Set-Content -Path "mpv.def" -Encoding ascii
+& $libPath /def:mpv.def /name:libmpv-2.dll /out:mpv.lib /machine:x64
+
+if (-not (Test-Path (Join-Path $mpvDir "mpv.lib"))) {
+    throw "Failed to generate mpv.lib"
+}
+
+Write-Host "Successfully generated mpv.lib ($($exports.Count) exports)"
+
+# Ensure .cargo/config.toml exists so cargo automatically finds mpv.lib
+$cargoDir = Join-Path $workspace ".cargo"
+New-Item -ItemType Directory -Force -Path $cargoDir | Out-Null
+$cargoConfig = Join-Path $cargoDir "config.toml"
+
+$escapedMpvDir = $mpvDir -replace '\\', '/'
+$configContent = @"
+[build]
+rustflags = ["-L", "native=$escapedMpvDir"]
+"@
+
+Set-Content -Path $cargoConfig -Value $configContent -Encoding utf8
+Write-Host "Configured .cargo/config.toml with rustflags"
+
+Set-Location $workspace
+Write-Host "Setup completed successfully!"

--- a/setup-windows-mpv.ps1
+++ b/setup-windows-mpv.ps1
@@ -9,17 +9,47 @@ New-Item -ItemType Directory -Force -Path $mpvDir | Out-Null
 New-Item -ItemType Directory -Force -Path $srcTauriDir | Out-Null
 
 $zipPath = Join-Path $mpvDir "mpv-dev.7z"
+$dllPath = Join-Path $mpvDir "libmpv-2.dll"
+$shaMarker = Join-Path $mpvDir "mpv-dev.sha256"
 $url = "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260610/mpv-dev-x86_64-20260610-git-304426c.7z"
+# The GitHub release asset's own `digest`. It pins $url, so moving one without the other fails the
+# check rather than skipping it. windows-release.yml carries the same pair as MPV_DEV_SHA256.
+$expectedSha = "8cbb25ea784f01afbb3f904217cab1317430a8bcfd5680fd827a866367f71cc9"
 
-if (-not (Test-Path (Join-Path $mpvDir "libmpv-2.dll"))) {
+# A leftover DLL from an earlier $url would otherwise skip the digest check entirely, so the marker
+# records which archive produced the files rather than trusting that one of them exists. It holds the
+# URL too: bumping $url and forgetting $expectedSha would otherwise still match and reuse the old DLL.
+# `-as [string]` rather than a cast, because Get-Content on a 0-byte file yields $null, not "".
+$markerValue = "$url|$expectedSha"
+$verified = (Test-Path $dllPath) -and (Test-Path $shaMarker) -and
+    ((((Get-Content $shaMarker -Raw) -as [string]).Trim()) -eq $markerValue)
+
+if (-not $verified) {
     Write-Host "Downloading mpv dev package..."
-    curl.exe -fsSL -o $zipPath $url
+    curl.exe -fSL --retry 3 -o $zipPath $url
+    # A native exe's non-zero exit does not trip $ErrorActionPreference.
+    if ($LASTEXITCODE -ne 0) {
+        Remove-Item $zipPath -ErrorAction SilentlyContinue
+        throw "curl exited $LASTEXITCODE fetching $url"
+    }
+    $actualSha = (Get-FileHash $zipPath -Algorithm SHA256).Hash
+    if ($actualSha -ne $expectedSha) {
+        Remove-Item $zipPath -ErrorAction SilentlyContinue
+        throw "mpv-dev.7z SHA-256 is $actualSha, expected $expectedSha. Not extracting it."
+    }
+    # Cleared only now that the archive is in hand and verified. An archive that turns out not to
+    # carry the DLL would otherwise leave the previous one in place for the marker to vouch for.
+    Remove-Item $dllPath -ErrorAction SilentlyContinue
+    Remove-Item $shaMarker -ErrorAction SilentlyContinue
     Write-Host "Extracting..."
     tar.exe -xf $zipPath -C $mpvDir
+    $tarExit = $LASTEXITCODE
     Remove-Item $zipPath -ErrorAction SilentlyContinue
+    if ($tarExit -ne 0) { throw "tar exited $tarExit extracting mpv-dev.7z" }
+    if (-not (Test-Path $dllPath)) { throw "mpv-dev.7z did not contain libmpv-2.dll" }
+    Set-Content -Path $shaMarker -Value $markerValue -Encoding ascii -Force
 }
 
-$dllPath = Join-Path $mpvDir "libmpv-2.dll"
 if (-not (Test-Path $dllPath)) {
     throw "libmpv-2.dll not found in $mpvDir"
 }
@@ -50,9 +80,11 @@ if ($dumpbin -and $libExe) {
 Write-Host "Using dumpbin at: $dumpbinPath"
 Write-Host "Using lib at: $libPath"
 
-# Extract exports and generate mpv.def
-Set-Location $mpvDir
-$exports = & $dumpbinPath /exports libmpv-2.dll |
+# Absolute paths throughout: a Set-Location here outlives the script and would strand the caller
+# in .libmpv on any throw below.
+$defPath = Join-Path $mpvDir "mpv.def"
+$libOut = Join-Path $mpvDir "mpv.lib"
+$exports = & $dumpbinPath /exports $dllPath |
     Select-String -Pattern '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\w+)' |
     ForEach-Object { $_.Matches[0].Groups[1].Value }
 
@@ -60,10 +92,13 @@ if ($exports.Count -lt 50) {
     throw "Parsed only $($exports.Count) exports from libmpv-2.dll"
 }
 
-@("EXPORTS") + ($exports | ForEach-Object { "    $_" }) | Set-Content -Path "mpv.def" -Encoding ascii
-& $libPath /def:mpv.def /name:libmpv-2.dll /out:mpv.lib /machine:x64
+@("EXPORTS") + ($exports | ForEach-Object { "    $_" }) | Set-Content -Path $defPath -Encoding ascii
+# Cleared first, so a failed lib.exe cannot leave last run's mpv.lib to pass the check below.
+Remove-Item $libOut -ErrorAction SilentlyContinue
+& $libPath "/def:$defPath" /name:libmpv-2.dll "/out:$libOut" /machine:x64
+if ($LASTEXITCODE -ne 0) { throw "lib.exe exited $LASTEXITCODE generating mpv.lib" }
 
-if (-not (Test-Path (Join-Path $mpvDir "mpv.lib"))) {
+if (-not (Test-Path $libOut)) {
     throw "Failed to generate mpv.lib"
 }
 
@@ -80,8 +115,22 @@ $configContent = @"
 rustflags = ["-L", "native=$escapedMpvDir"]
 "@
 
-Set-Content -Path $cargoConfig -Value $configContent -Encoding utf8
-Write-Host "Configured .cargo/config.toml with rustflags"
+$configNote = $null
+if (-not (Test-Path $cargoConfig)) {
+    Set-Content -Path $cargoConfig -Value $configContent -Encoding utf8
+    Write-Host "Configured .cargo/config.toml with rustflags"
+} else {
+    # Whether an existing config already links mpv cannot be decided without a TOML parser: the path
+    # may be a basic or a literal string, the flag may sit under [build] or a [target.*] table, and
+    # RUSTFLAGS in the environment overrides both. Overwriting it would drop settings this script
+    # knows nothing about, so it is reported and left alone rather than edited or guessed at.
+    $configNote = "$cargoConfig already existed and was left untouched. Check that it, or `$env:RUSTFLAGS, passes -L native=$escapedMpvDir to rustc."
+}
 
-Set-Location $workspace
-Write-Host "Setup completed successfully!"
+if ($configNote) {
+    Write-Host ""
+    Write-Host "Setup finished. mpv.lib is built, but one thing needs your eyes:"
+    Write-Host "  $configNote"
+} else {
+    Write-Host "Setup completed successfully!"
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,7 +1,31 @@
-// The UI's only door to Rust. context/11 UI contract — commands in, events out. The UI never
-// touches YouTube; everything here is a Tauri command or event payload.
-import { invoke } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { invoke as tauriInvoke } from '@tauri-apps/api/core';
+import { listen as tauriListen, type UnlistenFn } from '@tauri-apps/api/event';
+
+export const isTauri = () =>
+	typeof window !== 'undefined' &&
+	('__TAURI_INTERNALS__' in window || '__TAURI_IPC__' in window || '__TAURI__' in window);
+
+function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+	if (!isTauri()) {
+		return Promise.reject(new Error(`Tauri IPC unavailable in browser mode (${cmd})`));
+	}
+	try {
+		return tauriInvoke<T>(cmd, args);
+	} catch (e) {
+		return Promise.reject(e);
+	}
+}
+
+function listen<T>(event: string, handler: (e: { payload: T }) => void): Promise<UnlistenFn> {
+	if (!isTauri()) {
+		return Promise.resolve(() => {});
+	}
+	try {
+		return tauriListen<T>(event, handler);
+	} catch {
+		return Promise.resolve(() => {});
+	}
+}
 
 /** How the signed-in user rated a track (innertube `Rating`). The three states are mutually
  *  exclusive: liking a disliked track clears the dislike, and vice versa. */

--- a/ui/src/lib/components/NowPlayingSidebar.svelte
+++ b/ui/src/lib/components/NowPlayingSidebar.svelte
@@ -1,0 +1,409 @@
+<script lang="ts">
+	import { fade, fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import {
+		Cancel01Icon,
+		FavouriteIcon,
+		Add01Icon,
+		PlayIcon,
+		PauseIcon,
+		MusicNote01Icon,
+		Video01Icon,
+		VideoOffIcon,
+		UserIcon,
+		Queue01Icon,
+		Mic01Icon,
+		InfinityIcon,
+		ArrowRight01Icon
+	} from '@hugeicons/core-free-icons';
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button';
+	import * as api from '$lib/api';
+	import type { ArtistPage, SongItem } from '$lib/api';
+	import {
+		playback,
+		prefs,
+		toggleNowPlayingLike,
+		openAddToPlaylist,
+		wheelVolume
+	} from '$lib/player.svelte';
+	import { thumb } from '$lib/thumb';
+	import ArtistLine from './ArtistLine.svelte';
+	import Marquee from './Marquee.svelte';
+	import TrackMenu from './TrackMenu.svelte';
+
+	let {
+		onClose,
+		onOpenQueue,
+		onOpenLyrics
+	}: {
+		onClose: () => void;
+		onOpenQueue?: () => void;
+		onOpenLyrics?: () => void;
+	} = $props();
+
+	// Artist info fetching
+	let artistInfo = $state<ArtistPage | null>(null);
+	let loadingArtist = $state(false);
+
+	$effect(() => {
+		const artistId = playback.now?.artistId;
+		artistInfo = null;
+		if (!artistId || api.isLocalId(artistId)) return;
+
+		let cancelled = false;
+		loadingArtist = true;
+		api.getArtist(artistId)
+			.then((data) => {
+				if (!cancelled) artistInfo = data;
+			})
+			.catch(() => {})
+			.finally(() => {
+				if (!cancelled) loadingArtist = false;
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// Like state animation
+	let justLiked = $state(false);
+	function toggleLike() {
+		if (playback.rating !== 'like') justLiked = true;
+		toggleNowPlayingLike();
+	}
+
+	// Current song & Next song in queue
+	const currentSong = $derived.by(() => {
+		const cur = playback.queue.items[playback.queue.currentIndex];
+		return cur?.video_id === playback.now?.videoId ? cur : null;
+	});
+
+	const nextSong = $derived.by<SongItem | null>(() => {
+		const items = playback.queue.items;
+		const nextIndex = playback.queue.currentIndex + 1;
+		if (nextIndex >= 0 && nextIndex < items.length) {
+			return items[nextIndex];
+		}
+		return null;
+	});
+
+	// Video playback logic for video songs
+	let wantVideo = $state(true);
+	let videoUrl = $state<string | null>(null);
+	let videoEl = $state<HTMLVideoElement | null>(null);
+	const canVideo = $derived(prefs.musicVideos && !!playback.now?.isVideo);
+	const showVideo = $derived(canVideo && wantVideo && !!videoUrl);
+
+	$effect(() => {
+		const id = playback.now?.videoId;
+		videoUrl = null;
+		if (!id || !canVideo || !wantVideo) return;
+		let cancelled = false;
+		api.videoStream(id, 480)
+			.then((u) => !cancelled && (videoUrl = u))
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	function mpvNow() {
+		if (playback.paused) return playback.position;
+		const since = (performance.now() - playback.positionAt) / 1000;
+		if (since > 0.4) return playback.position;
+		return playback.position + since * playback.speed;
+	}
+
+	function syncVideo() {
+		const el = videoEl;
+		if (!el || !showVideo || el.seeking || el.readyState < 1) return;
+		const drift = mpvNow() - el.currentTime;
+		if (Math.abs(drift) > 2.5) {
+			el.playbackRate = playback.speed;
+			el.currentTime = mpvNow() + (playback.paused ? 0 : 1);
+		}
+	}
+
+	$effect(() => {
+		playback.position;
+		playback.paused;
+		syncVideo();
+	});
+
+	$effect(() => {
+		const paused = playback.paused;
+		const el = videoEl;
+		if (!el || !showVideo) return;
+		if (paused) el.pause();
+		else el.play().catch(() => {});
+	});
+
+	const sourceTitle = $derived(playback.queue.sourceName || 'Now Playing');
+</script>
+
+<!-- Backdrop scrim below lg screen size -->
+<button
+	class="absolute inset-0 z-20 cursor-default bg-black/40 lg:hidden"
+	onclick={onClose}
+	aria-label="Close now playing sidebar"
+	transition:fade={{ duration: 150 }}
+></button>
+
+<!-- Spotify-like Now Playing Sidebar -->
+<aside
+	transition:fly={{ x: 32, duration: 220, easing: cubicOut }}
+	class="absolute inset-y-0 right-0 z-30 flex h-full w-80 max-w-[85vw] flex-col border-l bg-card shadow-2xl lg:w-88 xl:w-96"
+>
+	<!-- Header -->
+	<div class="flex items-center justify-between border-b px-4 py-3">
+		<div class="min-w-0 flex-1 pr-2">
+			<div class="truncate text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+				{sourceTitle}
+			</div>
+		</div>
+		<Button
+			variant="ghost"
+			size="icon-sm"
+			onclick={onClose}
+			aria-label="Close sidebar"
+			class="hover:text-foreground"
+		>
+			<HugeiconsIcon icon={Cancel01Icon} class="h-4 w-4" />
+		</Button>
+	</div>
+
+	<!-- Scrollable Body -->
+	<div class="flex-1 overflow-y-auto p-4 space-y-5">
+		<!-- Artwork / Video Card -->
+		<div class="relative group overflow-hidden rounded-xl bg-muted shadow-lg" onwheel={wheelVolume}>
+			{#if showVideo}
+				<!-- svelte-ignore a11y_media_has_caption -->
+				<video
+					bind:this={videoEl}
+					src={videoUrl}
+					muted
+					playsinline
+					preload="auto"
+					onloadedmetadata={syncVideo}
+					oncanplay={syncVideo}
+					onerror={() => (videoUrl = null)}
+					class="aspect-square w-full bg-black object-contain"
+				></video>
+			{:else if playback.now?.thumbnail}
+				<img
+					src={thumb(playback.now.thumbnail, 400)}
+					alt={playback.now.title}
+					class="aspect-square w-full object-cover transition-transform duration-300 group-hover:scale-105"
+				/>
+			{:else}
+				<div class="flex aspect-square w-full items-center justify-center bg-muted text-muted-foreground/40">
+					<HugeiconsIcon icon={MusicNote01Icon} class="h-16 w-16" />
+				</div>
+			{/if}
+
+			<!-- Video toggle button -->
+			{#if canVideo}
+				<button
+					type="button"
+					onclick={() => (wantVideo = !wantVideo)}
+					aria-label={showVideo ? 'Show artwork' : 'Show video'}
+					class="absolute right-2 top-2 z-10 cursor-pointer rounded-md bg-black/50 p-1.5 text-white/80 transition-colors hover:text-white"
+				>
+					<HugeiconsIcon
+						icon={Video01Icon}
+						altIcon={VideoOffIcon}
+						showAlt={showVideo}
+						class="h-4 w-4"
+					/>
+				</button>
+			{/if}
+		</div>
+
+		<!-- Track Title & Artist Info -->
+		<div class="space-y-1.5">
+			<div class="flex items-start justify-between gap-2">
+				<div class="min-w-0 flex-1">
+					<Marquee
+						text={playback.now?.title ?? 'Nothing playing'}
+						class="text-base font-bold tracking-tight text-foreground"
+					/>
+					<ArtistLine
+						runs={playback.now?.artistRuns}
+						text={playback.now?.artists ?? ''}
+						marquee
+						class="block max-w-full text-sm text-muted-foreground hover:text-foreground"
+					/>
+				</div>
+
+				<!-- Track Action Buttons (Like, Add to playlist, Menu) -->
+				{#if playback.now}
+					<div class="flex items-center gap-0.5 shrink-0 pt-0.5">
+						{#if !api.isLocalId(playback.now.videoId)}
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								onclick={toggleLike}
+								aria-label="Like"
+								class="hover:text-primary"
+							>
+								<span
+									class="inline-flex"
+									class:animate-heart-pop={justLiked}
+									onanimationend={() => (justLiked = false)}
+								>
+									<HugeiconsIcon
+										icon={FavouriteIcon}
+										class="h-4.5 w-4.5 {playback.rating === 'like'
+											? 'fill-current text-primary'
+											: 'text-muted-foreground'}"
+									/>
+								</span>
+							</Button>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								onclick={() => {
+									const now = playback.now!;
+									openAddToPlaylist({
+										video_id: now.videoId,
+										title: now.title,
+										artists: now.artists,
+										artist_id: now.artistId,
+										thumbnail: now.thumbnail,
+										duration: now.duration
+									});
+								}}
+								aria-label="Add to playlist"
+							>
+								<HugeiconsIcon icon={Add01Icon} class="h-4.5 w-4.5 text-muted-foreground" />
+							</Button>
+						{/if}
+						{#if currentSong}
+							<TrackMenu
+								song={currentSong}
+								linksOnly
+								onAdd={() => openAddToPlaylist(currentSong!)}
+								triggerClass="inline-flex size-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground"
+							/>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<!-- About the Artist Card (Spotify-Style) -->
+		{#if playback.now?.artistId || playback.now?.artists}
+			<div class="overflow-hidden rounded-xl border bg-muted/40 p-4 transition-colors hover:bg-muted/60">
+				<div class="flex items-center justify-between pb-3">
+					<span class="text-xs font-bold uppercase tracking-wider text-muted-foreground">About the artist</span>
+					{#if playback.now?.artistId}
+						<button
+							onclick={() => goto(`/artist/${encodeURIComponent(playback.now!.artistId!)}`)}
+							class="flex items-center gap-1 text-xs font-semibold text-primary hover:underline"
+						>
+							View profile
+							<HugeiconsIcon icon={ArrowRight01Icon} class="h-3 w-3" />
+						</button>
+					{/if}
+				</div>
+
+				<div class="flex items-center gap-3">
+					<div class="relative h-14 w-14 shrink-0 overflow-hidden rounded-full bg-muted shadow">
+						{#if artistInfo?.thumbnail}
+							<img src={thumb(artistInfo.thumbnail, 120)} alt="" class="h-full w-full object-cover" />
+						{:else if playback.now?.thumbnail}
+							<img src={thumb(playback.now.thumbnail, 120)} alt="" class="h-full w-full object-cover" />
+						{:else}
+							<div class="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
+								<HugeiconsIcon icon={UserIcon} class="h-6 w-6" />
+							</div>
+						{/if}
+					</div>
+
+					<div class="min-w-0 flex-1">
+						<div class="truncate text-sm font-bold text-foreground">
+							{artistInfo?.name || playback.now?.artists || 'Artist'}
+						</div>
+						{#if artistInfo?.subscribers}
+							<div class="text-xs text-muted-foreground">
+								{artistInfo.subscribers} subscribers
+							</div>
+						{:else if artistInfo?.monthlyListeners}
+							<div class="text-xs text-muted-foreground">
+								{artistInfo.monthlyListeners} monthly listeners
+							</div>
+						{/if}
+					</div>
+				</div>
+
+				{#if artistInfo?.description}
+					<p class="mt-3 line-clamp-3 text-xs leading-relaxed text-muted-foreground">
+						{artistInfo.description}
+					</p>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Next in Queue Card -->
+		{#if nextSong}
+			<div class="rounded-xl border bg-muted/40 p-4">
+				<div class="flex items-center justify-between pb-2.5">
+					<span class="text-xs font-bold uppercase tracking-wider text-muted-foreground">Next in queue</span>
+					{#if onOpenQueue}
+						<button
+							onclick={onOpenQueue}
+							class="text-xs font-semibold text-primary hover:underline"
+						>
+							Open queue
+						</button>
+					{/if}
+				</div>
+
+				<div class="flex items-center gap-3">
+					<div class="h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-muted">
+						{#if nextSong.thumbnail}
+							<img src={thumb(nextSong.thumbnail, 96)} alt="" class="h-full w-full object-cover" />
+						{:else}
+							<div class="flex h-full w-full items-center justify-center text-muted-foreground/50">
+								<HugeiconsIcon icon={MusicNote01Icon} class="h-4 w-4" />
+							</div>
+						{/if}
+					</div>
+					<div class="min-w-0 flex-1">
+						<div class="truncate text-xs font-semibold text-foreground">{nextSong.title}</div>
+						<div class="truncate text-[11px] text-muted-foreground">{nextSong.artists}</div>
+					</div>
+				</div>
+			</div>
+		{/if}
+
+		<!-- Quick Lyrics / Queue Panel Switcher Buttons -->
+		<div class="flex items-center gap-2 pt-1">
+			{#if onOpenLyrics}
+				<Button
+					variant="outline"
+					size="sm"
+					class="flex-1 gap-2 text-xs"
+					onclick={onOpenLyrics}
+				>
+					<HugeiconsIcon icon={Mic01Icon} class="h-3.5 w-3.5" />
+					Lyrics
+				</Button>
+			{/if}
+			{#if onOpenQueue}
+				<Button
+					variant="outline"
+					size="sm"
+					class="flex-1 gap-2 text-xs"
+					onclick={onOpenQueue}
+				>
+					<HugeiconsIcon icon={Queue01Icon} class="h-3.5 w-3.5" />
+					Full Queue
+				</Button>
+			{/if}
+		</div>
+	</div>
+</aside>

--- a/ui/src/lib/components/PlayerBar.svelte
+++ b/ui/src/lib/components/PlayerBar.svelte
@@ -17,6 +17,7 @@
 		InfinityIcon,
 		MinimizeScreenIcon,
 		MusicNote01Icon,
+		InformationCircleIcon,
 		ArrowUp01Icon,
 		ArrowDown01Icon
 	} from '@hugeicons/core-free-icons';
@@ -336,6 +337,18 @@
 		</div>
 		<!-- One cluster, so they sit tighter to each other than to the volume slider. -->
 		<div class="flex items-center gap-0.5">
+			<Button
+				variant={np.sidebarOpen ? 'secondary' : 'ghost'}
+				size="icon-sm"
+				onclick={() => {
+					np.sidebarOpen = !np.sidebarOpen;
+					if (np.sidebarOpen) np.open = false;
+				}}
+				aria-label="Now playing view"
+				title="Now playing view"
+			>
+				<HugeiconsIcon icon={InformationCircleIcon} class="h-5 w-5" />
+			</Button>
 			<Button variant="ghost" size="icon-sm" onclick={openMiniPlayer} aria-label="Mini player">
 				<HugeiconsIcon icon={MinimizeScreenIcon} class="h-5 w-5" />
 			</Button>
@@ -360,7 +373,10 @@
 			<Button
 				variant="ghost"
 				size="icon-sm"
-				onclick={() => (np.open = !np.open)}
+				onclick={() => {
+					np.open = !np.open;
+					if (np.open) np.sidebarOpen = false;
+				}}
 				aria-label={np.open ? 'Minimise player' : 'Open player'}
 				aria-expanded={np.open}
 			>

--- a/ui/src/lib/components/PlayerBar.svelte
+++ b/ui/src/lib/components/PlayerBar.svelte
@@ -338,11 +338,18 @@
 		<!-- One cluster, so they sit tighter to each other than to the volume slider. -->
 		<div class="flex items-center gap-0.5">
 			<Button
-				variant={np.sidebarOpen ? 'secondary' : 'ghost'}
+				variant={np.sidebarOpen && !np.open ? 'secondary' : 'ghost'}
 				size="icon-sm"
 				onclick={() => {
+					// The full view hides the sidebar rather than closing it, so while it is up this
+					// has to bring the sidebar back. Toggling the flag instead would spend the click
+					// turning off something already off screen.
+					if (np.open) {
+						np.open = false;
+						np.sidebarOpen = true;
+						return;
+					}
 					np.sidebarOpen = !np.sidebarOpen;
-					if (np.sidebarOpen) np.open = false;
 				}}
 				aria-label="Now playing view"
 				title="Now playing view"
@@ -369,14 +376,12 @@
 				<HugeiconsIcon icon={Queue01Icon} class="h-5 w-5" />
 			</Button>
 			<!-- The keyboard (and discoverable) way in and out of the now-playing view; clicking the
-			     bar's empty space does the same thing. -->
+			     bar's empty space and Ctrl+E do the same thing. The sidebar is left alone on the way
+			     in: the layout already hides it while `np.open`, so it comes back on the way out. -->
 			<Button
 				variant="ghost"
 				size="icon-sm"
-				onclick={() => {
-					np.open = !np.open;
-					if (np.open) np.sidebarOpen = false;
-				}}
+				onclick={() => (np.open = !np.open)}
 				aria-label={np.open ? 'Minimise player' : 'Open player'}
 				aria-expanded={np.open}
 			>

--- a/ui/src/lib/components/ResizeBorders.svelte
+++ b/ui/src/lib/components/ResizeBorders.svelte
@@ -16,12 +16,12 @@
 		| 'SouthEast'
 		| 'SouthWest';
 
-	const w = getCurrentWindow();
-
 	function start(e: MouseEvent, dir: Dir) {
-		if (e.button !== 0) return;
+		if (e.button !== 0 || typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return;
 		e.preventDefault();
-		w.startResizeDragging(dir).catch(() => {});
+		try {
+			getCurrentWindow().startResizeDragging(dir).catch(() => {});
+		} catch {}
 	}
 
 	// Edges are 4px, corners 8px (corners win by being later in the DOM at the overlap).

--- a/ui/src/lib/components/SettingsDialog.svelte
+++ b/ui/src/lib/components/SettingsDialog.svelte
@@ -469,7 +469,7 @@
 							<div class={CARD}>
 								{@render row({
 									title: 'Open the player when you press play',
-									desc: 'On, playing a song, album or playlist brings up the full player view. Off, it starts playing and leaves you on the page you were browsing.',
+									desc: 'On, playing a song, album or playlist opens the now playing sidebar beside the page. Off, nothing opens and you stay exactly where you are.',
 									control: openPlayerSwitch,
 									tall: true
 								})}

--- a/ui/src/lib/components/Titlebar.svelte
+++ b/ui/src/lib/components/Titlebar.svelte
@@ -30,7 +30,12 @@
 	import { lt } from '$lib/lt.svelte';
 	import { anchorMenu, fitMenu, NO_ANCHOR } from '$lib/menu';
 
-	const win = getCurrentWindow();
+	function getWin() {
+		if (typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window) {
+			return getCurrentWindow();
+		}
+		return null;
+	}
 
 	// Back/forward. `depth` is how many history entries deep the session is, `deepest` how far it
 	// has ever been, so both buttons grey out instead of doing nothing. popstate carries a signed
@@ -271,21 +276,21 @@
 
 		<button
 			class="flex h-full w-11 items-center justify-center text-muted-foreground transition-colors hover:bg-accent/10 hover:text-foreground"
-			onclick={() => win.minimize()}
+			onclick={() => getWin()?.minimize()}
 			aria-label="Minimize"
 		>
 			<HugeiconsIcon icon={MinusSignIcon} class="h-4 w-4" />
 		</button>
 		<button
 			class="flex h-full w-11 items-center justify-center text-muted-foreground transition-colors hover:bg-accent/10 hover:text-foreground"
-			onclick={() => win.toggleMaximize()}
+			onclick={() => getWin()?.toggleMaximize()}
 			aria-label="Maximize"
 		>
 			<HugeiconsIcon icon={SquareIcon} class="h-3.5 w-3.5" />
 		</button>
 		<button
 			class="flex h-full w-11 items-center justify-center text-muted-foreground transition-colors hover:text-destructive"
-			onclick={() => win.close()}
+			onclick={() => getWin()?.close()}
 			aria-label="Close"
 		>
 			<HugeiconsIcon icon={Cancel01Icon} class="h-4 w-4" />

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -40,17 +40,22 @@ export const playback = $state({
 });
 
 /**
- * The full-window now-playing view (NowPlaying.svelte): big artwork, plus the Queue/Lyrics tabs.
- * It lives here rather than in the layout because starting something playing opens it, and every
+ * `open` is the full-window now-playing view (NowPlaying.svelte): big artwork, plus the
+ * Queue/Lyrics tabs. `sidebarOpen` is the docked panel beside the page. Both can be true at once:
+ * the layout renders the sidebar only while `!open`, so the full view hides it rather than closing
+ * it, and dismissing the full view brings it back.
+ * This lives here rather than in the layout because starting something playing opens it, and every
  * "play this" path already goes through this module. The open has to happen at the click: a
  * gapless advance looks exactly like a user play from the `now-playing` event alone.
+ * `sidebarOpen` starts false so the auto-open preference decides the first one, not this default.
  */
-export const np = $state({ open: false, sidebarOpen: true, tab: 'queue' as 'queue' | 'lyrics' });
+export const np = $state({ open: false, sidebarOpen: false, tab: 'queue' as 'queue' | 'lyrics' });
 
 export const prefs = $state({ musicVideos: false });
 
-/** Show the right Now Playing sidebar when playback starts. */
+/** No-op when the user has turned the auto-open off (#64): playback starts, the view stays put. */
 export const openPlayer = () => {
+	if (!appearance.openPlayerOnPlay) return;
 	np.sidebarOpen = true;
 	np.open = false;
 };

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -45,18 +45,14 @@ export const playback = $state({
  * "play this" path already goes through this module. The open has to happen at the click: a
  * gapless advance looks exactly like a user play from the `now-playing` event alone.
  */
-export const np = $state({ open: false, tab: 'queue' as 'queue' | 'lyrics' });
+export const np = $state({ open: false, sidebarOpen: true, tab: 'queue' as 'queue' | 'lyrics' });
 
-/**
- * Backend settings the app has to know outside the settings modal (which holds the rest in its own
- * local state). Hydrated once in `initApp`; the modal writes here too, so a toggle takes effect
- * without a reload.
- */
 export const prefs = $state({ musicVideos: false });
 
-/** No-op when the user has turned the auto-open off (#64): playback starts, the view stays put. */
+/** Show the right Now Playing sidebar when playback starts. */
 export const openPlayer = () => {
-	if (appearance.openPlayerOnPlay) np.open = true;
+	np.sidebarOpen = true;
+	np.open = false;
 };
 
 /** Play one track (a search row, a song card, a shelf), and show it. */

--- a/ui/src/lib/theme.svelte.ts
+++ b/ui/src/lib/theme.svelte.ts
@@ -94,7 +94,7 @@ export const appearance = $state({
 	 * side panels, which then sit over the now-playing view like they sit over a page (#62).
 	 */
 	tabbedPlayer: true,
-	/** Starting playback opens the now-playing view. Off, it plays and leaves you where you are (#64). */
+	/** Starting playback opens the now-playing sidebar. Off, it plays and opens nothing (#64). */
 	openPlayerOnPlay: true,
 	/** Take the accent colour from the playing track's cover, crossfading on each change. */
 	artworkAccent: false

--- a/ui/src/lib/win.svelte.ts
+++ b/ui/src/lib/win.svelte.ts
@@ -9,18 +9,18 @@ let started = false;
 export function initWin(): () => void {
 	if (started) return () => {};
 	started = true;
-	const w = getCurrentWindow();
-	// The window is created hidden (tauri.conf.json) so the window-state plugin can restore the
-	// saved size before anything is on screen: it only restores once the webview is ready, so a
-	// visible window would flash at the config's 1200x800, white, then snap (#45). By here the SPA
-	// has mounted, so showing it now costs nothing and skips the flash.
-	w.show().catch(() => {});
-	const sync = () =>
-		w
-			.isMaximized()
-			.then((m) => (win.maximized = m))
-			.catch(() => {});
-	sync();
-	const un = w.onResized(sync);
-	return () => un.then((u) => u());
+	try {
+		const w = getCurrentWindow();
+		w.show().catch(() => {});
+		const sync = () =>
+			w
+				.isMaximized()
+				.then((m) => (win.maximized = m))
+				.catch(() => {});
+		sync();
+		const un = w.onResized(sync);
+		return () => { un.then((u) => u()).catch(() => {}); };
+	} catch {
+		return () => {};
+	}
 }

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -31,6 +31,7 @@
 	import LinkDialog from '$lib/components/LinkDialog.svelte';
 	import MiniPlayer from '$lib/components/MiniPlayer.svelte';
 	import NowPlaying from '$lib/components/NowPlaying.svelte';
+	import NowPlayingSidebar from '$lib/components/NowPlayingSidebar.svelte';
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
 	import KeyboardShortcuts from '$lib/components/KeyboardShortcuts.svelte';
 	import { Button } from '$lib/components/ui/button';
@@ -79,7 +80,15 @@
 	// The mini player runs this same SPA in a second window (Rust `mini.rs`), so the window label is
 	// what tells the two apart: `mini` gets the widget instead of the app chrome, and none of the
 	// routes below it are ever rendered. Constant for the window's lifetime.
-	const isMini = browser && getCurrentWindow().label === 'mini';
+	const isMini =
+		browser &&
+		(() => {
+			try {
+				return getCurrentWindow().label === 'mini';
+			} catch {
+				return false;
+			}
+		})();
 
 	// Apply the saved accent color before the first paint (ssr=false → nothing renders until now).
 	if (browser) initTheme();
@@ -144,6 +153,19 @@
 			<!-- Lyrics before queue: side by side over the page, lyrics on the left, queue on the right. -->
 			{#if lyricsOpen}<LyricsPanel onClose={() => (lyricsOpen = false)} {queueOpen} />{/if}
 			{#if queueOpen}<QueuePanel onClose={() => (queueOpen = false)} />{/if}
+			{#if np.sidebarOpen && playback.now && !np.open}
+				<NowPlayingSidebar
+					onClose={() => (np.sidebarOpen = false)}
+					onOpenQueue={() => {
+						queueOpen = true;
+						np.sidebarOpen = false;
+					}}
+					onOpenLyrics={() => {
+						lyricsOpen = true;
+						np.sidebarOpen = false;
+					}}
+				/>
+			{/if}
 		</div>
 		{#if playback.now}
 			<!-- Slides up from its own height on first play; leaves instantly (bar removal is rare).


### PR DESCRIPTION
added an option to have a now playing sidebar option so that it pops up on the side and on the same level as the queue for a look that feels similar to spotify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a now-playing sidebar with artwork or video, track actions, artist details, queue previews, and lyrics navigation.
  * Added controls to open and close the sidebar from the player bar.
  * Added verified mpv support to Windows setup and release builds.

* **Bug Fixes**
  * Improved browser-mode compatibility and desktop window control reliability.
  * Improved window resizing and initialization error handling.
  * Updated playback view behavior and sidebar defaults.
  * Removed platform-specific startup workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->