### PR TITLE
Version 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,12 +1122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "data-url"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
-
-[[package]]
 name = "dbus"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5728,7 +5722,6 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "data-url",
  "dirs 6.0.0",
  "dunce",
  "embed_plist",

--- a/crates/innertube/src/endpoints.rs
+++ b/crates/innertube/src/endpoints.rs
@@ -525,6 +525,58 @@ impl InnerTube {
         Ok(())
     }
 
+    /// The raw `search` / `browse` responses, for the live smoke tests only (feature-gated, never
+    /// built into the app). Diagnosing a menu shape needs the JSON before the parsers drop it.
+    #[cfg(feature = "integration-tests")]
+    pub async fn search_json(
+        &self,
+        client: &YouTubeClient,
+        query: &str,
+        params: Option<&str>,
+    ) -> Result<serde_json::Value, Error> {
+        self.search_raw(client, query, params).await
+    }
+
+    #[cfg(feature = "integration-tests")]
+    pub async fn browse_json(
+        &self,
+        client: &YouTubeClient,
+        browse_id: &str,
+    ) -> Result<serde_json::Value, Error> {
+        self.browse(client, Some(browse_id), None).await
+    }
+
+    /// Add a track to the library, or take it out: `youtubei/v1/feedback` with a token minted on
+    /// the row itself ([`crate::models::LibraryToggle`]). Not the same thing as a like, which is
+    /// what `rate` does: Library ▸ Songs and Liked Music are separate lists on the account.
+    ///
+    /// YouTube answers 200 with a per-token result rather than an HTTP error, so a token that has
+    /// gone stale (the row was fetched long enough ago) surfaces here, not as a silent no-op.
+    pub async fn feedback(&self, client: &YouTubeClient, token: &str) -> Result<(), Error> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct FeedbackBody {
+            context: Context,
+            feedback_tokens: Vec<String>,
+        }
+        let body = FeedbackBody {
+            context: self.context_for(client),
+            feedback_tokens: vec![token.to_owned()],
+        };
+        let value = self.post("feedback", client, &body, true).await?;
+        let processed = value
+            .pointer("/feedbackResponses/0/isProcessed")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if processed {
+            Ok(())
+        } else {
+            Err(Error::Other(
+                "YouTube turned down the library change — reopen the list and try again.".into(),
+            ))
+        }
+    }
+
     /// Save an album/playlist to the library, or remove it. Same `like` endpoint as a track, with
     /// a playlist target: for an album pass its `OLAK5uy_…` audio playlist id. Live-verified.
     pub async fn like_playlist(

--- a/crates/innertube/src/models/metadata.rs
+++ b/crates/innertube/src/models/metadata.rs
@@ -88,6 +88,30 @@ pub struct SongItem {
     /// reads false even when the same song shows the badge on an album page.
     #[serde(default)]
     pub explicit: bool,
+    /// "Add to library" / "Remove from library" off this row's own menu ([`library_toggle`]).
+    /// `None` on rows YouTube sent no such menu for, and on the ones this app builds itself (local
+    /// files, On Repeat), where there is nothing to send.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub library: Option<LibraryToggle>,
+}
+
+/// A track's library membership as its menu states it, with the tokens for both directions.
+///
+/// Library ▸ Songs is not Liked Music: adding a song to the library is a `feedbackEndpoint`, a
+/// separate write from the rating, and the only handle on it is an opaque token minted with the
+/// row. That is why this rides along on every `SongItem` instead of being asked for later, and why
+/// a row we built ourselves can't offer the action.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LibraryToggle {
+    /// Whether the song is in the library right now, per the menu YouTube sent with the row.
+    pub in_library: bool,
+    /// One token per direction. Both are present when the row's menu is a *toggle*; a row that
+    /// offers the action one way only (a plain menu item, which is how some surfaces send it)
+    /// carries just the one it offers, and the way back has to come from a re-fetched row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remove_token: Option<String>,
 }
 
 /// How the signed-in user rated a track. One type for both directions: it's what a row's
@@ -508,6 +532,7 @@ pub(crate) fn parse_list_item(node: &Value) -> Option<SongItem> {
         is_video: is_video_row(node),
         is_upload: is_upload_row(node),
         explicit: is_explicit(node),
+        library: library_toggle(node),
     })
 }
 
@@ -600,6 +625,71 @@ fn removable(node: &Value) -> bool {
     find_all(node, "action").iter().any(|a| a.as_str() == Some("ACTION_REMOVE_VIDEO"))
 }
 
+/// The row's "Save to library" action, in either shape YouTube sends it.
+///
+/// Usually a `toggleMenuServiceItemRenderer` holding both directions, one `feedbackEndpoint` each.
+/// It carries no state field, so which way round it is comes from the icons: YouTube puts the
+/// action available *now* in `defaultIcon`/`defaultServiceEndpoint`, so a song already in the
+/// library arrives with the filled bookmark as its default. Some surfaces send a plain
+/// `menuServiceItemRenderer` with one direction only; that is the fallback below.
+///
+/// Icons, not the label, because the label is localised. A track menu carries other feedback
+/// toggles that must not match: "Add to liked songs" (FAVORITE/UNFAVORITE, a rating and a
+/// different list) and "Pin to Listen again" (KEEP/KEEP_OFF). Live-checked 2026-08-28: search rows
+/// send BOOKMARK_BORDER/BOOKMARK; the LIBRARY_* spellings are kept as YouTube has used them too.
+fn library_toggle(node: &Value) -> Option<LibraryToggle> {
+    /// The bookmark is empty when the song is not in the library — that direction adds it.
+    const ADDS: [&str; 2] = ["BOOKMARK_BORDER", "LIBRARY_ADD"];
+    /// Filled: it is in there, and this direction takes it out.
+    const REMOVES: [&str; 3] = ["BOOKMARK", "LIBRARY_REMOVE", "LIBRARY_SAVED"];
+
+    // Scoped to the row's menu where there is one: `find_all` walks everything, and a row can
+    // carry other people's endpoints (an album's, an artist's) elsewhere in its tree.
+    let menu = node.get("menu").unwrap_or(node);
+    let feedback_token = |endpoint: Option<&Value>| {
+        find_first_str(endpoint?.get("feedbackEndpoint")?, "feedbackToken")
+    };
+    let both = find_all(menu, "toggleMenuServiceItemRenderer").into_iter().find_map(|toggle| {
+        let icon = |key: &str| find_first_str(toggle.get(key)?, "iconType");
+        let default = feedback_token(toggle.get("defaultServiceEndpoint"))?;
+        let toggled = feedback_token(toggle.get("toggledServiceEndpoint"))?;
+        let (default_icon, toggled_icon) = (icon("defaultIcon")?, icon("toggledIcon")?);
+        let (default_icon, toggled_icon) = (default_icon.as_str(), toggled_icon.as_str());
+        if ADDS.contains(&default_icon) && REMOVES.contains(&toggled_icon) {
+            Some(LibraryToggle {
+                in_library: false,
+                add_token: Some(default),
+                remove_token: Some(toggled),
+            })
+        } else if REMOVES.contains(&default_icon) && ADDS.contains(&toggled_icon) {
+            Some(LibraryToggle {
+                in_library: true,
+                add_token: Some(toggled),
+                remove_token: Some(default),
+            })
+        } else {
+            None
+        }
+    });
+    both.or_else(|| {
+        find_all(menu, "menuServiceItemRenderer").into_iter().find_map(|item| {
+            let token = feedback_token(item.get("serviceEndpoint"))?;
+            let icon = find_first_str(item.get("icon")?, "iconType")?;
+            if ADDS.contains(&icon.as_str()) {
+                Some(LibraryToggle {
+                    in_library: false,
+                    add_token: Some(token),
+                    remove_token: None,
+                })
+            } else if REMOVES.contains(&icon.as_str()) {
+                Some(LibraryToggle { in_library: true, add_token: None, remove_token: Some(token) })
+            } else {
+                None
+            }
+        })
+    })
+}
+
 fn like_status(node: &Value) -> Option<Rating> {
     find_first_str(node, "likeStatus").map(|s| match s.as_str() {
         "LIKE" => Rating::Like,
@@ -643,6 +733,7 @@ fn parse_panel_video(node: &Value) -> Option<SongItem> {
         // Queue-panel rows carry no badges today; asking anyway costs a map lookup and picks the
         // flag up for free if YouTube ever adds one.
         explicit: is_explicit(node),
+        library: library_toggle(node),
     })
 }
 
@@ -968,6 +1059,58 @@ mod tests {
         // Fail closed: no tag means an ordinary track, so the normal client chain still runs.
         assert!(!is_upload_row(&json!({ "navigationEndpoint": cfg("MUSIC_VIDEO_TYPE_OMV") })));
         assert!(!is_upload_row(&json!({})));
+    }
+
+    // The library toggle is opaque tokens and no state field: which one is live is told by the
+    // icons alone, so a mixed-up pair would send "add" for a song already in the library (a no-op
+    // the UI would report as success). Both orientations, the one-way shape, and the two feedback
+    // toggles that sit right next to it in a real track menu and must not be mistaken for it.
+    #[test]
+    fn reads_the_library_action_in_every_shape() {
+        let toggle = |default_icon: &str, toggled_icon: &str| {
+            json!({ "menu": { "menuRenderer": { "items": [
+                { "toggleMenuServiceItemRenderer": {
+                    "defaultIcon": { "iconType": default_icon },
+                    "defaultServiceEndpoint": { "feedbackEndpoint": { "feedbackToken": "TOK_DEFAULT" } },
+                    "toggledIcon": { "iconType": toggled_icon },
+                    "toggledServiceEndpoint": { "feedbackEndpoint": { "feedbackToken": "TOK_TOGGLED" } }
+                } }
+            ] } } })
+        };
+
+        // Not in the library: the empty bookmark is the action on offer, so its token is default.
+        let out = library_toggle(&toggle("BOOKMARK_BORDER", "BOOKMARK")).unwrap();
+        assert!(!out.in_library);
+        assert_eq!(out.add_token.as_deref(), Some("TOK_DEFAULT"));
+        assert_eq!(out.remove_token.as_deref(), Some("TOK_TOGGLED"));
+
+        // Already in it: the same renderer arrives the other way round.
+        let out = library_toggle(&toggle("BOOKMARK", "BOOKMARK_BORDER")).unwrap();
+        assert!(out.in_library);
+        assert_eq!(out.add_token.as_deref(), Some("TOK_TOGGLED"));
+        assert_eq!(out.remove_token.as_deref(), Some("TOK_DEFAULT"));
+
+        // The older spelling, still accepted.
+        assert!(!library_toggle(&toggle("LIBRARY_ADD", "LIBRARY_REMOVE")).unwrap().in_library);
+
+        // One direction only, as a plain menu item: still worth offering, with no way back until
+        // the row is fetched again.
+        let one_way = json!({ "menu": { "menuRenderer": { "items": [
+            { "menuServiceItemRenderer": {
+                "icon": { "iconType": "BOOKMARK_BORDER" },
+                "serviceEndpoint": { "feedbackEndpoint": { "feedbackToken": "TOK_ONE_WAY" } }
+            } }
+        ] } } });
+        let out = library_toggle(&one_way).unwrap();
+        assert!(!out.in_library);
+        assert_eq!(out.add_token.as_deref(), Some("TOK_ONE_WAY"));
+        assert_eq!(out.remove_token, None);
+
+        // Its neighbours in a real menu: "Add to liked songs" is a rating on a different list, and
+        // "Pin to Listen again" is a feedback toggle too. Neither is this.
+        assert_eq!(library_toggle(&toggle("FAVORITE", "UNFAVORITE")), None);
+        assert_eq!(library_toggle(&toggle("KEEP", "KEEP_OFF")), None);
+        assert_eq!(library_toggle(&json!({})), None);
     }
 
     // The rating drives both thumbs on every row, and the third state is new: `DISLIKE` used to

--- a/crates/innertube/tests/live_smoke.rs
+++ b/crates/innertube/tests/live_smoke.rs
@@ -382,3 +382,140 @@ async fn library_songs_browse_returns_tracks() {
         assert!(!more.items.is_empty(), "the paging token resolved to nothing");
     }
 }
+
+/// "Add to library" on a song is a `feedbackEndpoint` token minted on the row itself, not a rating,
+/// so the whole feature stands on rows still arriving with that menu. It is invisible if it breaks:
+/// no tokens simply means the menu never offers the action. Reports what each surface carried, and
+/// dumps a row's actual menu when nothing matched, since the shape is the thing in question.
+///   LIMUSIC_COOKIE=… LIMUSIC_VISITOR=… cargo test -p innertube --features integration-tests library_tokens -- --ignored --nocapture
+#[tokio::test]
+#[ignore]
+async fn song_rows_carry_library_tokens() {
+    let Some(cookie) = std::env::var("LIMUSIC_COOKIE").ok().filter(|s| !s.is_empty()) else {
+        eprintln!("skipped: set LIMUSIC_COOKIE (+LIMUSIC_VISITOR) to run");
+        return;
+    };
+    let visitor = std::env::var("LIMUSIC_VISITOR").ok().filter(|s| !s.is_empty());
+    let it = InnerTube::new(
+        Session { cookie: Some(cookie), visitor_data: visitor, ..Session::default() },
+        None,
+    )
+    .unwrap();
+    let clients = Clients::bundled();
+    let client = clients.get("WEB_REMIX").expect("WEB_REMIX client");
+
+    // Every menu entry of the first song row, as YouTube sends it: renderer name, icon, and which
+    // kind of endpoint hangs off it. That is exactly the information the parser matches on.
+    fn dump_menu(label: &str, row: &serde_json::Value) {
+        let Some(menu) = row.get("menu") else {
+            let keys: Vec<&str> =
+                row.as_object().map(|o| o.keys().map(String::as_str).collect()).unwrap_or_default();
+            eprintln!("  {label}: no menu on this row. keys: {keys:?}");
+            return;
+        };
+        eprintln!("  {label} menu:");
+        for item in
+            menu.pointer("/menuRenderer/items").and_then(|i| i.as_array()).unwrap_or(&vec![])
+        {
+            let Some((renderer, body)) = item.as_object().and_then(|o| o.iter().next()) else {
+                continue;
+            };
+            let icon = |k: &str| {
+                body.pointer(&format!("/{k}/iconType")).and_then(|v| v.as_str()).unwrap_or("-")
+            };
+            let text = body
+                .pointer("/text/runs/0/text")
+                .or_else(|| body.pointer("/defaultText/runs/0/text"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("-");
+            let endpoints: Vec<&str> = body
+                .as_object()
+                .map(|o| o.keys().filter(|k| k.contains("Endpoint")).map(String::as_str).collect())
+                .unwrap_or_default();
+            eprintln!(
+                "    {renderer}: text={text:?} icon={} default={} toggled={} endpoints={endpoints:?} feedback={}",
+                icon("icon"),
+                icon("defaultIcon"),
+                icon("toggledIcon"),
+                serde_json::to_string(body).unwrap_or_default().contains("feedbackEndpoint")
+            );
+        }
+    }
+
+    let raw = it.search_json(client, "daft punk", Some("EgWKAQIIAWoKEAkQBRAKEAMQBA%3D%3D")).await;
+    let search = it.search_songs(client, "daft punk").await.expect("search");
+    let with_tokens = search.items.iter().filter(|s| s.library.is_some()).count();
+    eprintln!("search: {}/{} rows carry a library action", with_tokens, search.items.len());
+    if with_tokens == 0 {
+        if let Ok(raw) = &raw {
+            let rows = find_rows(raw, "musicResponsiveListItemRenderer");
+            eprintln!(
+                "  {} raw search rows; feedbackToken anywhere in the response: {}",
+                rows.len(),
+                serde_json::to_string(raw).unwrap_or_default().contains("feedbackToken")
+            );
+            if let Some(row) = rows.iter().find(|r| r.get("menu").is_some()).or(rows.first()) {
+                dump_menu("search row", row);
+            }
+        }
+    }
+
+    // Search is the surface this feature lives on: every row there carried the toggle when this was
+    // written (20/20, 2026-08-28). Zero means the menu shape moved again, and the dump above says how.
+    assert!(with_tokens > 0, "no search row carried a library action — the menu shape changed");
+
+    // Library ▸ Songs rows come from a browse, a different response with its own menus. Most of
+    // them ship without a menu at all, so this half only reports: it is not a guard.
+    // Note the rows that do carry one report `in_library: false` — that list is your *liked*
+    // songs, and liking is not the same write as saving to the library.
+    let page = it.playlist(client, "FEmusic_liked_videos", None).await.expect("library songs");
+    let saved = page.items.iter().filter(|s| s.library.is_some()).count();
+    let already =
+        page.items.iter().filter(|s| s.library.as_ref().is_some_and(|l| l.in_library)).count();
+    eprintln!(
+        "library songs: {}/{} carry an action, {} report in_library",
+        saved,
+        page.items.len(),
+        already
+    );
+    if saved == 0 {
+        if let Ok(raw) = it.browse_json(client, "FEmusic_liked_videos").await {
+            let rows = find_rows(&raw, "musicResponsiveListItemRenderer");
+            eprintln!("  {} raw library rows", rows.len());
+            if let Some(row) = rows.iter().find(|r| r.get("menu").is_some()).or(rows.first()) {
+                dump_menu("library row", row);
+            }
+        }
+    }
+    if let Some(song) = page.items.iter().find(|s| s.library.is_some()) {
+        let lib = song.library.as_ref().unwrap();
+        eprintln!(
+            "  {:?}: in_library={} add={:?} remove={:?}",
+            song.title,
+            lib.in_library,
+            lib.add_token.as_deref().map(|t| &t[..t.len().min(12)]),
+            lib.remove_token.as_deref().map(|t| &t[..t.len().min(12)])
+        );
+    }
+}
+
+/// Every `key` node in the tree, in document order (the crate keeps its own walker private).
+fn find_rows<'a>(root: &'a serde_json::Value, key: &str) -> Vec<&'a serde_json::Value> {
+    let mut out = Vec::new();
+    fn walk<'a>(v: &'a serde_json::Value, key: &str, out: &mut Vec<&'a serde_json::Value>) {
+        match v {
+            serde_json::Value::Object(map) => {
+                for (k, val) in map {
+                    if k == key {
+                        out.push(val);
+                    }
+                    walk(val, key, out);
+                }
+            }
+            serde_json::Value::Array(arr) => arr.iter().for_each(|e| walk(e, key, out)),
+            _ => {}
+        }
+    }
+    walk(root, key, &mut out);
+    out
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-tauri = { version = "2", features = ["webview-data-url", "tray-icon", "protocol-asset", "macos-private-api"] }
+tauri = { version = "2", features = ["tray-icon", "protocol-asset", "macos-private-api"] }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/cipher/mod.rs
+++ b/src-tauri/src/cipher/mod.rs
@@ -1,7 +1,8 @@
 //! `CipherDeobfuscator` (context/05) — the signature/`n`-transform runtime the orchestrator calls.
 //!
 //! Ties [`fetcher`] (player.js) + [`extractor`]/[`config`] (function names) + a hidden cipher
-//! webview ([`crate::webview`]) that runs YouTube's own code. Every public method degrades
+//! webview ([`crate::webview`]) that runs YouTube's own code (its `_yt_player` harness global comes
+//! with the document — see `webview::HARNESS_HTML`). Every public method degrades
 //! gracefully: a webview or extraction failure yields `None` / the original URL, and the
 //! orchestrator falls through to the non-cipher fallback clients (context/06 §5).
 
@@ -25,10 +26,6 @@ use fetcher::PlayerJsFetcher;
 const CIPHER_LABEL: &str = "limusic-cipher";
 const CALL_TIMEOUT: Duration = Duration::from_secs(5);
 const LOAD_TIMEOUT: Duration = Duration::from_secs(15);
-
-/// Minimal harness: predefine `_yt_player` (the IIFE arg) so the injected player.js can run.
-const HARNESS: &str = "<!doctype html><html><head><meta charset=utf-8></head><body>\
-<script>window._yt_player=window._yt_player||{};</script></body></html>";
 
 /// Discovery/validation (context/05): prove the injected exports actually WORK before the
 /// orchestrator commits to this player, by running each on a sample input.
@@ -251,9 +248,7 @@ impl CipherDeobfuscator {
                 let _ = b.destroy();
             }
         }
-        let bridge = Bridge::create(&self.app, CIPHER_LABEL, HARNESS, "")
-            .await
-            .map_err(|e| e.to_string())?;
+        let bridge = Bridge::create(&self.app, CIPHER_LABEL).await.map_err(|e| e.to_string())?;
         if let Err(e) = Self::load_player(&bridge, &injected).await {
             let _ = bridge.destroy(); // don't orphan the hidden window on a failed load
             return Err(e);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -724,9 +724,10 @@ fn editable_playlist<'a>(
     require_login(state)
 }
 
-/// Liked Music is a library playlist like any other, but the row already carries its thumbs-up
-/// state, so a second mark saying the same thing is noise. It is also the one list that runs to
-/// thousands of tracks, which would double the crawl on its own.
+/// Liked Music. It is indexed like the rest, because a search row is the one place YouTube tells
+/// us nothing: `search` responses carry no `likeStatus` at all (live-checked 2026-08-28), so
+/// membership of this list is the only way a result can draw its heart filled. Not shown in the
+/// "saved in" chip, though: the thumbs-up already says it (the UI filters it out there).
 const LIKED_MUSIC_ID: &str = "VLLM";
 /// How long the membership index is trusted before a re-crawl. Adds and removes made in this app
 /// patch it as they happen, so this window only ever covers edits made somewhere else.
@@ -760,7 +761,9 @@ pub async fn sync_playlist_index(
     }
     let fresh_until = state
         .db
-        .get_setting("playlist_index_synced_at")
+        // `_v2`: the key changed when Liked Music joined the index, so an install with a fresh
+        // stamp re-crawls once instead of showing hearts empty for another six hours.
+        .get_setting("playlist_index_synced_at_v2")
         .and_then(|at| at.parse::<i64>().ok())
         .map(|at| at + PLAYLIST_INDEX_TTL_SECS);
     if fresh_until.is_some_and(|until| now_secs() < until) {
@@ -776,7 +779,7 @@ pub async fn sync_playlist_index(
     }
     let mut indexed: Vec<String> = Vec::new();
     for item in library {
-        if item.id == ON_REPEAT_ID || item.id == LIKED_MUSIC_ID {
+        if item.id == ON_REPEAT_ID {
             continue;
         }
         // One playlist failing (a deleted id, a hiccup) must not abandon the rest of the crawl,
@@ -788,7 +791,9 @@ pub async fn sync_playlist_index(
         };
         // A collaborative playlist reads `owned: false` (YouTube drops the editable header on it)
         // but is one you add to and remove from, so the membership index has to cover it too.
-        if !page.owned && !page.collaborative {
+        // Liked Music is exempt: YouTube sends it without the editable header, so it reads
+        // `owned: false` even though it is yours.
+        if item.id != LIKED_MUSIC_ID && !page.owned && !page.collaborative {
             continue;
         }
         let mut video_ids: Vec<String> = page.items.into_iter().map(|song| song.video_id).collect();
@@ -803,7 +808,7 @@ pub async fn sync_playlist_index(
         indexed.push(item.id);
     }
     state.db.retain_playlists(&indexed);
-    state.db.set_setting("playlist_index_synced_at", &now_secs().to_string());
+    state.db.set_setting("playlist_index_synced_at_v2", &now_secs().to_string());
     Ok(state.db.playlist_memberships())
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -687,6 +687,15 @@ pub async fn rate(state: St<'_>, video_id: String, rating: Rating) -> Result<(),
     state.it.rate(client, &video_id, rating).await.map_err(|e| e.to_string())
 }
 
+/// Add a song to the library (Library ▸ Songs), or take it out. `token` comes from the row's own
+/// menu (`SongItem.library`), which is the only handle YouTube gives on this: it is a feedback
+/// action, not a rating, so it leaves Liked Music alone.
+#[tauri::command]
+pub async fn set_song_saved(state: St<'_>, token: String) -> Result<(), String> {
+    let client = require_login(&state)?;
+    state.it.feedback(client, &token).await.map_err(|e| e.to_string())
+}
+
 /// Save an album to the library, or remove it. `playlist_id` is the album's `OLAK5uy_…`
 /// (`AlbumPage.playlistId`).
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,6 +123,36 @@ pub(crate) fn tune_webview_labelled(app: &tauri::AppHandle, label: &str, media: 
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
+/// Logs to stdout **and** to `<app data>/limusic.log`, truncated each launch (the previous run is
+/// kept as `limusic.log.1`).
+///
+/// The file is the only way a Windows or macOS user can produce a log at all: `main.rs` sets
+/// `windows_subsystem = "windows"` in release, so there is no console to print to, and a bug that
+/// only reproduces on their machine (issue #71) otherwise has to be debugged by guessing.
+/// `RUST_LOG` still overrides the default filter for both.
+fn init_logging(dir: &std::path::Path) {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::Layer;
+
+    let filter = || {
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| "info,limusic_app=debug".into())
+    };
+    let path = dir.join("limusic.log");
+    let _ = std::fs::rename(&path, dir.join("limusic.log.1"));
+    // ponytail: one file per launch, no size cap. A run long enough to matter is a run whose log
+    // someone wants anyway; add rotation if that stops being true.
+    let file = std::fs::File::create(&path).ok().map(std::sync::Mutex::new);
+    let file_layer = file.map(|f| {
+        tracing_subscriber::fmt::layer().with_ansi(false).with_writer(f).with_filter(filter())
+    });
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_filter(filter()))
+        .with(file_layer)
+        .init();
+}
+
 pub fn run() {
     // NVIDIA + Wayland: WebKitGTK's DMABUF renderer trips over NVIDIA's explicit
     // sync (GBM buffer failures / blank window / Gdk Error 71). Disabling explicit
@@ -169,13 +199,6 @@ pub fn run() {
         }
     }
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info,limusic_app=debug".into()),
-        )
-        .init();
-
     tauri::Builder::default()
         // Must be the first plugin registered (its documented requirement). A second launch —
         // e.g. clicking the app icon while we're hidden in the tray — re-shows this instance
@@ -183,6 +206,14 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             tray::show_main(app);
         }))
+        // The hidden cipher webview's document (webview.rs). A registered scheme, because a
+        // `data:` URL is not a document WebView2 will navigate to.
+        .register_uri_scheme_protocol(webview::SCHEME, |_ctx, _req| {
+            tauri::http::Response::builder()
+                .header(tauri::http::header::CONTENT_TYPE, "text/html")
+                .body(webview::HARNESS_HTML.as_bytes())
+                .expect("static harness response")
+        })
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         // Folder picker for the local-music library (local.rs).
@@ -211,6 +242,7 @@ pub fn run() {
             // App data dir for the SQLite file and mpv's on-disk audio cache.
             let data_dir = app.path().app_data_dir().unwrap_or_else(|_| std::env::temp_dir());
             std::fs::create_dir_all(&data_dir).ok();
+            init_logging(&data_dir);
             let cache_dir = data_dir.join("audio-cache");
             std::fs::create_dir_all(&cache_dir).ok();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -461,6 +461,7 @@ pub fn run() {
             commands::play_playlist,
             commands::start_radio,
             commands::rate,
+            commands::set_song_saved,
             commands::set_album_saved,
             commands::add_to_playlist,
             commands::remove_from_playlist,

--- a/src-tauri/src/orchestrator.rs
+++ b/src-tauri/src/orchestrator.rs
@@ -250,8 +250,12 @@ impl Orchestrator {
                 audio_config_loudness = main_loudness(&resp);
             }
 
-            // Resolve the URL: direct, else decipher (context/05).
+            // Resolve the URL: direct, else decipher (context/05). A ciphered format with no
+            // working cipher webview lands here, and for an upload that is fatal: every client on
+            // its chain is a web client, so the whole chain produces nothing and the user sees
+            // "sign-in needed" for what is really a broken extraction runtime. Issues #71/#128.
             let Some(mut url) = self.find_url(format, video_id).await else {
+                tracing::warn!(video_id, client = %key, itag = format.itag, "no stream URL (deciphering unavailable?)");
                 continue;
             };
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2924,6 +2924,8 @@ fn track_to_song(t: &Track) -> SongItem {
         is_upload: false,
         // The Listen Together wire shape carries no badge, so a mirrored guest queue shows none.
         explicit: false,
+        // Same: no menu came with a mirrored row, so there is no library token to offer.
+        library: None,
     }
 }
 

--- a/src-tauri/src/webview.rs
+++ b/src-tauri/src/webview.rs
@@ -1,24 +1,28 @@
-//! Shared hidden-webview bridge for the cipher + PoToken JS runtimes. context/13.
+//! Shared hidden-webview bridge for the cipher JS runtime. context/13.
 //!
 //! Mechanics pinned against the installed tauri 2.11 / wry 0.55 source:
 //! - **Rust→JS→Rust:** [`WebviewWindow::eval_with_callback`] delivers the JSON of a *synchronous*
 //!   JS value. wry's WebKitGTK `run_javascript` does NOT await promises, so synchronous calls
-//!   (cipher sig/n) round-trip in one shot; async work (BotGuard) stores its result into a JS
-//!   global that we poll ([`Bridge::call_async`]).
+//!   (cipher sig/n) round-trip in one shot; async work stores its result into a JS global that we
+//!   poll ([`Bridge::call_async`]).
 //! - **Handles:** fetched fresh via `get_webview_window` per call and dropped before any `.await`,
 //!   so we never hold a non-`Send` handle across a suspension point.
 //! - **Lifecycle:** create/destroy run on the main thread via `run_on_main_thread` (GTK requires
 //!   it). Callers must invoke `create` from a spawned task, not from `setup()` — the event loop
 //!   isn't pumping yet during setup and the closure would never run.
-//! - **Harness HTML:** loaded as a `data:text/html` URL (CustomProtocol). The app CSP is `null`
-//!   so nothing is injected; BotGuard's dynamic eval runs unhindered (proven in botguard-spike).
-//!   **Keep it `null`.** Tauri injects the configured CSP as a `<meta>` tag into any `data:` URL
-//!   webview (`tauri::manager::webview`, `prepare_webview`). A `data:` document has an opaque
-//!   origin, so a policy as ordinary as `default-src 'self'` blocks every inline script here and
-//!   the harness loads with none of its functions defined — the page still reports "loaded" and
-//!   the eval probe still round-trips, so it fails as `Can't find variable: runBotGuard` at mint
-//!   time, not at build time. Hardening the main window costs the extraction stack; if it's ever
-//!   worth it, serve the harness from a custom URI scheme (which Tauri does not rewrite) first.
+//! - **Harness HTML:** served over the app's own `limusicharness://` URI scheme (registered in
+//!   `lib.rs`), NOT a `data:` URL. Tauri hands a `data:` URL to wry as a plain URL, and on Windows
+//!   wry navigates to it — which Chromium refuses for a top-level document, so WebView2 sat on the
+//!   initial `about:blank` forever and the readiness probe (then `location.protocol==='data:'`)
+//!   could never pass. The cipher webview therefore never existed on Windows: no deciphered URLs,
+//!   so WEB_REMIX/TVHTML5/WEB_CREATOR produced nothing and the user's own uploads (the one thing
+//!   with no anonymous chain behind it) failed with "sign-in needed". Issues #71/#128.
+//!   A registered scheme is a real document on all three engines (wry maps it to
+//!   `http://limusicharness.localhost` on Windows), so page-load fires, the origin is not opaque,
+//!   and Tauri does not rewrite the response the way it rewrites a `data:` URL to inject CSP.
+//!   **Keep the app CSP `null`.** BotGuard is gone from here, but the injected player.js still
+//!   needs unhindered inline script; a policy as ordinary as `default-src 'self'` would block the
+//!   harness's own inline preamble and the page would load with none of its globals defined.
 
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -50,37 +54,45 @@ pub struct Bridge {
     label: String,
 }
 
+/// URI scheme the harness document is served over. Registered on the Tauri builder in `lib.rs`
+/// (see [`HARNESS_HTML`]); wry rewrites it to `http://limusicharness.localhost` on Windows.
+pub const SCHEME: &str = "limusicharness";
+
+/// The harness document. Everything the bridge needs lives in this inline script rather than in an
+/// `initialization_script`, because an init script is registered *after* the engine has already
+/// created its first `about:blank` document: if a navigation ever fails, the page that is left has
+/// no globals at all. Part of the document, they exist exactly when the document does — which is
+/// also what `__harness` proves to the readiness probe.
+///
+/// `_yt_player` is the IIFE argument YouTube's player.js expects (context/05); the error hooks feed
+/// [`Error::BadWebview`], and `__slots` is the bag [`Bridge::call_async`] parks its results in.
+pub const HARNESS_HTML: &str = "<!doctype html><html><head><meta charset=utf-8></head><body>\
+<script>\
+window.__jserr=null;window.__slots={};window._yt_player=window._yt_player||{};\
+window.addEventListener('error',function(e){window.__jserr=String((e&&e.message)||e);});\
+window.onunhandledrejection=function(e){window.__jserr=String((e.reason&&e.reason.message)||e.reason);};\
+window.__harness=1;\
+</script></body></html>";
+
 impl Bridge {
-    /// Create a hidden webview over `html` (loaded from a `data:` URL) + an initialization script
-    /// (runs before the document's own scripts). Resolves once the page has finished loading (Tauri
-    /// `on_page_load`) AND a probe confirms JS↔Rust round-trips. On any failure the just-built
-    /// window is destroyed so its label can be reused (no orphan "already exists").
-    pub async fn create(
-        app: &AppHandle,
-        label: &str,
-        html: &str,
-        init_script: &str,
-    ) -> Result<Bridge, Error> {
+    /// Create a hidden webview over the [`HARNESS_HTML`] document. Resolves once the page has
+    /// finished loading (Tauri `on_page_load`) AND a probe confirms JS↔Rust round-trips. On any
+    /// failure the just-built window is destroyed so its label can be reused (no orphan
+    /// "already exists").
+    pub async fn create(app: &AppHandle, label: &str) -> Result<Bridge, Error> {
         // Reclaim the label if a prior attempt left an orphan (or a concurrent build raced us).
         destroy_and_wait(app, label).await;
 
-        // Preamble every harness gets: uncaught-error capture (for BadWebview) + a slots bag.
-        let init = format!(
-            "window.__jserr=null;window.__slots={{}};\
-             window.addEventListener('error',function(e){{window.__jserr=String((e&&e.message)||e);}});\
-             window.onunhandledrejection=function(e){{window.__jserr=String((e.reason&&e.reason.message)||e.reason);}};\n{init_script}"
-        );
-        let raw_url = format!("data:text/html,{}", urlencoding::encode(html));
-        let url = tauri::Url::parse(&raw_url).map_err(|e| Error::Build(e.to_string()))?;
+        let url = tauri::Url::parse(&format!("{SCHEME}://localhost/"))
+            .map_err(|e| Error::Build(e.to_string()))?;
         // The readiness probe (see below): proves the round-trip AND that OUR document is the one
-        // answering, since `about:blank` (where a fresh WebView2 sits) is not a `data:` page.
-        let probe = "location.protocol==='data:'";
+        // answering, since `about:blank` (where a fresh WebView2 sits) defines no `__harness`.
+        let probe = "window.__harness===1";
         let webview_url = WebviewUrl::CustomProtocol(url);
 
-        // Page-load signal from the runtime (`on_page_load` → Finished). It's the fast path on
-        // WebKitGTK; on WebView2 it is unreliable for the initial `data:` harness (loaded as
-        // NavigateToString, whose NavigationCompleted often never fires — WebView2Feedback #998),
-        // so it's an accelerator here, not the gate. The real readiness gate is an eval round-trip.
+        // Page-load signal from the runtime (`on_page_load` → Finished). An accelerator, not the
+        // gate: WebView2's NavigationCompleted is not always delivered for a webview built this way
+        // (WebView2Feedback #998). The real readiness gate is the eval round-trip below.
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
         let ready_slot = Arc::new(StdMutex::new(Some(ready_tx)));
 
@@ -95,7 +107,6 @@ impl Bridge {
                 .skip_taskbar(true)
                 .decorations(false)
                 .focused(false)
-                .initialization_script(init)
                 .on_page_load(move |_wv, payload| {
                     if matches!(payload.event(), PageLoadEvent::Finished) {
                         if let Some(tx) = ready_slot2.lock().unwrap().take() {
@@ -117,21 +128,18 @@ impl Bridge {
 
         // Give the page-load event a brief chance (WebKitGTK fires it in ~tens of ms, so no evals
         // are issued before load there); if it doesn't arrive, fall through to probing JS directly
-        // — a hidden WebView2 runs JS even when NavigationCompleted never fires. This is the fix
-        // that makes the cipher/PoToken webviews work on Windows.
+        // — a hidden WebView2 runs JS even when NavigationCompleted never fires.
         tokio::select! {
             _ = ready_rx => tracing::info!(label, "webview page loaded"),
             _ = tokio::time::sleep(Duration::from_secs(1)) =>
                 tracing::debug!(label, "no page-load event within 1s — probing JS directly"),
         }
 
-        // Real readiness gate: poll until JS confirms our own document is actually loaded, which
-        // (unlike a plain `1+1`, which would pass on `about:blank` too) proves BOTH the JS↔Rust
-        // round-trip works AND the right document loaded. WebView2 misses the load *event*, not the
-        // load itself; on WebKitGTK the document is loaded via `load_uri`, so the check holds there
-        // too (no Linux regression). Short per-attempt timeout so an eval whose callback is dropped
-        // pre-load (WebKitGTK quirk) retries instead of stalling. On timeout the window exists but
-        // is unusable — destroy it.
+        // Real readiness gate: poll until the harness's own global answers, which (unlike a plain
+        // `1+1`, which would pass on `about:blank` too) proves BOTH the JS↔Rust round-trip works
+        // AND that the document we asked for is the one running. Short per-attempt timeout so an
+        // eval whose callback is dropped pre-load (WebKitGTK quirk) retries instead of stalling.
+        // On timeout the window exists but is unusable — destroy it.
         let deadline = Instant::now() + Duration::from_secs(12);
         loop {
             let ready = bridge.eval_json(probe.to_owned(), Duration::from_millis(800)).await;

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -36,6 +36,11 @@ export interface SongItem {
 	added_by_avatar?: string;
 	/** The signed-in user's rating (absent when the response didn't say — same as 'indifferent'). */
 	rating?: Rating;
+	/** "Add to library" off the row's own menu, with a token for each direction. Absent on rows
+	 *  YouTube sent no menu for, and on the ones built here (local files, On Repeat, a Listen
+	 *  Together guest's queue) — the menu hides the action rather than offering a dead one.
+	 *  Library ▸ Songs is not Liked Music: this is a feedback write, not a rating. */
+	library?: { in_library: boolean; add_token?: string; remove_token?: string };
 	/** Listen Together: name of the guest who added this queue item (session adds only). */
 	queued_by?: string;
 	/** Queued to play next ("Play next", or a guest's session add) — the "Next in queue" block. */
@@ -492,6 +497,9 @@ export const deletePlaylist = (playlistId: string) =>
 	invoke<void>('delete_playlist', { playlistId });
 export const subscribe = (channelId: string, subscribed: boolean) =>
 	invoke<void>('subscribe', { channelId, subscribed });
+/** Add a song to Library ▸ Songs, or take it out. `token` is `SongItem.library.add_token` /
+ *  `.remove_token`; YouTube mints them per row, so they come from the list the song was shown in. */
+export const setSongSaved = (token: string) => invoke<void>('set_song_saved', { token });
 /** Save an album to the library (or remove it). `playlistId` is `AlbumPage.playlistId`. */
 export const setAlbumSaved = (playlistId: string, saved: boolean) =>
 	invoke<void>('set_album_saved', { playlistId, saved });

--- a/ui/src/lib/components/LibrarySongs.svelte
+++ b/ui/src/lib/components/LibrarySongs.svelte
@@ -21,7 +21,7 @@
 	import ErrorState from './ErrorState.svelte';
 	import * as api from '$lib/api';
 	import type { SongItem } from '$lib/api';
-	import { getCached, putCached } from '$lib/pagecache';
+	import { getCached, putCached, LIBRARY_SONGS_KEY } from '$lib/pagecache';
 	import { thumb } from '$lib/thumb';
 	import {
 		openAddToPlaylist,
@@ -40,7 +40,7 @@
 
 	// Cached like every other browse page, so switching tabs (or leaving the Library and coming
 	// back) paints the list instead of refetching it and losing every page you scrolled in.
-	const KEY = $derived(uploads ? 'library:uploads' : 'library:songs');
+	const KEY = $derived(uploads ? 'library:uploads' : LIBRARY_SONGS_KEY);
 	type Cached = { items: SongItem[]; continuation?: string };
 
 	// `$state.raw`, same reason as the playlist page: a deep proxy puts every read of every row

--- a/ui/src/lib/components/LibrarySongs.svelte
+++ b/ui/src/lib/components/LibrarySongs.svelte
@@ -23,7 +23,13 @@
 	import type { SongItem } from '$lib/api';
 	import { getCached, putCached } from '$lib/pagecache';
 	import { thumb } from '$lib/thumb';
-	import { openAddToPlaylist, openPlayer, playback } from '$lib/player.svelte';
+	import {
+		openAddToPlaylist,
+		openPlayer,
+		playback,
+		removeSongFromLibrary,
+		songLibraryRemoval
+	} from '$lib/player.svelte';
 	import { t } from '$lib/i18n.svelte';
 
 	// The same tab, pointed at a different browse id: Library ▸ Songs by default, or the tracks the
@@ -193,6 +199,19 @@
 	// plays after it. The pages that haven't arrived ride along as the token, which the backend
 	// walks into the queue behind what's playing (mixing them into the unplayed tail on shuffle),
 	// so Shuffle all is a shuffle of the library and not of the first 25 songs.
+	// Only where there is a way out: YouTube sends no menu for a song that is in this list because
+	// its album is saved, and the album is what holds it. The Uploads tab is a different list
+	// entirely, and removing from it would be deleting the upload.
+	const removable = (song: SongItem) => !uploads && !!songLibraryRemoval(song);
+
+	// Drop the row on success only, and write the shortened list back to the page cache: coming
+	// back to the tab paints from there, and a row that is gone from YouTube must not reappear.
+	async function remove(song: SongItem) {
+		if (!(await removeSongFromLibrary(song))) return;
+		songs = songs.filter((s) => s !== song);
+		cache();
+	}
+
 	function play(start: number | null, shuffle = false) {
 		if (!songs.length) return;
 		openPlayer();
@@ -269,8 +288,11 @@
 					{song}
 					index={i}
 					active={song.video_id === nowId}
+					inLibraryList={!uploads}
 					onplay={() => play(songs.indexOf(song))}
 					onAdd={() => openAddToPlaylist(song)}
+					onRemove={removable(song) ? () => remove(song) : undefined}
+					removeLabel={t('library.remove_from_library')}
 				/>
 			{/each}
 		</div>

--- a/ui/src/lib/components/PlaylistMenu.svelte
+++ b/ui/src/lib/components/PlaylistMenu.svelte
@@ -11,7 +11,9 @@
 		Radio02Icon,
 		ArrowUpNarrowWideIcon,
 		ArrowDownWideNarrowIcon,
+		BookmarkCheck02Icon,
 		BookmarkMinus02Icon,
+		BookPlusIcon,
 		DashboardSquare02Icon,
 		Share08Icon
 	} from '@hugeicons/core-free-icons';
@@ -22,9 +24,14 @@
 	import { t } from '$lib/i18n.svelte';
 	import {
 		addPick,
+		addToLibrary,
 		auth,
+		inLibrary,
 		isSaved,
+		ownedByUser,
+		removeFromLibrary,
 		isSynced,
+		loadLibraryExtras,
 		openShare,
 		personal,
 		removePick,
@@ -58,6 +65,13 @@
 	const savedHere = $derived(
 		isSaved(item.id) && !(auth.account?.signedIn && isSynced(item.id))
 	);
+	// Saved here or on the account. `savedHere` is the narrower one: only a local row can be taken
+	// back out from a menu, since undoing YouTube's own copy belongs on the item's page.
+	const inLib = $derived(inLibrary(item));
+	// Your own playlists, uploads, Liked Music and On Repeat are in the library by being what they
+	// are: the row says so and does nothing. Everything else got saved, so it can be unsaved.
+	const owned = $derived(ownedByUser(item));
+
 	// Radio and Share both need a YouTube item behind them: local folders and the locally-built
 	// On Repeat have none.
 	const onYouTube = $derived(!api.isLocalId(item.id) && item.id !== api.ON_REPEAT_ID);
@@ -79,6 +93,37 @@
 		}
 	}
 
+	let saving = $state(false);
+	async function save() {
+		if (saving) return;
+		saving = true;
+		try {
+			const result = await addToLibrary(item);
+			toast.success(
+				result === 'already' ? t('toasts.already_in_library') : t('library.saved_to_library')
+			);
+			menuOpen = false;
+		} catch (e) {
+			toast.error(String(e));
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function unsave() {
+		if (saving) return;
+		saving = true;
+		try {
+			await removeFromLibrary(item);
+			toast.success(t('toasts.removed_from_library'));
+			menuOpen = false;
+		} catch (e) {
+			toast.error(String(e));
+		} finally {
+			saving = false;
+		}
+	}
+
 	let menuOpen = $state(false);
 	let anchor = $state(NO_ANCHOR);
 
@@ -86,6 +131,11 @@
 	function openMenu(e: MouseEvent) {
 		e.preventDefault(); // a right-click must not also raise WebKit's own menu
 		e.stopPropagation();
+		// Saved albums and artists are only fetched by the Library page, and without them every card
+		// outside it would offer "Save to library" for something the account already holds. Cached
+		// after the first menu, so this is one pair of requests per session.
+		if (auth.account?.signedIn && (item.kind === 'album' || item.kind === 'artist'))
+			loadLibraryExtras();
 		anchor = anchorMenu(e, { align: 'right' });
 		menuOpen = true;
 	}
@@ -195,6 +245,37 @@
 				<HugeiconsIcon icon={Share08Icon} class="h-4 w-4" /> {t("player.share")}
 			</button>
 		{/if}
+		<!-- One row for library membership: put it in, take the local copy back out, or just say it
+		     is already there (YouTube's own copy is unsaved from the item's page, which knows which
+		     write to send). Local folders and On Repeat have no library to be in. -->
+		{#if onYouTube && !inLib}
+			<button
+				class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10 disabled:opacity-50"
+				disabled={saving}
+				onclick={(e) => {
+					e.stopPropagation();
+					save();
+				}}
+			>
+				<HugeiconsIcon icon={BookPlusIcon} class="h-4 w-4" /> {t('library.save_to_library')}
+			</button>
+		{:else if onYouTube && !savedHere && !owned}
+			<button
+				class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10 disabled:opacity-50"
+				disabled={saving}
+				onclick={(e) => {
+					e.stopPropagation();
+					unsave();
+				}}
+			>
+				<HugeiconsIcon icon={BookmarkMinus02Icon} class="h-4 w-4" />
+				{t('library.remove_from_library')}
+			</button>
+		{:else if onYouTube}
+			<div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground">
+				<HugeiconsIcon icon={BookmarkCheck02Icon} class="h-4 w-4" /> {t('library.in_library')}
+			</div>
+		{/if}
 		<!-- Only for cards saved on this machine: YouTube's own library rows are unsaved from their
 		     page, where the button knows which write action to send. -->
 		{#if savedHere}
@@ -206,7 +287,7 @@
 						toast.success(t('toasts.removed_from_library'));
 					})}
 			>
-				<HugeiconsIcon icon={BookmarkMinus02Icon} class="h-4 w-4" /> Remove from library
+				<HugeiconsIcon icon={BookmarkMinus02Icon} class="h-4 w-4" /> {t('library.remove_from_library')}
 			</button>
 		{/if}
 	</div>

--- a/ui/src/lib/components/SearchSuggest.svelte
+++ b/ui/src/lib/components/SearchSuggest.svelte
@@ -239,13 +239,18 @@
 					</div>
 				{/each}
 			{/if}
-			<!-- submit, so the enclosing form decides what "all results" does. -->
+			<!-- Submits the enclosing form, which is where each caller decides what "all results" does.
+			     Explicitly, not type="submit": closing the panel unmounts this button mid-click, and a
+			     submit button removed from the DOM before the click completes never submits (#125). -->
 			<button
-				type="submit"
+				type="button"
 				class="flex w-full cursor-pointer items-center gap-2 border-t bg-muted/30 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
 				onmousedown={(e) => e.preventDefault()}
 				onmouseenter={() => (active = -1)}
-				onclick={close}
+				onclick={(e) => {
+					e.currentTarget.form?.requestSubmit();
+					close();
+				}}
 			>
 				<HugeiconsIcon icon={Search01Icon} class="h-3.5 w-3.5" />
 				All results for “{value.trim()}”

--- a/ui/src/lib/components/TheaterMode.svelte
+++ b/ui/src/lib/components/TheaterMode.svelte
@@ -581,16 +581,3 @@
 		{/if}
 	</div>
 </section>
-
-<style>
-	/* A thicker track than the app-wide `.range`: this bar is the width of the cover and is being
-	   read from across a room, and 4px on that width reads as a hairline. */
-	.theater-range::-webkit-slider-runnable-track {
-		height: 6px;
-	}
-	.theater-range::-webkit-slider-thumb {
-		margin-top: -4px;
-		height: 14px;
-		width: 14px;
-	}
-</style>

--- a/ui/src/lib/components/TrackMenu.svelte
+++ b/ui/src/lib/components/TrackMenu.svelte
@@ -12,6 +12,8 @@
 		MoreVerticalIcon,
 		PlayListAddIcon,
 		PlayListRemoveIcon,
+		BookmarkMinus02Icon,
+		BookPlusIcon,
 		ArrowUpNarrowWideIcon,
 		ArrowDownWideNarrowIcon,
 		Radio02Icon,
@@ -29,12 +31,15 @@
 	import {
 		addPick,
 		enqueue,
+		inSongLibrary,
+		songLibraryToken,
 		openShare,
 		personal,
 		ratingOf,
 		removePick,
 		startRadio,
-		toggleRating
+		toggleRating,
+		toggleSongLibrary
 	} from '$lib/player.svelte';
 	import { t } from '$lib/i18n.svelte';
 	import TempoPitchDialog from './TempoPitchDialog.svelte';
@@ -93,6 +98,11 @@
 	}
 
 	const rated = $derived(ratingOf(song));
+	// Library ▸ Songs, which is a different list from Liked Music and a different write. Only rows
+	// YouTube sent a menu with carry the tokens for it, so the row is absent on the ones this app
+	// builds itself (local files, On Repeat, a mirrored guest queue) rather than dead.
+	const inLib = $derived(inSongLibrary(song));
+	const libraryToken = $derived(songLibraryToken(song));
 	// A local file has no YouTube identity: liking it or putting it in a YTM playlist is not a
 	// thing, so those items don't show. Queue, shortcuts and go-to-album work normally.
 	const isLocal = $derived(api.isLocalId(song.video_id));
@@ -183,6 +193,21 @@
 					class="h-4 w-4 {rated === 'dislike' ? 'fill-current text-foreground' : ''}"
 				/>
 				{rated === 'dislike' ? t('player.remove_dislike') : t('common.dislike')}
+			</button>
+		{/if}
+		{#if libraryToken}
+			<button
+				class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
+				onclick={(e) => run(e, () => toggleSongLibrary(song))}
+			>
+				<!-- altIcon/showAlt, not a ternary: `icon` is read once at mount. -->
+				<HugeiconsIcon
+					icon={BookPlusIcon}
+					altIcon={BookmarkMinus02Icon}
+					showAlt={inLib}
+					class="h-4 w-4"
+				/>
+				{inLib ? t('library.remove_from_library') : t('library.save_to_library')}
 			</button>
 		{/if}
 		{#if song.artist_id}

--- a/ui/src/lib/components/TrackMenu.svelte
+++ b/ui/src/lib/components/TrackMenu.svelte
@@ -50,7 +50,8 @@
 		onAdd,
 		onRemove,
 		removeLabel = t('player.remove_from_playlist'),
-		linksOnly = false
+		linksOnly = false,
+		inLibraryList = false
 	}: {
 		song: SongItem;
 		/** Classes for the ⋯ trigger button (positioning differs per host: inline vs overlay). */
@@ -63,6 +64,12 @@
 		/** Player-bar variant: ⋮ trigger, and only artist/album/shortcuts (queue and like already
 		    have their own buttons there). */
 		linksOnly?: boolean;
+		/**
+		 * The row is being shown *in* Library ▸ Songs, where "Save to library" makes no sense: the
+		 * only direction is out, and that is the host's `onRemove` (it owns the list the row has to
+		 * disappear from). A song sitting in that list because its album is saved gets neither.
+		 */
+		inLibraryList?: boolean;
 	} = $props();
 
 	// Already on the home grid: the menu offers the way out rather than a second copy.
@@ -195,7 +202,7 @@
 				{rated === 'dislike' ? t('player.remove_dislike') : t('common.dislike')}
 			</button>
 		{/if}
-		{#if libraryToken}
+		{#if libraryToken && !inLibraryList}
 			<button
 				class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
 				onclick={(e) => run(e, () => toggleSongLibrary(song))}

--- a/ui/src/lib/components/TrackRow.svelte
+++ b/ui/src/lib/components/TrackRow.svelte
@@ -30,7 +30,8 @@
 		onplay,
 		onAdd,
 		onRemove,
-		removeLabel = t('player.remove_from_playlist')
+		removeLabel = t('player.remove_from_playlist'),
+		inLibraryList = false
 	}: {
 		song: SongItem;
 		/** Position badge when set (playlist/queue); omitted for flat search results. */
@@ -56,6 +57,8 @@
 		 */
 		hideRating?: boolean;
 		onplay: () => void;
+		/** The row lives in Library ▸ Songs: passed through so its menu drops "Save to library". */
+		inLibraryList?: boolean;
 		/** Adds an "Add to playlist" menu item. */
 		onAdd?: () => void;
 		/** Adds a remove menu item (label via `removeLabel`). */
@@ -263,6 +266,7 @@
 			{onAdd}
 			{onRemove}
 			{removeLabel}
+			{inLibraryList}
 			triggerClass="cursor-pointer rounded-md p-1.5 text-muted-foreground transition hover:bg-accent/20 hover:text-foreground focus-visible:opacity-100 {compact
 				? ''
 				: 'opacity-0 group-hover:opacity-100'}"

--- a/ui/src/lib/locales/en.ts
+++ b/ui/src/lib/locales/en.ts
@@ -519,6 +519,7 @@ export const en = {
 		playlist_updated: 'Playlist updated',
 		playlist_created: 'Created "{title}"',
 		playlist_deleted: 'Playlist deleted',
+		already_in_library: 'Already in your library',
 		removed_from_library: 'Removed from library',
 		removed_from_liked: 'Removed from Liked Music',
 		removed_from_playlist: 'Removed from playlist',

--- a/ui/src/lib/locales/tr.ts
+++ b/ui/src/lib/locales/tr.ts
@@ -522,6 +522,7 @@ export const tr: Translations = {
 		playlist_updated: 'Çalma listesi güncellendi',
 		playlist_created: '"{title}" oluşturuldu',
 		playlist_deleted: 'Çalma listesi silindi',
+		already_in_library: 'Zaten kitaplığınızda',
 		removed_from_library: 'Kitaplıktan çıkarıldı',
 		removed_from_liked: 'Beğenilenlerden çıkarıldı',
 		removed_from_playlist: 'Çalma listesinden çıkarıldı',

--- a/ui/src/lib/pagecache.ts
+++ b/ui/src/lib/pagecache.ts
@@ -26,6 +26,9 @@ export function putCached(key: string, data: unknown): void {
 	store.set(key, { data, at: Date.now() });
 }
 
+/** Library ▸ Songs, shared: every write that changes what's in that list has to drop it. */
+export const LIBRARY_SONGS_KEY = 'library:songs';
+
 export function invalidateCached(key: string): void {
 	store.delete(key);
 }

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -770,8 +770,9 @@ const RATED: Record<Rating, string> = {
 	indifferent: 'Rating removed'
 };
 
-/** Optimistic rating change, reverted if YouTube rejects it. */
-async function rate(song: SongItem, next: Rating) {
+/** Optimistic rating change, reverted if YouTube rejects it. `msg` overrides the toast, for the
+ *  callers that clear a like by another name (out of Library ▸ Songs, which is that same list). */
+async function rate(song: SongItem, next: Rating, msg?: string) {
 	const prev = ratingOf(song);
 	if (prev === next) return;
 	const isNow = playback.now?.videoId === song.video_id;
@@ -783,7 +784,7 @@ async function rate(song: SongItem, next: Rating) {
 		// otherwise correct it runs at most every six hours.
 		if (next === 'like') noteSavedIn(api.LIKED_MUSIC_ID, [song.video_id]);
 		else noteUnsavedFrom(api.LIKED_MUSIC_ID, song.video_id);
-		toast.success(RATED[next]);
+		toast.success(msg ?? RATED[next]);
 		if (next === 'dislike') dropDisliked(song.video_id, isNow);
 	} catch (e) {
 		ratings[song.video_id] = prev;
@@ -815,6 +816,40 @@ const songLibrary = $state<Record<string, boolean>>({});
  *  until the list is fetched again — better than a button that answers "token expired". */
 export function songLibraryToken(song: SongItem): string | undefined {
 	return inSongLibrary(song) ? song.library?.remove_token : song.library?.add_token;
+}
+
+/**
+ * How a row in Library ▸ Songs can be taken back out, if it can at all.
+ *
+ * `token` when YouTube sent one with the row, which is the individually-saved case. Otherwise a
+ * like is what put the song in that list (it browses `FEmusic_liked_videos`), so clearing the like
+ * is the removal. A song that is only there because its album is saved has neither, and gets no
+ * option: YouTube sends those rows without a menu, which is its own way of saying the album is
+ * what holds them.
+ */
+export function songLibraryRemoval(song: SongItem): 'token' | 'like' | undefined {
+	if (song.library?.remove_token) return 'token';
+	return isLiked(song) ? 'like' : undefined;
+}
+
+/** Take a song out of Library ▸ Songs by whichever route it has. Answers whether it worked, so the
+ *  list only drops the row on success. Toasts either way. */
+export async function removeSongFromLibrary(song: SongItem): Promise<boolean> {
+	const how = songLibraryRemoval(song);
+	if (!how) return false;
+	if (how === 'like') {
+		await rate(song, 'indifferent', t('toasts.removed_from_library'));
+		return ratingOf(song) !== 'like';
+	}
+	try {
+		await api.setSongSaved(song.library!.remove_token!);
+		songLibrary[song.video_id] = false;
+		toast.success(t('toasts.removed_from_library'));
+		return true;
+	} catch (e) {
+		toast.error(String(e));
+		return false;
+	}
 }
 
 /** In Library ▸ Songs? The row's own menu is the fallback; a write in this session wins. */

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -13,7 +13,7 @@ import type {
 	SongItem
 } from './api';
 import { applyLtState, lt } from './lt.svelte';
-import { clearCached } from './pagecache';
+import { clearCached, invalidateCached, LIBRARY_SONGS_KEY } from './pagecache';
 import * as pl from './personal';
 import type { Personal } from './personal';
 import { appearance } from './theme.svelte';
@@ -784,6 +784,9 @@ async function rate(song: SongItem, next: Rating, msg?: string) {
 		// otherwise correct it runs at most every six hours.
 		if (next === 'like') noteSavedIn(api.LIKED_MUSIC_ID, [song.video_id]);
 		else noteUnsavedFrom(api.LIKED_MUSIC_ID, song.video_id);
+		// Library ▸ Songs *is* the liked-videos browse, and its tab paints from the cache without
+		// revalidating, so a like from anywhere else has to drop it or the row is missing for 5 min.
+		invalidateCached(LIBRARY_SONGS_KEY);
 		toast.success(msg ?? RATED[next]);
 		if (next === 'dislike') dropDisliked(song.video_id, isNow);
 	} catch (e) {
@@ -869,6 +872,7 @@ export async function toggleSongLibrary(song: SongItem): Promise<void> {
 	songLibrary[song.video_id] = next; // optimistic
 	try {
 		await api.setSongSaved(token);
+		invalidateCached(LIBRARY_SONGS_KEY); // the tab paints from cache; this changed what's in it
 		toast.success(next ? t('library.saved_to_library') : t('toasts.removed_from_library'));
 	} catch (e) {
 		delete songLibrary[song.video_id];

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -196,7 +196,10 @@ export async function createLibraryPlaylist(title: string): Promise<void> {
 	// YouTube's library browse is eventually-consistent and won't include a brand-new playlist for a
 	// few seconds, so surface it immediately instead of refetching.
 	const browseId = id.startsWith('VL') ? id : `VL${id}`;
-	library.items = [{ kind: 'playlist', id: browseId, title }, ...library.items];
+	// The owner line in YouTube's own format ("<owner> • N tracks"), because that is what
+	// `ownedByUser` reads to know this one is yours before the library reloads and says so itself.
+	const subtitle = auth.account?.name ? `${auth.account.name} \u2022 0 tracks` : undefined;
+	library.items = [{ kind: 'playlist', id: browseId, title, subtitle }, ...library.items];
 }
 
 /** Optimistically apply an edit to a library playlist's row (sidebar + Library grid), so a rename
@@ -234,7 +237,9 @@ export const savedIn = $state({ map: {} as Record<string, string[]> });
 export function savedPlaylists(videoId: string): BrowseItem[] {
 	const ids = savedIn.map[videoId];
 	if (!ids?.length) return [];
-	const holding = new Set(ids);
+	// Liked Music is indexed (it is what fills the heart on a search row) but never named here:
+	// the thumbs-up next to the chip already says it.
+	const holding = new Set(ids.filter((id) => id !== api.LIKED_MUSIC_ID));
 	return library.items.filter((it) => holding.has(it.id));
 }
 
@@ -455,6 +460,148 @@ export const isSaved = (id: string): boolean => pl.isSaved(personal, id);
 export const isSynced = (id: string): boolean => pl.isSynced(personal, id);
 
 /**
+ * Put one saved card on the account. `known` is the library's playlist grid when the caller already
+ * has it. Answers what happened: 'saved', 'already' when YouTube's own copy made it a no-op, or
+ * 'unsupported' for a kind YouTube has nothing to save (a song, which lives in Liked Music).
+ */
+async function pushSaved(
+	item: BrowseItem,
+	known?: Set<string>
+): Promise<'saved' | 'already' | 'unsupported'> {
+	if (item.kind === 'album') {
+		// YouTube's own answer, so it can't be liked twice. The album's audio playlist is the like
+		// target and only its page carries it, which is what this fetch is for.
+		const album = await api.getAlbum(item.id);
+		if (album.inLibrary) return 'already';
+		if (!album.playlistId) throw new Error('no album playlist');
+		await api.setAlbumSaved(album.playlistId, true);
+	} else if (item.kind === 'artist') {
+		// Subscribing twice is the same subscription. No pre-check: the library's artist grid is
+		// built from the songs in your library, not from subscriptions, so it can't answer.
+		await api.subscribe(item.id, true);
+	} else if (item.kind === 'playlist') {
+		// A playlist is liked by its browseId (Rust strips the `VL`), and it lands in the same grid
+		// `known` was built from, so a hit there means it is already saved.
+		if (known?.has(item.id)) return 'already';
+		await api.setAlbumSaved(item.id, true);
+	} else {
+		return 'unsupported';
+	}
+	return 'saved';
+}
+
+/**
+ * Is this card in the library, wherever the library happens to live: saved on this machine, or on
+ * the signed-in account. Albums and artists only answer once `loadLibraryExtras` has run, which is
+ * why the menus kick it off when they open.
+ *
+ * Songs are not here: their library is Liked Music (Library ▸ Songs browses `FEmusic_liked_videos`),
+ * so `isLiked` is the answer and TrackMenu uses it.
+ */
+export function inLibrary(item: BrowseItem): boolean {
+	if (pl.isSaved(personal, item.id)) return true;
+	if (!auth.account?.signedIn) return false;
+	const list =
+		item.kind === 'album' ? library.albums : item.kind === 'artist' ? library.artists : library.items;
+	return list.some((i) => i.id === item.id);
+}
+
+/**
+ * The menu's "Save to library": the local row always (it is the whole library signed out, and it is
+ * what makes the indicator flip everywhere at once), plus the matching write on the account when
+ * signed in, flagged `synced` so the Library's sync button has nothing left to push for it.
+ */
+export async function addToLibrary(item: BrowseItem): Promise<'saved' | 'already'> {
+	// Whatever the menu was showing, say so instead of writing again: the card can have landed in
+	// the account library from another device since this view was fetched.
+	if (inLibrary(item)) return 'already';
+	const known = item.kind === 'playlist' ? new Set(library.items.map((i) => i.id)) : undefined;
+	pl.toggleSaved(personal, item);
+	savePersonal(); // before the write: a rejected push must not lose the local row too
+	if (!auth.account?.signedIn) return 'saved';
+	const result = await pushSaved(item, known);
+	if (result !== 'unsupported') {
+		pl.markSynced(personal, [item.id]);
+		savePersonal();
+	}
+	return result === 'already' ? 'already' : 'saved';
+}
+
+/**
+ * Yours by definition, so there is no "remove from library" to offer: a playlist you made (YTM's
+ * library subtitle is "<owner> • N tracks", and on your own it names you), your uploads, Liked
+ * Music and the locally-built On Repeat. Everything else in the library got there by being saved,
+ * and can be unsaved.
+ *
+ * ponytail: the owner name, because the grid browse carries no ownership flag (only a playlist's
+ * own page does, via `musicEditablePlaylistDetailHeaderRenderer`). If this ever reads wrong, the
+ * removal it wrongly offers is a no-op and `loadLibrary(true)` puts the row straight back.
+ */
+export function ownedByUser(item: BrowseItem): boolean {
+	if (item.id === api.LIKED_MUSIC_ID || item.id === api.ON_REPEAT_ID || api.isLocalId(item.id))
+		return true;
+	if (item.isUpload) return true;
+	if (item.kind !== 'playlist') return false;
+	const me = auth.account?.name?.trim();
+	if (!me) return false;
+	// The library's own row wins: a card from a home shelf carries a different subtitle.
+	const row = library.items.find((i) => i.id === item.id) ?? item;
+	return (row.subtitle ?? '').split('\u2022')[0].trim() === me;
+}
+
+/**
+ * Take a card back out of the library: the local row, and the account's own copy when signed in
+ * (an album's like, an artist's subscription, a saved playlist's like). Optimistic, like every
+ * other library write here, and reverted if YouTube says no. Not for the kinds `ownedByUser`
+ * covers, which have nothing to undo.
+ */
+export async function removeFromLibrary(item: BrowseItem): Promise<void> {
+	const wasSaved = pl.isSaved(personal, item.id);
+	if (wasSaved) {
+		pl.toggleSaved(personal, item);
+		savePersonal();
+	}
+	if (!auth.account?.signedIn) return;
+	const before = { items: library.items, albums: library.albums, artists: library.artists };
+	library.items = library.items.filter((i) => i.id !== item.id);
+	library.albums = library.albums.filter((i) => i.id !== item.id);
+	library.artists = library.artists.filter((i) => i.id !== item.id);
+	try {
+		if (item.kind === 'album') {
+			// The like sits on the album's audio playlist, which only its page carries.
+			const album = await api.getAlbum(item.id);
+			if (album.inLibrary && album.playlistId) await api.setAlbumSaved(album.playlistId, false);
+		} else if (item.kind === 'artist') {
+			await api.subscribe(item.id, false);
+		} else if (item.kind === 'playlist') {
+			await api.setAlbumSaved(item.id, false);
+		}
+	} catch (e) {
+		library.items = before.items;
+		library.albums = before.albums;
+		library.artists = before.artists;
+		if (wasSaved) {
+			pl.toggleSaved(personal, item);
+			savePersonal();
+		}
+		throw e;
+	}
+}
+
+/**
+ * Mirror an account-side save into the local library row: the artist page's Subscribe, the album
+ * page's Save. Without it a card's ⋯ menu would keep offering "Save to library" for something the
+ * account already holds, since the library's artist grid is built from songs, not subscriptions.
+ * Flagged `synced`, so the Library's sync button doesn't count it and no menu offers a local-only
+ * removal of a row YouTube owns.
+ */
+export function noteLibrary(item: BrowseItem, saved: boolean) {
+	if (saved !== pl.isSaved(personal, item.id)) pl.toggleSaved(personal, item);
+	if (saved) pl.markSynced(personal, [item.id]);
+	savePersonal();
+}
+
+/**
  * Push everything saved on this machine into the signed-in account. The local rows stay put and are
  * only flagged `synced`: they are the whole library again the moment the user signs out, and
  * `mergeSaved` dedupes the two copies into one card while signed in. Sequential, like every other
@@ -469,25 +616,7 @@ export async function syncSavedToYouTube(): Promise<{ synced: number; failed: nu
 	let failed = 0;
 	for (const item of pl.unsynced(personal)) {
 		try {
-			if (item.kind === 'album') {
-				// YouTube's own answer, so it can't be liked twice. The album's audio playlist is the
-				// like target and only its page carries it, which is what this fetch is for.
-				const album = await api.getAlbum(item.id);
-				if (!album.inLibrary) {
-					if (!album.playlistId) throw new Error('no album playlist');
-					await api.setAlbumSaved(album.playlistId, true);
-				}
-			} else if (item.kind === 'artist') {
-				// Subscribing twice is the same subscription. No pre-check: the library's artist grid
-				// is built from the songs in your library, not from subscriptions, so it can't answer.
-				await api.subscribe(item.id, true);
-			} else if (item.kind === 'playlist') {
-				// A playlist is liked by its browseId (Rust strips the `VL`), and it lands in the same
-				// grid `known` was built from, so a hit there means it is already saved.
-				if (!known.has(item.id)) await api.setAlbumSaved(item.id, true);
-			} else {
-				continue; // ponytail: songs can't be saved today, so there is nothing to push
-			}
+			if ((await pushSaved(item, known)) === 'unsupported') continue;
 			done.push(item.id);
 		} catch {
 			failed++;
@@ -518,7 +647,15 @@ const ratings = $state<Record<string, Rating>>({});
 
 export function ratingOf(song: SongItem): Rating {
 	if (playback.now?.videoId === song.video_id) return playback.rating;
-	return ratings[song.video_id] ?? song.rating ?? 'indifferent';
+	// The saved-in index is the fallback, not an override: a `search` response carries no
+	// `likeStatus` on any row (live-checked 2026-08-28), so without it every search result drew
+	// itself unrated. A row that does state its rating still wins, since it is fresher than a
+	// crawl up to six hours old.
+	return (
+		ratings[song.video_id] ??
+		song.rating ??
+		(savedIn.map[song.video_id]?.includes(api.LIKED_MUSIC_ID) ? 'like' : 'indifferent')
+	);
 }
 
 export const isLiked = (song: SongItem): boolean => ratingOf(song) === 'like';
@@ -642,6 +779,10 @@ async function rate(song: SongItem, next: Rating) {
 	if (isNow) playback.rating = next;
 	try {
 		await api.rate(song.video_id, next);
+		// Keep the index in step: it outlives this override on a reload, and the crawl that would
+		// otherwise correct it runs at most every six hours.
+		if (next === 'like') noteSavedIn(api.LIKED_MUSIC_ID, [song.video_id]);
+		else noteUnsavedFrom(api.LIKED_MUSIC_ID, song.video_id);
 		toast.success(RATED[next]);
 		if (next === 'dislike') dropDisliked(song.video_id, isNow);
 	} catch (e) {
@@ -662,6 +803,42 @@ async function dropDisliked(videoId: string, isNow: boolean) {
 		if (items[i]?.video_id === videoId) await api.removeFromQueue(i).catch(() => {});
 	}
 	if (isNow) api.nextTrack().catch((e) => toast.error(String(e)));
+}
+
+// Library membership for songs, overriding what the row was fetched with — the same trick as
+// `ratings` above and for the same reason: one song shows up in a list, its ⋯ menu and the queue at
+// once, and all three have to agree the moment one of them writes.
+const songLibrary = $state<Record<string, boolean>>({});
+
+/** The token for the direction this song can move in, if the row carried one. A menu that offered
+ *  only one way (see `LibraryToggle`) runs out after that one write, and the row hides the action
+ *  until the list is fetched again — better than a button that answers "token expired". */
+export function songLibraryToken(song: SongItem): string | undefined {
+	return inSongLibrary(song) ? song.library?.remove_token : song.library?.add_token;
+}
+
+/** In Library ▸ Songs? The row's own menu is the fallback; a write in this session wins. */
+export function inSongLibrary(song: SongItem): boolean {
+	return songLibrary[song.video_id] ?? song.library?.in_library ?? false;
+}
+
+/**
+ * Add a song to the library, or take it out. Nothing to do with the rating: Library ▸ Songs and
+ * Liked Music are separate lists, and this write is a feedback token minted on the row itself, so
+ * only songs YouTube sent a menu with can offer it (`song.library`).
+ */
+export async function toggleSongLibrary(song: SongItem): Promise<void> {
+	const next = !inSongLibrary(song);
+	const token = songLibraryToken(song);
+	if (!token) return;
+	songLibrary[song.video_id] = next; // optimistic
+	try {
+		await api.setSongSaved(token);
+		toast.success(next ? t('library.saved_to_library') : t('toasts.removed_from_library'));
+	} catch (e) {
+		delete songLibrary[song.video_id];
+		toast.error(String(e));
+	}
 }
 
 /** Click the rating you already have to clear it, the way YouTube Music's own buttons work.

--- a/ui/src/routes/album/[id]/+page.svelte
+++ b/ui/src/routes/album/[id]/+page.svelte
@@ -38,6 +38,7 @@
         playFrom,
         startRadio,
         toast,
+        noteLibrary,
         toggleSaved,
     } from "$lib/player.svelte";
     import { getCached, putCached } from "$lib/pagecache";
@@ -184,16 +185,19 @@
             toast.success(next ? "Saved to library" : "Removed from library");
             return;
         }
-        // Signed in: YouTube owns it from here, so drop any local row left from before signing in.
-        if (savedHere) toggleSaved(asItem());
+        // Signed in: YouTube owns it from here. The local row is kept in step rather than dropped,
+        // so a card's ⋯ menu elsewhere shows the album as being in the library (and it still renders
+        // offline); `noteLibrary` flags it synced, so nothing offers a local-only removal.
         if (a.inLibrary === next) {
+            noteLibrary(asItem(), next);
             toast.success(next ? "Saved to library" : "Removed from library");
-            return; // YouTube already agrees; only the local row had to go
+            return; // YouTube already agrees; only the local row had to move
         }
         a.inLibrary = next;
         savingLibrary = true;
         try {
             await api.setAlbumSaved(a.playlistId, next);
+            noteLibrary(asItem(), next);
             toast.success(next ? "Saved to library" : "Removed from library");
         } catch (e) {
             a.inLibrary = !next;

--- a/ui/src/routes/artist/[id]/+page.svelte
+++ b/ui/src/routes/artist/[id]/+page.svelte
@@ -32,6 +32,7 @@
 		playFrom,
 		startRadio,
 		toast,
+		noteLibrary,
 		toggleSaved
 	} from '$lib/player.svelte';
 	import { getCached, putCached } from '$lib/pagecache';
@@ -136,6 +137,7 @@
 		try {
 			await api.subscribe(artist.channelId, next);
 			putCached(`artist:${id}`, { ...artist, subscribed: next }); // keep the cache truthful
+			noteLibrary(asItem(), next); // so every card's menu agrees the artist is in the library
 			toast.success(next ? `Subscribed to ${artist.name ?? ''}` : `Unsubscribed`);
 		} catch (e) {
 			subscribed = !next; // revert

--- a/ui/src/routes/artist/[id]/+page.svelte
+++ b/ui/src/routes/artist/[id]/+page.svelte
@@ -131,16 +131,21 @@
 
 	async function toggleSub() {
 		if (!artist || subBusy) return;
+		// Everything below the await names the artist this click was about, not whoever the page is
+		// showing by the time YouTube answers (same guard as `shuffle`).
+		const who = artist;
+		const cid = id;
+		const item = asItem();
 		const next = !subscribed;
 		subBusy = true;
 		subscribed = next; // optimistic
 		try {
-			await api.subscribe(artist.channelId, next);
-			putCached(`artist:${id}`, { ...artist, subscribed: next }); // keep the cache truthful
-			noteLibrary(asItem(), next); // so every card's menu agrees the artist is in the library
-			toast.success(next ? `Subscribed to ${artist.name ?? ''}` : `Unsubscribed`);
+			await api.subscribe(who.channelId, next);
+			putCached(`artist:${cid}`, { ...who, subscribed: next }); // keep the cache truthful
+			noteLibrary(item, next); // so every card's menu agrees the artist is in the library
+			toast.success(next ? `Subscribed to ${who.name ?? ''}` : `Unsubscribed`);
 		} catch (e) {
-			subscribed = !next; // revert
+			if (cid === id) subscribed = !next; // revert, unless we've since left that artist
 			toast.error(String(e));
 		} finally {
 			subBusy = false;

--- a/ui/src/routes/artist/[id]/+page.svelte
+++ b/ui/src/routes/artist/[id]/+page.svelte
@@ -142,6 +142,7 @@
 		try {
 			await api.subscribe(who.channelId, next);
 			putCached(`artist:${cid}`, { ...who, subscribed: next }); // keep the cache truthful
+			if (cid === id) subscribed = next; // left and came back: `load` repainted the old answer
 			noteLibrary(item, next); // so every card's menu agrees the artist is in the library
 			toast.success(next ? `Subscribed to ${who.name ?? ''}` : `Unsubscribed`);
 		} catch (e) {

--- a/ui/src/routes/layout.css
+++ b/ui/src/routes/layout.css
@@ -696,6 +696,16 @@ input[type='range'].range::-webkit-slider-thumb {
 	opacity: 0;
 	transition: opacity 0.15s ease, transform 0.15s ease;
 }
+/* Theater mode's bar is the width of the cover and is being read from across a room, where 4px on
+   that width reads as a hairline. */
+input[type='range'].range.theater-range::-webkit-slider-runnable-track {
+	height: 6px;
+}
+input[type='range'].range.theater-range::-webkit-slider-thumb {
+	margin-top: -4px;
+	height: 14px;
+	width: 14px;
+}
 /* The mini player's seek bar sits on cover art, where --muted has nothing to contrast with. */
 input[type='range'].range.on-art::-webkit-slider-runnable-track {
 	background: linear-gradient(to right, var(--primary) var(--pct, 0%), rgb(255 255 255 / 0.35) var(--pct, 0%));

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -15,6 +15,7 @@
 		DashboardSquare02Icon,
 		Share08Icon,
 		BookmarkAdd02Icon,
+		BookmarkCheck02Icon,
 		BookmarkMinus02Icon,
 		ListRestartIcon,
 		Sorting01Icon,
@@ -47,7 +48,11 @@
 	} from '$lib/sort';
 	import {
 		addPick,
+		addToLibrary,
 		auth,
+		library,
+		ownedByUser,
+		removeFromLibrary,
 		enqueue,
 		isSaved,
 		isSynced,
@@ -133,9 +138,12 @@
 	// playlists, Liked Music and On Repeat are in the library already by definition.
 	// Once the sync button has put it on the account, the account owns the save: removing only the
 	// local copy would leave it in the library grid, so the entry hides until the user signs out.
-	const savable = $derived(
-		!isOnRepeat && !isLiked && !editable && !(auth.account?.signedIn && isSynced(id))
+	// On the account already (pushed from here, or saved on another device): the local copy is not
+	// what holds it in the library any more, so the menu says so instead of offering a second save.
+	const inAccount = $derived(
+		!!auth.account?.signedIn && (isSynced(id) || library.items.some((i) => i.id === id))
 	);
+	const savable = $derived(!isOnRepeat && !isLiked && !editable && !inAccount);
 	const savedHere = $derived(isSaved(id));
 	// YouTube's header count includes rows that never make it into the list (unavailable or
 	// region-blocked tracks), so it reads high. Once every page is in, we know the real number, so
@@ -534,6 +542,34 @@
 	});
 
 	// This playlist as a card, for the sidebar's last-played sort and the Shortcuts grid.
+	// Saving goes through the shared path (local row, plus the account write when signed in), so a
+	// playlist saved here is in the library everywhere and not only until the next sync. Removal
+	// stays local: undoing YouTube's own copy is what `inAccount` hides this row for.
+	async function saveToLibrary() {
+		if (savedHere) {
+			toggleSaved(asItem());
+			toast.success(t('library.removed_from_library'));
+			return;
+		}
+		try {
+			const result = await addToLibrary(asItem());
+			toast.success(
+				result === 'already' ? t('toasts.already_in_library') : t('library.saved_to_library')
+			);
+		} catch (e) {
+			toast.error(String(e));
+		}
+	}
+
+	async function unsaveFromLibrary() {
+		try {
+			await removeFromLibrary(asItem());
+			toast.success(t('library.removed_from_library'));
+		} catch (e) {
+			toast.error(String(e));
+		}
+	}
+
 	const asItem = (): BrowseItem => ({
 		kind: 'playlist',
 		id,
@@ -981,14 +1017,7 @@
 		{#if savable}
 			<button
 				class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
-				onclick={() =>
-					run(() =>
-						toast.success(
-							toggleSaved(asItem())
-								? t('library.saved_to_library')
-								: t('library.removed_from_library')
-						)
-					)}
+				onclick={() => run(saveToLibrary)}
 			>
 				<!-- altIcon/showAlt, not a ternary: `icon` is read once at mount. -->
 				<HugeiconsIcon
@@ -999,6 +1028,20 @@
 				/>
 				{savedHere ? t('library.remove_from_library') : t('library.save_to_library')}
 			</button>
+		{:else if inAccount && !isOnRepeat && !isLiked && !editable}
+			{#if ownedByUser(asItem())}
+				<div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground">
+					<HugeiconsIcon icon={BookmarkCheck02Icon} class="h-4 w-4" /> {t('library.in_library')}
+				</div>
+			{:else}
+				<button
+					class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"
+					onclick={() => run(unsaveFromLibrary)}
+				>
+					<HugeiconsIcon icon={BookmarkMinus02Icon} class="h-4 w-4" />
+					{t('library.remove_from_library')}
+				</button>
+			{/if}
 		{/if}
 		{#if editable}
 			<button


### PR DESCRIPTION
Six commits on top of master.

### New features
- Save a song to your library from the ⋯ menu, and take it back out again
  from Library ▸ Songs. Songs that sit in the list because their album is
  saved get no remove option, since the album is what holds them. (#130)

### Bug fixes
- The hidden cipher webview now serves its harness over a URI scheme,
  which fixes signature extraction on Windows. (#71 and #128)
- Liked songs show as liked in search results (#129).
- "All results" is clickable in the search fields (#125).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and remove songs, albums, artists, and playlists from your YouTube library.
  * Manage song library membership from track menus and Library ▸ Songs.
  * Keep library state synchronized across playlists, albums, artists, and liked music.
* **Bug Fixes**
  * Improved search suggestions so “All results” submits reliably.
  * Improved hidden playback support on Windows.
  * Added clearer diagnostics when media URLs cannot be found.
* **Localization**
  * Added English and Turkish messaging for songs already in your library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->