### PR TITLE
fix(uploads): a real fallback chain for your own uploads, and a Library tab to find them in

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -613,8 +613,18 @@ fn spawn_event_pump(
                     // The track died (dead/403 URL etc). on_track_failed records a WEB_REMIX 403
                     // (context/06 §2), evicts the poisoned cache, and retries the track once via
                     // the fallback clients — only toast the error if it gave up and advanced.
-                    tracing::warn!(error = %msg, "track failed");
+                    //
+                    // Read the client before the retry: it advances the queue when it gives up,
+                    // and which client served the dead URL is the one fact a bug report has to
+                    // carry. Nobody can read the log on Windows (no console, no log file), so it
+                    // goes in the message the user can see and copy. Issue #71.
+                    let client = state.current_stream_client().await;
+                    tracing::warn!(error = %msg, client = ?client, "track failed");
                     if !state.on_track_failed().await {
+                        let msg = match client {
+                            Some(c) => format!("{msg} ({c})"),
+                            None => msg,
+                        };
                         let _ = app.emit("playback-error", serde_json::json!({ "message": msg }));
                     }
                 }

--- a/src-tauri/src/orchestrator.rs
+++ b/src-tauri/src/orchestrator.rs
@@ -2,11 +2,13 @@
 //!
 //! Phase 2: WEB_REMIX is the primary client (STS + PoToken + cipher/n-transform), with the
 //! direct-URL clients (VISIONOS → ANDROID_VR → IOS) as graceful fallback and rustypipe as the
-//! last-ditch net. All seven context/06 critical behaviors are preserved: metadata from MAIN,
-//! WEB_REMIX skips HEAD (with per-videoId failure memory), last client accepted unvalidated,
-//! HIGH two-pass, off-hot-path self-heal, and graceful PoToken/cipher degradation.
+//! last-ditch net. The context/06 critical behaviors are preserved: metadata from MAIN, the
+//! per-videoId WEB_REMIX failure memory, the HIGH two-pass, off-hot-path self-heal, and graceful
+//! PoToken/cipher degradation. Every client is HEAD-validated (see the note in `resolve`); for an
+//! upload a failed HEAD demotes the URL instead of rejecting it, because there is no anonymous
+//! chain behind an upload to fall through to.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -197,18 +199,22 @@ impl Orchestrator {
 
         // 4. Fallback loop. idx == -1 reuses the main response; 0.. are the fallback clients.
         let mut best: Option<Candidate> = None;
+        // A login client's upload URL that failed HEAD. Used only if nothing validates.
+        let mut upload_fallback: Option<Candidate> = None;
         let last_idx = order.len() as isize - 1;
 
         for idx in -1..=last_idx {
             let (key, resp): (String, PlayerResponse) = if idx == -1 {
                 // A WEB_REMIX stream that already died in the player is not retried for this
                 // video: it passed HEAD and failed anyway, so validation has nothing left to say.
-                // Not for an upload: WEB_REMIX and WEB_CREATOR are the only login clients that
-                // can serve one, and both hang off this slot (WEB_CREATOR via the gate retry
-                // above). Honouring the memory here would leave attempt two with nothing at all.
+                // Uploads included. This used to exempt them, on the belief that skipping this
+                // slot left the retry with nothing, but the rest of `UPLOAD_FALLBACK_ORDER`
+                // (TVHTML5, then WEB_CREATOR) is exactly what the retry is for. Exempting them
+                // meant the second attempt re-resolved the same dead WEB_REMIX URL and failed
+                // identically, which is the loop issue #71 has been stuck in.
                 if !main_ok
                     || disabled.contains(MAIN_CLIENT)
-                    || (!is_upload && self.web_remix_failed.lock().await.contains(video_id))
+                    || self.web_remix_failed.lock().await.contains(video_id)
                 {
                     continue;
                 }
@@ -283,10 +289,10 @@ impl Orchestrator {
             // - WEB_REMIX skipped it on Metrolist's note that its authed URLs 403 on HEAD but
             //   stream on GET. That holds for ExoPlayer, which fetches in bounded ranges. mpv opens
             //   with `Range: bytes=0-`, and for the videos where googlevideo caps a WEB_REMIX URL
-            //   (only the first ~768 KiB is served, in ≤256 KiB pieces) that open-ended request
+            //   (only the first ~768 KiB is served, in <=256 KiB pieces) that open-ended request
             //   gets the same 403 the HEAD does.
             //
-            // Measured on fresh URLs, HEAD agrees with what mpv gets every time — 200/206 for
+            // Measured on fresh URLs, HEAD agrees with what mpv gets every time: 200/206 for
             // dQw4w9WgXcQ, 403/403 for XqZsoesa55w and D07O_cbJ_Rw. So the check costs one
             // round trip and turns a guaranteed failed load, an error toast, a retry and a round
             // of cipher/PoToken self-heal churn into a silent fall-through at resolve time.
@@ -294,19 +300,12 @@ impl Orchestrator {
             // It also stays correct if a valid PoToken lifts the cap on those videos: then HEAD
             // passes and WEB_REMIX is used. Nothing here has to know which way that goes.
             //
-            // EXCEPT for an upload, which is not validated at all. A privately-owned track's URL
-            // is bound to the session that owns it, and a HEAD against it does not predict what
-            // mpv's GET gets: it passes for some accounts' uploads and 403s for others' (issue
-            // #71, and Metrolist stopped validating private tracks for the same reason, PR #3517).
-            // Every client in `UPLOAD_FALLBACK_ORDER` is authenticated and there is nothing behind
-            // the chain to fall through to, so the first one that produced a URL is the best
-            // answer available. Rejecting it only turns a stream that would have played into a
-            // "sign-in needed" skip.
-            //
-            // Short-circuit, so the `else if` below is unreachable for an upload: a failed HEAD
-            // that says nothing must not invalidate the session PoToken or churn the cipher
-            // config, which is playback-wide damage done on behalf of one track.
-            if is_upload || self.validate_head(&url, client.map(|c| c.user_agent.as_str())).await {
+            // The probe sends exactly the headers `build` will hand mpv (same UA, cookie only
+            // where mpv gets one), because a HEAD that carries something the real GET does not
+            // is not a prediction of anything. Issue #71.
+            let headers =
+                stream_headers(client.map(|c| c.user_agent.clone()), self.it.cookie(), is_upload);
+            if self.validate_head(&url, &headers).await {
                 let ping = main_ping.clone().or_else(|| playback_ping(&resp, &key));
                 return Ok(self.build(
                     video_id,
@@ -317,29 +316,39 @@ impl Orchestrator {
                     audio_config_loudness,
                     &main_resp,
                     ping,
-                    is_upload,
+                    headers,
                 ));
-            } else if needs_n {
-                // A cipher client that fails validation may have a stale config → self-heal off
-                // the hot path so it never blocks falling through (context/06 §7). If the heal
-                // changes the config table, clear the WEB_REMIX failure memory (context/06 §2).
-                let cipher = self.cipher.clone();
-                let potoken = self.potoken.clone();
-                let failed = self.web_remix_failed.clone();
-                tauri::async_runtime::spawn(async move {
-                    // The session PoToken now outlives the process, so a rejected web stream is
-                    // the only signal left that Google stopped honouring it early. Drop it here
-                    // rather than replay it for the rest of its nominal 12 hours.
-                    potoken.invalidate_session_token().await;
-                    if cipher.on_stream_rejected().await {
-                        failed.lock().await.clear();
-                    }
-                });
+            }
+
+            // An upload's failed HEAD is a demotion, never a rejection. Metrolist stopped
+            // validating privately-owned tracks outright (PR #3517) because a HEAD against one
+            // does not reliably predict its GET, and this app then went further and returned the
+            // very first URL unvalidated. That made WEB_REMIX the only client an upload ever
+            // used: TVHTML5 and WEB_CREATOR sat behind an unconditional `return` and could never
+            // run, so an account whose WEB_REMIX URLs 403 (no accepted PoToken on that machine, a
+            // stale cipher) had no second chance and no way to recover. Issue #71.
+            //
+            // So: keep the first URL as a last resort, let the rest of the chain have its turn,
+            // and hand the unvalidated one back only if nothing better turns up. Worst case this
+            // is what the old code did, one or two round trips later.
+            if is_upload {
+                if upload_fallback.is_none() {
+                    tracing::info!(video_id, client = %key, "upload stream failed HEAD, trying the next login client");
+                    let ping = main_ping.clone().or_else(|| playback_ping(&resp, &key));
+                    upload_fallback =
+                        Some(Candidate { format: format.clone(), url, expires, client: key, ping });
+                }
+                continue;
+            }
+
+            if needs_n {
+                self.self_heal();
             }
         }
 
         // 6. HIGH wanted but only a non-HIGH found → use the remembered best.
         if let Some(c) = best {
+            let headers = self.headers_for(&c.client, is_upload);
             return Ok(self.build(
                 video_id,
                 &c.format,
@@ -349,7 +358,30 @@ impl Orchestrator {
                 audio_config_loudness,
                 &main_resp,
                 c.ping,
-                is_upload,
+                headers,
+            ));
+        }
+
+        // 6b. An upload nothing validated: hand back the first URL a login client produced
+        // rather than skip the track. See the demotion note in the loop.
+        if let Some(c) = upload_fallback {
+            tracing::warn!(video_id, client = %c.client, "no upload stream passed HEAD, using the first anyway");
+            // Every login client's URL was refused, which is the one upload failure that does say
+            // something about the session rather than about the track. Heal off the hot path so a
+            // machine stuck on a rejected PoToken or a stale cipher can get itself out; without
+            // this an upload-only failure had no route back at all.
+            self.self_heal();
+            let headers = self.headers_for(&c.client, is_upload);
+            return Ok(self.build(
+                video_id,
+                &c.format,
+                c.url,
+                c.expires,
+                &c.client,
+                audio_config_loudness,
+                &main_resp,
+                c.ping,
+                headers,
             ));
         }
 
@@ -426,17 +458,45 @@ impl Orchestrator {
     }
 
     /// HEAD validation (context/06 §validateStatus). Success = 2xx. False on any error.
-    async fn validate_head(&self, url: &str, ua: Option<&str>) -> bool {
+    ///
+    /// `headers` is what mpv will send for this stream, so the probe is the same request the
+    /// player will make. It used to always attach the cookie while `build` attached it only for
+    /// uploads, which let an ordinary track pass validation and then 403 on the real open.
+    async fn validate_head(&self, url: &str, headers: &HashMap<String, String>) -> bool {
         // The 10s budget used to live on a client of its own; it is a property of this one
         // probe, not of the app's HTTP.
         let mut req = crate::http::client().head(url).timeout(Duration::from_secs(10));
-        if let Some(ua) = ua {
-            req = req.header("User-Agent", ua);
-        }
-        if let Some(cookie) = self.it.cookie() {
-            req = req.header("Cookie", cookie.as_str());
+        for (k, v) in headers {
+            req = req.header(k, v);
         }
         matches!(req.send().await, Ok(r) if r.status().is_success())
+    }
+
+    /// A cipher client's stream was refused → its config may be stale. Heal off the hot path so
+    /// it never blocks falling through (context/06 §7). If the heal changes the config table,
+    /// clear the WEB_REMIX failure memory (context/06 §2).
+    fn self_heal(&self) {
+        let cipher = self.cipher.clone();
+        let potoken = self.potoken.clone();
+        let failed = self.web_remix_failed.clone();
+        tauri::async_runtime::spawn(async move {
+            // The session PoToken now outlives the process, so a rejected web stream is the only
+            // signal left that Google stopped honouring it early. Drop it here rather than replay
+            // it for the rest of its nominal 12 hours.
+            potoken.invalidate_session_token().await;
+            if cipher.on_stream_rejected().await {
+                failed.lock().await.clear();
+            }
+        });
+    }
+
+    /// [`stream_headers`] for a client registry key.
+    fn headers_for(&self, client: &str, is_upload: bool) -> HashMap<String, String> {
+        stream_headers(
+            self.clients.get(client).map(|c| c.user_agent.clone()),
+            self.it.cookie(),
+            is_upload,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -450,26 +510,8 @@ impl Orchestrator {
         loudness: Option<f64>,
         main_resp: &Option<PlayerResponse>,
         ping: Option<PlaybackPing>,
-        is_upload: bool,
+        headers: HashMap<String, String>,
     ) -> PlaybackData {
-        let ua = self.clients.get(client).map(|c| c.user_agent.clone());
-        let mut headers = std::collections::HashMap::new();
-        if let Some(ua) = ua {
-            headers.insert("User-Agent".to_owned(), ua);
-        }
-        // A privately-owned track's googlevideo URL is only served to the session that owns it, so
-        // mpv's GET has to carry the cookie too. `validate_head` already sends it, which is how an
-        // upload could pass HEAD and then 403 on the real open. Uploads only: this is the hot path
-        // and there is no evidence an ordinary stream wants a cookie. Issue #71.
-        //
-        // mpv's header properties are global (crates/player: `http-header-fields`), so a track
-        // appended for gapless playback inherits whatever the current one set. Same host either
-        // way, so it is harmless, but it means the cookie can outlive the upload that needed it.
-        if is_upload {
-            if let Some(cookie) = self.it.cookie() {
-                headers.insert("Cookie".to_owned(), cookie.to_string());
-            }
-        }
         let vd = main_resp.as_ref().and_then(|r| r.video_details.as_ref());
         tracing::info!(video_id, client, itag = format.itag, "resolved stream");
         PlaybackData {
@@ -488,6 +530,32 @@ impl Orchestrator {
             stream_client: client.to_owned(),
         }
     }
+}
+
+/// The headers mpv (and the validating HEAD) must send for one stream.
+///
+/// A privately-owned track's googlevideo URL is only served to the session that owns it, so an
+/// upload's GET has to carry the cookie. Uploads only: this is the hot path and there is no
+/// evidence an ordinary stream wants one. Issue #71.
+///
+/// mpv's header properties are global (crates/player: `http-header-fields`), so a track appended
+/// for gapless playback inherits whatever the current one set. Same host either way, so it is
+/// harmless, but it means the cookie can outlive the upload that needed it.
+fn stream_headers(
+    ua: Option<String>,
+    cookie: Option<String>,
+    is_upload: bool,
+) -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    if let Some(ua) = ua {
+        headers.insert("User-Agent".to_owned(), ua);
+    }
+    if is_upload {
+        if let Some(cookie) = cookie {
+            headers.insert("Cookie".to_owned(), cookie);
+        }
+    }
+    headers
 }
 
 fn is_high(f: &Format) -> bool {
@@ -536,4 +604,28 @@ fn best_thumbnail(resp: &PlayerResponse) -> Option<String> {
         .and_then(|v| v.thumbnail.as_ref())
         .and_then(|t| t.thumbnails.last())
         .map(|t| t.url.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stream_headers;
+
+    /// The HEAD probe and mpv share this, so what it returns has to be identical for both callers
+    /// (that mismatch is issue #71): the cookie rides along for an upload and for nothing else.
+    #[test]
+    fn only_an_upload_carries_the_cookie() {
+        let ua = || Some("UA/1".to_owned());
+        let cookie = || Some("SAPISID=secret".to_owned());
+
+        let up = stream_headers(ua(), cookie(), true);
+        assert_eq!(up.get("User-Agent").map(String::as_str), Some("UA/1"));
+        assert_eq!(up.get("Cookie").map(String::as_str), Some("SAPISID=secret"));
+
+        let ordinary = stream_headers(ua(), cookie(), false);
+        assert_eq!(ordinary.get("User-Agent").map(String::as_str), Some("UA/1"));
+        assert!(!ordinary.contains_key("Cookie"), "an ordinary stream must not send the cookie");
+
+        // Signed out: an upload cannot play at all, but it must not produce a bogus header.
+        assert!(!stream_headers(ua(), None, true).contains_key("Cookie"));
+    }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1353,6 +1353,13 @@ impl AppState {
         });
     }
 
+    /// Which client's URL the playing track was resolved from ("WEB_REMIX", "cache", ...).
+    /// Names the culprit in a playback-error toast, which on Windows is the only diagnostic a
+    /// reporter can actually produce.
+    pub async fn current_stream_client(&self) -> Option<String> {
+        self.queue.lock().await.current_client.clone()
+    }
+
     /// A track died at the player layer (dead/403 URL). If WEB_REMIX served it, record the failure
     /// so the next resolve for this id bypasses WEB_REMIX (context/06 §2). Then retry the SAME
     /// track once — the re-resolve now runs the direct-URL fallback clients, which is what makes

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -168,6 +168,13 @@ export const LIKED_MUSIC_ID = 'VLLM';
 export const LIBRARY_SONGS_ID = 'FEmusic_liked_videos';
 
 /**
+ * The tracks the signed-in user uploaded to YouTube Music themselves. Browses like the songs grid
+ * above, so the same tab component reads it; the rows come back with `is_upload` set, which is what
+ * sends them down the login-only fallback chain when they play (issue #71).
+ */
+export const LIBRARY_UPLOADS_ID = 'FEmusic_library_privately_owned_tracks';
+
+/**
  * Local music (Rust `local.rs`). A file on disk is a song whose `video_id` is `LOCAL:<path>`, and
  * an album of them is a browseId `LOCALALBUM:<key>` — so local items ride every existing surface
  * (cards, queue, Shortcuts, the album page) and play with no network.

--- a/ui/src/lib/components/LibrarySongs.svelte
+++ b/ui/src/lib/components/LibrarySongs.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
-	// The Library page's Songs tab: every song saved to the account's library as one list, with a
+	// The Library page's Songs tab (and, with `uploads`, its Uploads tab): one flat list with a
 	// Shuffle all over the whole thing (issue #73).
 	//
-	// `FEmusic_liked_videos` is YouTube's own Library ▸ Songs despite the name, and it browses like
-	// any other playlist, so this reads it through `get_playlist` and the Rust side gains nothing.
+	// `FEmusic_liked_videos` is YouTube's own Library ▸ Songs despite the name, and
+	// `FEmusic_library_privately_owned_tracks` is Uploads ▸ Songs. Both browse like any other
+	// playlist, so this reads them through `get_playlist` and the Rust side gains nothing.
 	// What pins that: `library_songs_browse_returns_tracks` in crates/innertube/tests/live_smoke.rs.
 	import { onMount } from 'svelte';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
-	import { MusicNote01Icon, PlayIcon, ShuffleIcon } from '@hugeicons/core-free-icons';
+	import {
+		CloudUploadIcon,
+		MusicNote01Icon,
+		PlayIcon,
+		ShuffleIcon
+	} from '@hugeicons/core-free-icons';
 	import { Button } from '$lib/components/ui/button';
 	import TrackFilter, { filterTracks } from './TrackFilter.svelte';
 	import TrackRow from './TrackRow.svelte';
@@ -20,9 +26,15 @@
 	import { openAddToPlaylist, openPlayer, playback } from '$lib/player.svelte';
 	import { t } from '$lib/i18n.svelte';
 
+	// The same tab, pointed at a different browse id: Library ▸ Songs by default, or the tracks the
+	// user uploaded to YouTube Music themselves. Both browse like a headerless playlist and page the
+	// same way, so the only differences are the id and the words around it.
+	let { uploads = false }: { uploads?: boolean } = $props();
+	const BROWSE_ID = $derived(uploads ? api.LIBRARY_UPLOADS_ID : api.LIBRARY_SONGS_ID);
+
 	// Cached like every other browse page, so switching tabs (or leaving the Library and coming
 	// back) paints the list instead of refetching it and losing every page you scrolled in.
-	const KEY = 'library:songs';
+	const KEY = $derived(uploads ? 'library:uploads' : 'library:songs');
 	type Cached = { items: SongItem[]; continuation?: string };
 
 	// `$state.raw`, same reason as the playlist page: a deep proxy puts every read of every row
@@ -62,7 +74,9 @@
 			? token && !moreError
 				? t('library.matching_songs_so_far', { count: shownSongs.length.toLocaleString() })
 				: t('library.matching_songs', { count: shownSongs.length.toLocaleString() })
-			: t('library.every_song_saved')
+			: uploads
+				? t('library.every_upload')
+				: t('library.every_song_saved')
 	);
 	// Four covers for the mosaic. Distinct ones: a library that opens on six tracks off the same
 	// album would otherwise draw the same sleeve four times.
@@ -80,7 +94,7 @@
 
 	// The queue this tab builds. Not a `playFrom`: there is no page behind "the songs in your
 	// library", so it has no business landing in recents or the sidebar's last-played order.
-	const SOURCE = 'Your songs';
+	const SOURCE = $derived(uploads ? 'Your uploads' : 'Your songs');
 
 	onMount(() => {
 		const cached = getCached<Cached>(KEY);
@@ -102,7 +116,7 @@
 		error = null;
 		moreError = false;
 		try {
-			const page = await api.getPlaylist(api.LIBRARY_SONGS_ID);
+			const page = await api.getPlaylist(BROWSE_ID);
 			songs = page.items;
 			token = page.continuation;
 			cache();
@@ -218,11 +232,13 @@
 				<img src={thumb(covers[0], 400)} alt="" class="h-28 w-28 shrink-0 rounded-xl object-cover shadow-lg" />
 			{:else}
 				<div class="flex h-28 w-28 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-					<HugeiconsIcon icon={MusicNote01Icon} class="h-10 w-10" />
+					<HugeiconsIcon icon={uploads ? CloudUploadIcon : MusicNote01Icon} class="h-10 w-10" />
 				</div>
 			{/if}
 			<div class="min-w-0 flex-1">
-				<h2 class="font-heading text-2xl font-bold tracking-tight">{t('common.songs')}</h2>
+				<h2 class="font-heading text-2xl font-bold tracking-tight">
+					{uploads ? t('library.uploads_tab') : t('common.songs')}
+				</h2>
 				<p class="mt-0.5 text-sm text-muted-foreground">
 					{line}
 				</p>
@@ -264,7 +280,9 @@
 		</p>
 	{:else}
 		<p class="text-sm text-muted-foreground">
-			No songs in your library yet. Hit the ⋯ on a song and save it, or like it, and it lands here.
+			{uploads
+				? t('library.no_uploads')
+				: 'No songs in your library yet. Hit the ⋯ on a song and save it, or like it, and it lands here.'}
 		</p>
 	{/if}
 

--- a/ui/src/lib/locales/en.ts
+++ b/ui/src/lib/locales/en.ts
@@ -156,6 +156,7 @@ export const en = {
 		albums_tab: 'Albums',
 		artists_tab: 'Artists',
 		local_tab: 'Local',
+		uploads_tab: 'Uploads',
 		matching_songs: '{count} matching',
 		matching_songs_so_far: '{count} matching so far',
 		sync_idle_tooltip: 'Add the {count} saved on this device to your YouTube Music library',
@@ -177,7 +178,10 @@ export const en = {
 		still_loading: ' yet, still loading',
 		saved_to_library: 'Saved to library',
 		removed_from_library: 'Removed from library',
-		every_song_saved: 'Every song you’ve saved, in one list'
+		every_song_saved: 'Every song you’ve saved, in one list',
+		every_upload: 'Every track you’ve uploaded to YouTube Music',
+		no_uploads: 'Nothing uploaded yet. Songs you upload at music.youtube.com show up here.',
+		uploads_signed_out: 'Sign in to see the music you’ve uploaded to YouTube Music.'
 	},
 	local: {
 		scanning: 'Scanning folder...',

--- a/ui/src/lib/locales/tr.ts
+++ b/ui/src/lib/locales/tr.ts
@@ -158,6 +158,7 @@ export const tr: Translations = {
 		albums_tab: 'Albümler',
 		artists_tab: 'Sanatçılar',
 		local_tab: 'Yerel',
+		uploads_tab: 'Yüklemeler',
 		matching_songs: '{count} eşleşen',
 		matching_songs_so_far: 'şu ana kadar {count} eşleşen',
 		sync_idle_tooltip: 'Bu cihazda kayıtlı {count} parçayı YouTube Music kitaplığınıza ekleyin',
@@ -180,6 +181,9 @@ export const tr: Translations = {
 		saved_to_library: 'Kitaplığa kaydedildi',
 		removed_from_library: 'Kitaplıktan çıkarıldı',
 		every_song_saved: 'Kaydettiğin bütün şarkılar tek bir listede',
+		every_upload: 'YouTube Music’a yüklediğin bütün parçalar',
+		no_uploads: 'Henüz bir şey yüklemedin. music.youtube.com üzerinden yüklediğin şarkılar burada görünür.',
+		uploads_signed_out: 'YouTube Music’a yüklediğin müzikleri görmek için giriş yap.'
 	},
 	local: {
 		scanning: 'Klasör taranıyor...',

--- a/ui/src/routes/library/+page.svelte
+++ b/ui/src/routes/library/+page.svelte
@@ -11,6 +11,7 @@
 	import {
 		Add01Icon,
 		CloudSyncIcon,
+		CloudUploadIcon,
 		DriveIcon,
 		MusicNote01Icon,
 		MusicNoteSquare02Icon,
@@ -230,16 +231,19 @@
 			<Tabs.Trigger value="songs">
 				<HugeiconsIcon icon={MusicNote01Icon} class="h-4 w-4" /> {t('library.songs_tab')}
 			</Tabs.Trigger>
+			<Tabs.Trigger value="uploads">
+				<HugeiconsIcon icon={CloudUploadIcon} class="h-4 w-4" /> {t('library.uploads_tab')}
+			</Tabs.Trigger>
 			<Tabs.Trigger value="local">
 				<HugeiconsIcon icon={DriveIcon} class="h-4 w-4" /> {t('library.local_tab')}
 			</Tabs.Trigger>
 		</Tabs.List>
 		<!-- Every branch below is gated on `tab`, because bits-ui never unmounts an inactive panel: it
-		     renders all five and hides the others. Left alone, opening Library builds each card twice
+		     renders every one and hides the inactive ones. Left alone, opening Library builds each card twice
 		     (once for All, once for its own tab) and mounts the whole Local tab, disk scan included,
 		     for a panel you cannot see. -->
-		<!-- Songs and Local stand apart: one is a track list rather than a card grid, the other needs
-		     neither an account nor a connection, and the states below fit neither. -->
+		<!-- Songs, Uploads and Local stand apart: two are track lists rather than card grids, the
+		     third needs neither an account nor a connection, and the states below fit none of them. -->
 		<Tabs.Content value="songs">
 			{#if tab === 'songs'}
 				{#if signedOut}
@@ -252,9 +256,18 @@
 				{/if}
 			{/if}
 		</Tabs.Content>
+		<Tabs.Content value="uploads">
+			{#if tab === 'uploads'}
+				{#if signedOut}
+					<p class="text-sm text-muted-foreground">{t('library.uploads_signed_out')}</p>
+				{:else}
+					<LibrarySongs uploads />
+				{/if}
+			{/if}
+		</Tabs.Content>
 		<Tabs.Content value="local">{#if tab === 'local'}<LocalMusic />{/if}</Tabs.Content>
-		{#if tab === 'local' || tab === 'songs'}
-			<!-- nothing else: the grid states below have no bearing on these two -->
+		{#if tab === 'local' || tab === 'songs' || tab === 'uploads'}
+			<!-- nothing else: the grid states below have no bearing on these three -->
 		{:else if loading}
 			<div class="card-grid">
 				{#each Array(12) as _, i (i)}


### PR DESCRIPTION
Two things about YouTube Music uploads, one a fix and one a feature.

### The fix (issue #71)

An upload had exactly one client to fail on. `is_upload ||` short-circuited the HEAD check in the
fallback loop, so the moment `/player` came back OK the loop returned WEB_REMIX's URL
unconditionally. TVHTML5 and WEB_CREATOR sat behind that `return` and never ran, which made
`UPLOAD_FALLBACK_ORDER` dead code. On top of it, the WEB_REMIX failure memory was ignored for
uploads, so the retry after an mpv failure re-resolved the same dead URL. Any account whose
WEB_REMIX URLs 403 was stuck there permanently.

- Uploads are HEAD-validated like everything else, but a failure demotes rather than rejects: the
  first URL is kept as a last resort, the rest of the chain gets its turn, and the unvalidated one
  is only returned if nothing validates. Worst case is the old behaviour a round trip later, so
  nothing regresses for people it already works for.
- `web_remix_failed` now applies to uploads, so a retry rotates to TVHTML5 then WEB_CREATOR.
- When the whole login chain fails HEAD, the off-hot-path self-heal runs. An upload-only failure
  previously had no route back.
- Separate defect, same area: `validate_head` always sent the session cookie while `build` attached
  it only for uploads, so the probe was not the request mpv makes and an ordinary track could pass
  validation and 403 on the real open. Both go through one `stream_headers` now.
- The playback-error toast names the client that served the dead URL ("... rejected the stream link
  (WEB_REMIX)"). Windows has no console and no log file, so that word is the only diagnostic a
  reporter can produce.

### The tab

Your uploaded music had nowhere to be seen in the app. New Uploads tab in the Library, between
Songs and Local. `FEmusic_library_privately_owned_tracks` browses like a headerless playlist,
exactly as Library > Songs does, so `LibrarySongs` took an `uploads` prop instead of a second
component. No backend change: `get_playlist` already returns the rows with `is_upload` set, which
is what puts them on the login-only chain above.

Uploaded albums and artists (the `_releases` / `_artists` grids, which YouTube Music gives their
own sub-tabs) are not included.

### Testing

`cargo test --workspace` green, including a new `only_an_upload_carries_the_cookie` covering the
HEAD/GET header parity. clippy and fmt clean, `pnpm check` 0 errors.

Uploads are region-locked where this was built, so both halves were verified by hand over a VPN:
uploads resolve and play, and the new tab lists them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Uploads** tab to the Library for browsing tracks uploaded to YouTube Music.
  - Added localized upload labels, descriptions, empty states, and sign-in prompts in English and Turkish.
  - Improved playback reliability for uploaded tracks with better fallback handling.

- **Bug Fixes**
  - Playback error notifications now identify the stream service involved when retries fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->