### PR TITLE
fix(i18n): localize package manager update notice and interactive status messages

### DIFF
--- a/ui/src/lib/components/SettingsDialog.svelte
+++ b/ui/src/lib/components/SettingsDialog.svelte
@@ -712,9 +712,9 @@
 								{@render row({
 									title: t('settings.about.check_updates'),
 									desc: updateState.available && !updateState.canInstall
-										? `${updateState.available.version} ${t('settings.about.update_available').replace('{version}', '')} Bu derleme paket yöneticisiyle kuruldu, aynı şekilde güncelleyin.`
+										? t('settings.about.update_available_pkg', { version: updateState.available.version })
 										: updateState.available
-											? t('settings.about.update_available').replace('{version}', updateState.available.version)
+											? t('settings.about.update_available', { version: updateState.available.version })
 											: t('settings.about.up_to_date'),
 									control: updateButton,
 									below: updateResult && !updateState.available ? updateAlert : undefined

--- a/ui/src/lib/locales/en.ts
+++ b/ui/src/lib/locales/en.ts
@@ -318,6 +318,8 @@ export const en = {
 			checking_updates: 'Checking for updates...',
 			up_to_date: 'You are using the latest version.',
 			update_available: 'Version {version} is available!',
+			update_available_pkg:
+				'Version {version} is available! This build was installed via a package manager, update it the same way.',
 			install_update: 'Install and Restart',
 			download_page: 'Open download page',
 			changelog: 'Changelog & Release Notes',

--- a/ui/src/lib/locales/tr.ts
+++ b/ui/src/lib/locales/tr.ts
@@ -321,6 +321,8 @@ export const tr: Translations = {
 			checking_updates: 'Güncellemeler denetleniyor...',
 			up_to_date: 'En güncel sürümü kullanıyorsunuz.',
 			update_available: '{version} sürümü mevcut!',
+			update_available_pkg:
+				'{version} sürümü mevcut! Bu derleme paket yöneticisiyle kuruldu, aynı şekilde güncelleyin.',
 			install_update: 'Yükle ve Yeniden Başlat',
 			download_page: 'İndirme sayfasını aç',
 			changelog: 'Değişiklik Günlüğü ve Sürüm Notları',

--- a/ui/src/lib/updater.svelte.ts
+++ b/ui/src/lib/updater.svelte.ts
@@ -57,11 +57,18 @@ export async function checkForUpdatesQuiet() {
 export async function checkForUpdatesInteractive(): Promise<{ message: string; error: boolean }> {
 	updateState.checking = true;
 	try {
-		if (await look())
-			return { message: `Update available: v${updateState.available!.version}`, error: false };
-		return { message: 'You are running the latest version', error: false };
+		if (await look()) {
+			const key = !updateState.canInstall
+				? 'settings.about.update_available_pkg'
+				: 'settings.about.update_available';
+			return {
+				message: t(key, { version: updateState.available!.version }),
+				error: false
+			};
+		}
+		return { message: t('settings.about.up_to_date'), error: false };
 	} catch (e) {
-		return { message: `Update check failed: ${e}`, error: true };
+		return { message: t('toasts.update_failed', { error: String(e) }), error: true };
 	} finally {
 		updateState.checking = false;
 	}


### PR DESCRIPTION
### Description
This PR fixes hardcoded strings in the update checker and properly routes all update status and notice messages through `i18n`.

### Changes
- Replaced the hardcoded Turkish notice and broken version prefixing in `SettingsDialog.svelte` with `settings.about.update_available_pkg` across `en` and `tr` locales.
- Localized interactive update check result messages in `updater.svelte.ts` via `t(...)` instead of hardcoded English strings.
<img width="511" height="87" alt="image" src="https://github.com/user-attachments/assets/d2f99958-22a7-4b1c-85e7-ddae9d769b21" />
<img width="518" height="158" alt="image" src="https://github.com/user-attachments/assets/baeb3546-9e86-4f6f-ada0-2a54f65abde4" />


### Testing
- Ran `cd ui && pnpm check` (`svelte-check`) — 0 errors, 0 warnings.
- Ran `cd ui && pnpm build` — successfully compiled static assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized update-available messages for English and Turkish.
  * Update notifications now distinguish between self-installable and package-managed installations.
  * Update check failures are displayed using localized error messages.
* **Bug Fixes**
  * Corrected version interpolation in update status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->