### PR TITLE
Multiple Google accounts with switching

### DIFF
--- a/crates/innertube/src/transport.rs
+++ b/crates/innertube/src/transport.rs
@@ -137,6 +137,51 @@ impl InnerTube {
         self.session.write().unwrap().visitor_data = vd;
     }
 
+    /// Apply `Set-Cookie` pairs to the session jar (name → value, `Max-Age=0` deletes). Values
+    /// come from authenticated responses only, so every pair belongs to this session.
+    fn merge_set_cookies(&self, set_cookies: &[String]) {
+        let mut s = self.session.write().unwrap();
+        let Some(mut jar) = s.cookie.clone() else { return };
+        let mut changed = false;
+        for raw in set_cookies {
+            let mut parts = raw.split(';');
+            let Some(pair) = parts.next() else { continue };
+            let Some((name, value)) = pair.trim().split_once('=') else { continue };
+            let name = name.trim();
+            if name.is_empty() || name.contains(' ') {
+                continue;
+            }
+            let deleted = parts.any(|attr| {
+                attr.trim()
+                    .split_once('=')
+                    .map(|(k, v)| k.trim().eq_ignore_ascii_case("max-age") && v.trim() == "0")
+                    .unwrap_or(false)
+            });
+            let mut entries: Vec<(String, String)> = jar
+                .split(';')
+                .filter_map(|kv| {
+                    let (k, v) = kv.trim().split_once('=')?;
+                    Some((k.trim().to_owned(), v.trim().to_owned()))
+                })
+                .collect();
+            if deleted {
+                let before = entries.len();
+                entries.retain(|(k, _)| k != name);
+                changed |= entries.len() != before;
+            } else if let Some(entry) = entries.iter_mut().find(|(k, _)| k == name) {
+                changed |= entry.1 != value;
+                entry.1 = value.to_owned();
+            } else {
+                entries.push((name.to_owned(), value.to_owned()));
+                changed = true;
+            }
+            jar = entries.iter().map(|(k, v)| format!("{k}={v}")).collect::<Vec<_>>().join("; ");
+        }
+        if changed {
+            s.cookie = Some(jar);
+        }
+    }
+
     /// Build the request `context` for a client from the current session. Crate-internal — the
     /// endpoints facade calls it. Reads and drops the lock synchronously (no `.await` inside).
     pub(crate) fn context_for(&self, client: &YouTubeClient) -> crate::models::context::Context {
@@ -188,7 +233,23 @@ impl InnerTube {
                 .await
                 .and_then(|r| r.error_for_status());
             match res {
-                Ok(resp) => return Ok(resp.json().await?),
+                Ok(resp) => {
+                    // Google rotates its short-lived tokens (`__Secure-*SIDTS` and friends) on
+                    // authenticated responses; a statically captured cookie eventually stops
+                    // authenticating (KI-2). Merge every `Set-Cookie` pair into the session jar
+                    // the way a browser's cookie store would, so a session that is actually used
+                    // keeps itself alive across switches and restarts.
+                    if self.is_logged_in() {
+                        let set_cookies = resp
+                            .headers()
+                            .get_all(reqwest::header::SET_COOKIE)
+                            .iter()
+                            .filter_map(|v| v.to_str().ok().map(str::to_owned))
+                            .collect::<Vec<_>>();
+                        self.merge_set_cookies(&set_cookies);
+                    }
+                    return Ok(resp.json().await?);
+                }
                 // Retry only on connect/timeout (transient), matching Metrolist's IOException filter.
                 Err(e) if attempt < 3 && (e.is_timeout() || e.is_connect() || e.is_request()) => {
                     tracing::warn!(attempt, error = %e, "retrying InnerTube POST {path}");
@@ -487,5 +548,32 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(s.sapisid().as_deref(), Some("secret123"));
+    }
+
+    /// Google rotates its short-lived tokens on authenticated responses; the transport must
+    /// merge them into the jar (add, replace, `Max-Age=0` delete) so a used session stays alive.
+    #[test]
+    fn set_cookie_pairs_merge_into_the_session_jar() {
+        let session = Session { cookie: Some("SAPISID=aaa; __Secure-3PSIDTS=old".into()), ..Default::default() };
+        let it = InnerTube::new(session, None).unwrap();
+
+        it.merge_set_cookies(&[
+            "__Secure-3PSIDTS=new; Path=/; Domain=.youtube.com; HttpOnly; Secure".into(),
+            "NEWCOOKIE=fresh; Path=/; Max-Age=3600".into(),
+        ]);
+        let jar = it.cookie().unwrap();
+        assert_eq!(
+            jar,
+            "SAPISID=aaa; __Secure-3PSIDTS=new; NEWCOOKIE=fresh",
+            "rotated tokens replace, new cookies append"
+        );
+
+        it.merge_set_cookies(&["__Secure-3PSIDTS=x; Path=/; Max-Age=0".into()]);
+        assert_eq!(it.cookie().unwrap(), "SAPISID=aaa; NEWCOOKIE=fresh", "Max-Age=0 deletes");
+
+        // Not logged in → nothing to merge into, stays None.
+        let guest = InnerTube::new(Session::default(), None).unwrap();
+        guest.merge_set_cookies(&["SAPISID=ignored".into()]);
+        assert_eq!(guest.cookie(), None);
     }
 }

--- a/docs/SIGN-IN-SESSIONS.md
+++ b/docs/SIGN-IN-SESSIONS.md
@@ -1,0 +1,93 @@
+# Sign-in sessions: where the data lives
+
+Everything below is per-OS under Tauri's app-data dir for identifier `com.limusic.desktop`
+(`tauri.conf.json`), created in `lib.rs` via `app.path().app_data_dir()`:
+
+| OS | Directory |
+|---|---|
+| Windows | `%APPDATA%\com.limusic.desktop\` |
+| Linux | `~/.local/share/com.limusic.desktop/` |
+| macOS | `~/Library/Application Support/com.limusic.desktop/` |
+
+## 1. SQLite — `limusic.sqlite`
+
+The canonical store of your saved Google accounts and the active session. Schema: `src-tauri/src/db.rs`.
+
+### `accounts` table (multi-account, canonical)
+
+| Column | Contents |
+|---|---|
+| `id` | Opaque account key: `ga-<hash>` over the cookie's long-lived `SAPISID` value (`db::account_key`). One row per Google account. |
+| `session_cookie` | The full `Cookie:` header captured at sign-in (SAPISID, SID, `__Secure-*`, …) — the actual login credential. |
+| `data_sync_id` | Server-issued delegated identity of the selected YouTube channel within this Google account. |
+| `selected_identity_json` | Canonical account model: name, handle, email, thumbnail, channelId, data_sync_id. `NULL` = login authenticated but a multi-channel pick is still pending. |
+| `account_json` | The JSON shape the UI consumes (`signedIn`, `name`, …). |
+| `visitor_data` | Login-bound visitorData for this account. |
+| `added_at` | Unix seconds; the account menu lists oldest first (re-logins don't reorder). |
+
+### `settings` rows (active-account projections + legacy keys)
+
+The active account is projected into these keys so the startup bootstrap in `lib.rs`,
+`AppState::account_snapshot`, and the channel switcher keep working unchanged:
+
+| Key | Contents |
+|---|---|
+| `active_account` | `id` of the active account; absent = signed out (guest). |
+| `session_cookie` | Cookie of the active account only. |
+| `selected_identity_json` | Active account's identity model. |
+| `data_sync_id`, `account_json` | Legacy projections, written atomically with the above (`Db::set_auth_identity`). |
+| `account_selection_pending` | `"true"` while a multi-channel login awaits a pick. |
+| `visitor_data` | Active session's visitorData (anonymous bootstrap id until first login). |
+
+Databases from before multi-account are migrated once on open (`Db::open`): the legacy
+`session_cookie` row becomes an `accounts` row and `active_account` is set.
+
+## 2. Webview cookie store — the login window's own Google session
+
+The sign-in webview (`src-tauri/src/session.rs`) is persistent (non-incognito) on purpose. Its
+cookies live in the OS webview profile data *next to* the app data dir, not in the SQLite file:
+
+- **Windows (WebView2):** user-data folder under `%LOCALAPPDATA%\com.limusic.desktop\EBWebView\`
+- **Linux (WebKitGTK):** `~/.local/share/com.limusic.desktop/` webkit data (or XDG cache)
+- **macOS (WKWebView):** inside `~/Library/Application Support/com.limusic.desktop/` WebKit data
+
+This is why a re-login is one click with no password/paste, and why deleting `limusic.sqlite`
+alone does not sign the webview out of Google. Limusic itself never reads this store as state —
+`session.rs` copies the youtube-domain cookies out of it into the Cookie header after each login
+and then stores that copy in SQLite. The one deliberate exception: the **Add account** flow first
+deletes every google.com/youtube.com cookie from this store (webview-side sign-out only — the
+SQLite sessions are untouched), so a fresh sign-in lands on the account just entered instead of
+auto-continuing into whatever session the webview was already holding.
+
+## 3. What never leaves Rust
+
+Auth material (`session_cookie`, `selected_identity_json`, `data_sync_id`, `account_json`,
+`visitor_data`, `account_selection_pending`) is excluded from the `get_settings` whitelist
+(`commands.rs::UI_SETTINGS`), so the renderer can't read or overwrite it. The UI only ever sees
+display fields plus opaque selectors (`id`, `selectionKey`).
+
+## Flow summary
+
+- **Sign in** (`login_webview`): ServiceLogin webview → redirect to music.youtube.com → cookies
+  captured (polling for a few seconds so the jar includes the rotation tokens the YTM page's first
+  requests set) → validated via `account_menu` → `accounts` row upserted (keyed on SAPISID; a new
+  Google account adds a row, the same one refreshes its row) → `active_account` set → `auth-changed`.
+- **Session freshness**: Google rotates its short-lived tokens (`__Secure-*SIDTS` and friends) on
+  authenticated responses. The innertube transport merges every `Set-Cookie` into its jar, and a
+  60-second timer in the app writes the rotated jar back to the active account's row (and the
+  `session_cookie` projection), so switching away and back or restarting never revives a dead
+  cookie. An account only needs a fresh sign-in again if it sat unused long enough for Google to
+  expire it entirely, or after sign-out/removal.
+- **Add account** (`login_webview` with `add_account: true`): first the *webview* is signed out of
+  Google — every google.com/youtube.com cookie is deleted from its shared cookie store, leaving the
+  app's saved accounts in SQLite untouched. Then Google's `accounts.google.com/AddSession` screen
+  opens, so the account the user signs in with becomes the webview's only session and the redirect
+  back to music.youtube.com lands on it. (As a fallback, if the captured cookie still matches a
+  saved account, the webview is bounced once through `accounts.google.com/AccountChooser`.)
+- **Switch account** (`switch_google_account`): stored cookie validated with `account_menu`
+  first, then projections + `active_account` swap atomically, playlist index forgotten,
+  `auth-changed` emitted. A row saved mid multi-channel sign-in reopens the required channel picker.
+- **Sign out / remove** (`sign_out`, `remove_google_account`): deletes the account's row; if it
+  was active, drops to guest. Other saved accounts remain listed.
+- **Channel switch** (`switch_account`): unchanged — picks a YouTube channel *within* the active
+  Google account.

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Local Windows build config — points the MSVC linker at the libmpv import library this
+# machine generated from shinchiro's mpv-dev package (docs/BUILD-PLATFORMS.md §Windows).
+# Machine-specific (C:\libmpv does not exist elsewhere): keep uncommitted.
+[build]
+rustflags = ["-L", "C:\\libmpv"]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -364,13 +364,39 @@ pub async fn sign_out(state: St<'_>) -> Result<(), String> {
     Ok(())
 }
 
-/// Open the in-app Google sign-in webview (context/15 Path A). Completes asynchronously; the UI
-/// hears back via `auth-changed` (success) or `login-error`.
+// --- saved Google accounts (multi-account, context/15) ---------------------------------------
+
 #[tauri::command]
-pub async fn login_webview(state: St<'_>) -> Result<(), String> {
+pub async fn get_google_accounts(state: St<'_>) -> Result<Vec<serde_json::Value>, String> {
+    Ok(state.google_accounts())
+}
+
+/// Activate a saved Google account without a Google re-login. Fails if the stored cookie no
+/// longer authenticates, in which case the caller should re-sign-in with that account.
+#[tauri::command]
+pub async fn switch_google_account(
+    state: St<'_>,
+    id: String,
+) -> Result<serde_json::Value, String> {
+    state.switch_google_account(&id).await
+}
+
+/// Delete a saved account. Removing the active one signs out; the others stay listed.
+#[tauri::command]
+pub async fn remove_google_account(state: St<'_>, id: String) -> Result<(), String> {
+    state.remove_google_account(&id);
+    Ok(())
+}
+
+/// Open the in-app Google sign-in webview (context/15 Path A). Completes asynchronously; the UI
+/// hears back via `auth-changed` (success) or `login-error`. With `add_account`, the webview
+/// opens Google's AddSession screen so a second account can be added even when the webview
+/// already holds a Google session.
+#[tauri::command]
+pub async fn login_webview(state: St<'_>, add_account: Option<bool>) -> Result<(), String> {
     let state = state.inner().clone();
     let app = state.app.clone();
-    crate::session::open_login(app, state);
+    crate::session::open_login(app, state, add_account.unwrap_or(false));
     Ok(())
 }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,11 +1,37 @@
 //! Local SQLite state. context/11 §state. `rusqlite` (bundled) behind a Mutex — one file, low
 //! write volume, no async pool needed (plan decision).
 
+use std::hash::{Hash, Hasher};
 use std::sync::Mutex;
 
 use rusqlite::Connection;
 
 pub struct Db(Mutex<Connection>);
+
+/// The stored-account key (multi-account support): a stable per-Google-account identifier derived
+/// from the long-lived `SAPISID` cookie value — the one piece of the jar Google does not rotate.
+/// Hashed so the raw auth material never appears in a key the UI gets to see.
+pub fn account_key(session_cookie: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    "limusic-google-account-v1".hash(&mut hasher);
+    innertube::cookie_sapisid(session_cookie).unwrap_or_default().hash(&mut hasher);
+    format!("ga-{:016x}", hasher.finish())
+}
+
+/// One saved Google account. Canonical multi-account state; the `settings` rows `session_cookie`,
+/// `selected_identity_json`, `data_sync_id`, `account_json` and `visitor_data` remain as
+/// projections of the *active* account, so everything that read them before (startup bootstrap in
+/// lib.rs, `account_snapshot`, the channel switcher, legacy fallbacks) keeps working unchanged.
+#[derive(Debug, Clone)]
+pub struct StoredAccount {
+    pub id: String,
+    pub session_cookie: String,
+    pub data_sync_id: Option<String>,
+    pub selected_identity_json: Option<String>,
+    pub account_json: Option<String>,
+    pub visitor_data: Option<String>,
+    pub added_at: i64,
+}
 
 /// Unix seconds. Lives here because every wall-clock value in the app is a column in this file
 /// (`expires_at`, `played_at`, `fetched_at`) or something stored alongside them.
@@ -93,6 +119,15 @@ impl Db {
                 PRIMARY KEY (playlist_id, video_id)
             ) WITHOUT ROWID;
             CREATE INDEX IF NOT EXISTS playlist_track_video ON playlist_track(video_id);
+            CREATE TABLE IF NOT EXISTS accounts (
+                id                     TEXT PRIMARY KEY,
+                session_cookie         TEXT NOT NULL,
+                data_sync_id           TEXT,
+                selected_identity_json TEXT,
+                account_json           TEXT,
+                visitor_data           TEXT,
+                added_at               INTEGER NOT NULL
+            );
             "#,
         )?;
         // Migrate pre-Phase-4 DBs that predate the loudness_db column. Errors ("duplicate column")
@@ -120,6 +155,45 @@ impl Db {
         // built up before anything pruned at all (1803 rows, 1772 of them expired, on a real
         // install) would sit there until it happened to.
         let _ = conn.execute("DELETE FROM stream_url_cache WHERE expires_at <= ?1", [now_secs()]);
+        // One-time migration of the pre-multi-account single session into `accounts`. The legacy
+        // settings rows stay in place as projections of the active account (see `StoredAccount`).
+        let legacy_cookie = conn
+            .query_row("SELECT value FROM settings WHERE key = 'session_cookie'", [], |r| {
+                r.get::<_, String>(0)
+            })
+            .ok();
+        if let Some(cookie) = legacy_cookie {
+            let existing: i64 =
+                conn.query_row("SELECT COUNT(*) FROM accounts", [], |r| r.get(0)).unwrap_or(0);
+            if existing == 0 && innertube::cookie_sapisid(&cookie).is_some() {
+                let get = |key: &str| -> Option<String> {
+                    conn.query_row("SELECT value FROM settings WHERE key = ?1", [key], |r| {
+                        r.get(0)
+                    })
+                    .ok()
+                };
+                let id = account_key(&cookie);
+                let _ = conn.execute(
+                    "INSERT OR IGNORE INTO accounts(id, session_cookie, data_sync_id, \
+                     selected_identity_json, account_json, visitor_data, added_at) \
+                     VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    rusqlite::params![
+                        id,
+                        cookie,
+                        get("data_sync_id"),
+                        get("selected_identity_json"),
+                        get("account_json"),
+                        get("visitor_data"),
+                        now_secs()
+                    ],
+                );
+                let _ = conn.execute(
+                    "INSERT INTO settings(key, value) VALUES('active_account', ?1) \
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    [id],
+                );
+            }
+        }
         Ok(Db(Mutex::new(conn)))
     }
 
@@ -214,6 +288,121 @@ impl Db {
         {
             tx.execute("DELETE FROM settings WHERE key = ?1", [key])?;
         }
+        tx.commit()
+    }
+
+    // --- saved Google accounts (multi-account) ------------------------------------------------
+
+    /// Insert or refresh a saved account. `added_at` is deliberately not updated on conflict: a
+    /// re-login refreshes the cookie and identity, not the account's place in the list order.
+    pub fn upsert_account(&self, account: &StoredAccount) -> rusqlite::Result<()> {
+        let conn = self.0.lock().unwrap();
+        conn.execute(
+            "INSERT INTO accounts(id, session_cookie, data_sync_id, selected_identity_json, \
+             account_json, visitor_data, added_at) \
+             VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+             ON CONFLICT(id) DO UPDATE SET \
+                session_cookie = excluded.session_cookie, \
+                data_sync_id = excluded.data_sync_id, \
+                selected_identity_json = excluded.selected_identity_json, \
+                account_json = excluded.account_json, \
+                visitor_data = excluded.visitor_data",
+            rusqlite::params![
+                account.id,
+                account.session_cookie,
+                account.data_sync_id,
+                account.selected_identity_json,
+                account.account_json,
+                account.visitor_data,
+                account.added_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Saved accounts, oldest first. No raw auth material leaves this function's callers except
+    /// back into the transport; the UI only ever sees display fields plus the opaque id.
+    pub fn list_accounts(&self) -> Vec<StoredAccount> {
+        let conn = self.0.lock().unwrap();
+        let mut out = Vec::new();
+        if let Ok(mut stmt) = conn.prepare(
+            "SELECT id, session_cookie, data_sync_id, selected_identity_json, account_json, \
+             visitor_data, added_at FROM accounts ORDER BY added_at",
+        ) {
+            if let Ok(rows) = stmt.query_map([], |r| {
+                Ok(StoredAccount {
+                    id: r.get(0)?,
+                    session_cookie: r.get(1)?,
+                    data_sync_id: r.get(2)?,
+                    selected_identity_json: r.get(3)?,
+                    account_json: r.get(4)?,
+                    visitor_data: r.get(5)?,
+                    added_at: r.get(6)?,
+                })
+            }) {
+                out.extend(rows.flatten());
+            }
+        }
+        out
+    }
+
+    pub fn get_account(&self, id: &str) -> Option<StoredAccount> {
+        let conn = self.0.lock().unwrap();
+        conn.query_row(
+            "SELECT id, session_cookie, data_sync_id, selected_identity_json, account_json, \
+             visitor_data, added_at FROM accounts WHERE id = ?1",
+            [id],
+            |r| {
+                Ok(StoredAccount {
+                    id: r.get(0)?,
+                    session_cookie: r.get(1)?,
+                    data_sync_id: r.get(2)?,
+                    selected_identity_json: r.get(3)?,
+                    account_json: r.get(4)?,
+                    visitor_data: r.get(5)?,
+                    added_at: r.get(6)?,
+                })
+            },
+        )
+        .ok()
+    }
+
+    pub fn remove_account(&self, id: &str) {
+        let conn = self.0.lock().unwrap();
+        let _ = conn.execute("DELETE FROM accounts WHERE id = ?1", [id]);
+    }
+
+    /// Write a saved account's fields into the active-account `settings` projections, atomically
+    /// (used when switching to a saved account). Clears `account_selection_pending`: a completed
+    /// account needs no channel pick.
+    pub fn restore_account(&self, account: &StoredAccount) -> rusqlite::Result<()> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO settings(key, value) VALUES('session_cookie', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [&account.session_cookie],
+        )?;
+        for (key, value) in [
+            ("data_sync_id", account.data_sync_id.as_deref()),
+            ("selected_identity_json", account.selected_identity_json.as_deref()),
+            ("account_json", account.account_json.as_deref()),
+            ("visitor_data", account.visitor_data.as_deref()),
+        ] {
+            match value {
+                Some(value) => {
+                    tx.execute(
+                        "INSERT INTO settings(key, value) VALUES(?1, ?2)
+                         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                        [key, value],
+                    )?;
+                }
+                None => {
+                    tx.execute("DELETE FROM settings WHERE key = ?1", [key])?;
+                }
+            }
+        }
+        tx.execute("DELETE FROM settings WHERE key = 'account_selection_pending'", [])?;
         tx.commit()
     }
 
@@ -773,6 +962,86 @@ mod tests {
         d.record_play("stale", "{}", 1_000, 60);
         d.record_play("fresh", "{}", 5_000, 60); // prunes anything before 4_940
         assert_eq!(d.top_plays(0, 20), vec![("{}".to_string(), 1)]);
+    }
+
+    /// A re-login refreshes an account's row without resetting its place in the list, and a
+    /// cookie from a different Google account lands in its own row keyed on its SAPISID.
+    #[test]
+    fn accounts_round_trip_refresh_and_remove() {
+        let d = db();
+        let a = StoredAccount {
+            id: account_key("SAPISID=aaa"),
+            session_cookie: "SAPISID=aaa".into(),
+            data_sync_id: Some("channel-a".into()),
+            selected_identity_json: Some(r#"{"data_sync_id":"channel-a"}"#.into()),
+            account_json: Some(r#"{"name":"A"}"#.into()),
+            visitor_data: Some("vd-a".into()),
+            added_at: 100,
+        };
+        d.upsert_account(&a).unwrap();
+        assert_ne!(a.id, account_key("SAPISID=bbb"), "keys follow the Google account");
+
+        d.upsert_account(&StoredAccount {
+            id: account_key("SAPISID=bbb"),
+            session_cookie: "SAPISID=bbb".into(),
+            data_sync_id: Some("channel-b".into()),
+            selected_identity_json: Some(r#"{"data_sync_id":"channel-b"}"#.into()),
+            account_json: Some(r#"{"name":"B"}"#.into()),
+            visitor_data: None,
+            added_at: 200,
+        })
+        .unwrap();
+        assert_eq!(d.list_accounts().len(), 2);
+
+        // Same Google account re-login: refreshes the row, keeps its original `added_at`.
+        d.upsert_account(&StoredAccount {
+            id: a.id.clone(),
+            session_cookie: "SAPISID=aaa; __Secure-3PSID=new".into(),
+            data_sync_id: Some("channel-a".into()),
+            selected_identity_json: Some(r#"{"data_sync_id":"channel-a"}"#.into()),
+            account_json: Some(r#"{"name":"A renamed"}"#.into()),
+            visitor_data: Some("vd-a2".into()),
+            added_at: 999,
+        })
+        .unwrap();
+        let accounts = d.list_accounts();
+        assert_eq!(accounts.len(), 2);
+        let refreshed = accounts.iter().find(|acc| acc.id == a.id).unwrap();
+        assert_eq!(refreshed.session_cookie, "SAPISID=aaa; __Secure-3PSID=new");
+        assert_eq!(refreshed.account_json.as_deref(), Some(r#"{"name":"A renamed"}"#));
+        assert_eq!(refreshed.added_at, 100, "re-login must not reorder the list");
+        assert_eq!(d.get_account(&a.id).unwrap().visitor_data.as_deref(), Some("vd-a2"));
+
+        d.remove_account(&a.id);
+        assert!(d.get_account(&a.id).is_none());
+        assert_eq!(d.list_accounts().len(), 1);
+    }
+
+    /// Databases written before multi-account migrate their single session into `accounts` once.
+    #[test]
+    fn opening_the_db_migrates_the_legacy_session() {
+        let path = std::env::temp_dir().join("limusic-accounts-migration-test.sqlite");
+        std::fs::remove_file(&path).ok();
+        {
+            let d = Db::open(&path).unwrap();
+            d.set_setting("session_cookie", "SAPISID=legacy");
+            d.set_setting("data_sync_id", "channel-x");
+            d.set_setting("account_json", r#"{"name":"Legacy"}"#);
+            d.set_setting("visitor_data", "vd-x");
+        }
+        {
+            let d = Db::open(&path).unwrap();
+            let accounts = d.list_accounts();
+            assert_eq!(accounts.len(), 1);
+            assert_eq!(accounts[0].session_cookie, "SAPISID=legacy");
+            assert_eq!(accounts[0].data_sync_id.as_deref(), Some("channel-x"));
+            assert_eq!(
+                d.get_setting("active_account").as_deref(),
+                Some(accounts[0].id.as_str()),
+                "the migrated session is the active account"
+            );
+        }
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -429,7 +429,21 @@ pub fn run() {
             }
 
             // Pump mpv events → UI events + queue advance. context/11 events, context/14 §TrackEnded.
-            spawn_event_pump(app_state, handle, events);
+            spawn_event_pump(app_state.clone(), handle, events);
+
+            // Google rotates its short-lived cookie tokens on authenticated responses; the
+            // innertube transport merges them into its jar as requests happen. Persist the
+            // rotated jar for the active account on a timer so switching away and back (or a
+            // restart) never revives a dead cookie.
+            {
+                let st = app_state.clone();
+                tauri::async_runtime::spawn(async move {
+                    loop {
+                        tokio::time::sleep(Duration::from_secs(60)).await;
+                        st.refresh_active_account_cookie();
+                    }
+                });
+            }
 
             // Prewarm the webviews off the first-play path (context/04 §startup). The delays let
             // the event loop come up first (run_on_main_thread needs it pumping).
@@ -525,6 +539,9 @@ pub fn run() {
             commands::switch_account,
             commands::sign_out,
             commands::login_webview,
+            commands::get_google_accounts,
+            commands::switch_google_account,
+            commands::remove_google_account,
             commands::open_mini,
             commands::close_mini,
             commands::get_home,

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -40,9 +40,25 @@ const LOGIN_UA: Option<&str> = None;
 const LOGIN_URL: &str =
     "https://accounts.google.com/ServiceLogin?service=youtube&continue=https://music.youtube.com/";
 
+/// Google's own "Add account" entry point (the one their account picker's "Add account" links
+/// to). Unlike ServiceLogin it presents the fresh sign-in screen even when the webview already
+/// holds a Google session, which is what lets a second account be added without signing the
+/// first one out of the webview. Verified: it renders the identifier screen with no session.
+const ADD_ACCOUNT_URL: &str =
+    "https://accounts.google.com/AddSession?service=youtube&continue=https://music.youtube.com/";
+
+/// The account chooser, used as a bounce target in the add-account flow. After AddSession, Google
+/// auto-continues its redirect into the webview's *default* session (`authuser=0`) — usually the
+/// account that was already signed in — so the cookies captured on music.youtube.com would belong
+/// to the wrong Google account. Picking the new session here is what makes Google swap the jar's
+/// active-session cookies before the final redirect back.
+const ACCOUNT_CHOOSER_URL: &str =
+    "https://accounts.google.com/AccountChooser?service=youtube&continue=https://music.youtube.com/";
+
 /// Open the login webview. Returns immediately; sign-in completes asynchronously (the UI learns via
-/// the `auth-changed` event, or `login-error` on failure).
-pub fn open_login(app: AppHandle, state: Arc<AppState>) {
+/// the `auth-changed` event, or `login-error` on failure). `add_account` picks the AddSession
+/// flow so an additional Google account can be added while another is signed in.
+pub fn open_login(app: AppHandle, state: Arc<AppState>, add_account: bool) {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
     // When the webview lands on music.youtube.com, capture cookies + sign in. Runs off the
@@ -51,28 +67,60 @@ pub fn open_login(app: AppHandle, state: Arc<AppState>) {
     {
         let app = app.clone();
         tauri::async_runtime::spawn(async move {
+            // Add-account flow: Google can auto-continue its redirect into an already-saved
+            // session (the default `authuser=0`) instead of the account the user just added. One
+            // bounce through the account chooser fixes the active-session cookies; the guard
+            // makes it once per login window so re-picking the same account can't loop.
+            let mut chooser_shown = false;
             while rx.recv().await.is_some() {
                 // The redirect that lands us here sets the youtube cookies; they may appear a beat
-                // after the page finishes, so poll briefly.
-                for _ in 0..6 {
+                // after the page finishes, and the YTM app the window loads keeps setting more of
+                // them (Google's rotating `__Secure-*SIDTS` tokens arrive via its first requests).
+                // Poll for a few seconds and sign in with the *latest* jar, not the first one
+                // that has a SAPISID — a jar captured too early is missing the rotation tokens
+                // and goes stale almost immediately.
+                let mut latest: Option<String> = None;
+                let mut bounced = false;
+                for _ in 0..8 {
                     let cookie = read_login_cookies(&app).await;
                     if innertube::cookie_sapisid(&cookie).is_some() {
-                        match state.sign_in(cookie).await {
-                            Ok(SignInOutcome::Complete) => {
-                                let _ = app.emit("login-done", ());
-                            }
-                            // The authenticated cookie is saved, but the account remains
-                            // deliberately unfinished until the main-window picker selects a
-                            // server-issued delegated identity.
-                            Ok(SignInOutcome::SelectionRequired) => {}
-                            Err(e) => {
-                                let _ = app.emit("login-error", e);
-                            }
+                        if add_account && !chooser_shown && state.matches_saved_account(&cookie) {
+                            chooser_shown = true;
+                            let app2 = app.clone();
+                            let _ = app.run_on_main_thread(move || {
+                                if let Some(w) = app2.get_webview_window(LOGIN_LABEL) {
+                                    if let Ok(url) = tauri::Url::parse(ACCOUNT_CHOOSER_URL) {
+                                        let _ = w.navigate(url);
+                                    }
+                                }
+                            });
+                            // Re-arm the page-load watch: picking an account reloads YTM with
+                            // that session's cookies as the active set.
+                            bounced = true;
+                            break;
                         }
-                        close_login(&app);
-                        return;
+                        latest = Some(cookie);
                     }
                     tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+                if bounced {
+                    continue;
+                }
+                if let Some(cookie) = latest {
+                    match state.sign_in(cookie).await {
+                        Ok(SignInOutcome::Complete) => {
+                            let _ = app.emit("login-done", ());
+                        }
+                        // The authenticated cookie is saved, but the account remains
+                        // deliberately unfinished until the main-window picker selects a
+                        // server-issued delegated identity.
+                        Ok(SignInOutcome::SelectionRequired) => {}
+                        Err(e) => {
+                            let _ = app.emit("login-error", e);
+                        }
+                    }
+                    close_login(&app);
+                    return;
                 }
                 // Landed on music.youtube.com but not authenticated yet — keep watching.
             }
@@ -86,7 +134,15 @@ pub fn open_login(app: AppHandle, state: Arc<AppState>) {
         if let Some(w) = app2.get_webview_window(LOGIN_LABEL) {
             let _ = w.destroy();
         }
-        let Ok(url) = tauri::Url::parse(LOGIN_URL) else { return };
+        // Add-account flow: sign the *webview* out of Google first, so the fresh sign-in is the
+        // webview's only session and music.youtube.com lands on the new account instead of
+        // auto-continuing into whichever one it was already holding. The app's own saved sessions
+        // live in SQLite (`accounts`), not in this cookie store — they are never touched here.
+        if add_account {
+            clear_google_webview_cookies(&app2);
+        }
+        let url = if add_account { ADD_ACCOUNT_URL } else { LOGIN_URL };
+        let Ok(url) = tauri::Url::parse(url) else { return };
         let builder = WebviewWindowBuilder::new(&app2, LOGIN_LABEL, WebviewUrl::External(url))
             .title("Sign in to YouTube Music")
             .inner_size(480.0, 720.0)
@@ -109,6 +165,29 @@ pub fn open_login(app: AppHandle, state: Arc<AppState>) {
     if let Err(e) = dispatched {
         let _ = app.emit("login-error", format!("Couldn't open the sign-in window: {e}"));
     }
+}
+
+/// Delete every google.com / youtube.com cookie from the webview's cookie store (one shared store
+/// for all of the app's webviews). Only the webview-side Google session is lost: the app's saved
+/// accounts are SQLite rows in `Db`, and the main window never sends YouTube cookies itself.
+/// Reads through the main window's webview — always alive, and the store is profile-wide.
+fn clear_google_webview_cookies(app: &AppHandle) {
+    let Some(wv) = app.get_webview_window("main") else { return };
+    let Ok(cookies) = wv.cookies() else { return };
+    let mut cleared = 0;
+    for cookie in cookies {
+        let domain = cookie.domain().unwrap_or_default();
+        if domain == "google.com"
+            || domain.ends_with(".google.com")
+            || domain == "youtube.com"
+            || domain.ends_with(".youtube.com")
+        {
+            if wv.delete_cookie(cookie).is_ok() {
+                cleared += 1;
+            }
+        }
+    }
+    tracing::info!(cleared, "cleared the webview's Google session for add-account sign-in");
 }
 
 /// Merge the youtube-domain cookies into a `Cookie` header string. Reads the platform cookie store

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -15,7 +15,7 @@ use player::Player;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
 
-use crate::db::{now_secs, Db};
+use crate::db::{now_secs, Db, StoredAccount};
 use crate::discord::DiscordHandle;
 use crate::listentogether::{LtSession, SyncCommand};
 use crate::media::MediaHandle;
@@ -584,6 +584,7 @@ impl AppState {
                 error.to_string()
             })?;
             self.persist_visitor_data(active_visitor_data.as_deref());
+            self.sync_active_account();
             let _ = self.app.emit("account-selection-required", ());
             return Ok(SignInOutcome::SelectionRequired);
         }
@@ -691,6 +692,7 @@ impl AppState {
             )
             .map_err(|e| format!("Couldn't save the selected YouTube channel: {e}"))?;
         self.persist_visitor_data(visitor_data);
+        self.sync_active_account();
         self.forget_playlist_index();
         self.it.set_data_sync_id(selected.data_sync_id.clone());
         let _ = self.app.emit("auth-changed", &account);
@@ -725,12 +727,181 @@ impl AppState {
     }
 
     pub async fn sign_out(&self) {
-        self.it.set_cookie(None);
-        self.it.set_data_sync_id(None);
-        self.db.delete_setting("session_cookie");
+        let active = self
+            .db
+            .get_setting("active_account")
+            .or_else(|| self.it.cookie().map(|c| crate::db::account_key(&c)));
+        match active {
+            // "Sign out" removes the active account from the saved list (drops to guest); the
+            // other saved accounts stay available in the menu for a one-click switch back.
+            Some(id) => self.remove_google_account(&id),
+            None => {
+                self.it.set_cookie(None);
+                self.it.set_data_sync_id(None);
+                self.db.delete_setting("session_cookie");
+                self.forget_playlist_index();
+                let _ = self.db.clear_auth_identity();
+                let _ = self.app.emit("auth-changed", serde_json::json!({ "signedIn": false }));
+            }
+        }
+    }
+
+    /// True when `cookie` authenticates as an account we already have saved. The add-account
+    /// login flow uses this to detect that Google auto-continued its redirect into an existing
+    /// session (the default `authuser=0`) instead of the account the user just added, and bounces
+    /// the webview through the account chooser so the right session becomes active.
+    pub fn matches_saved_account(&self, cookie: &str) -> bool {
+        let Some(sapisid) = innertube::cookie_sapisid(cookie) else { return false };
+        self.db
+            .list_accounts()
+            .iter()
+            .any(|account| innertube::cookie_sapisid(&account.session_cookie) == Some(sapisid))
+    }
+
+    /// Saved Google accounts for the account menu. Display fields only — cookies, delegated ids
+    /// and visitorData never cross the Tauri boundary (context/15).
+    pub fn google_accounts(&self) -> Vec<serde_json::Value> {
+        let active = self.db.get_setting("active_account");
+        self.db
+            .list_accounts()
+            .into_iter()
+            .map(|account| {
+                let info = account
+                    .account_json
+                    .as_deref()
+                    .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
+                    .unwrap_or_else(|| serde_json::json!({}));
+                serde_json::json!({
+                    "id": account.id,
+                    "name": info.get("name").cloned(),
+                    "handle": info.get("handle").cloned(),
+                    "email": info.get("email").cloned(),
+                    "thumbnail": info.get("thumbnail").cloned(),
+                    "active": active.as_deref() == Some(account.id.as_str()),
+                })
+            })
+            .collect()
+    }
+
+    /// Activate a saved Google account without a webview round trip. The stored cookie is
+    /// validated with `account_menu` first — Google rotates its short-lived cookies, and
+    /// activating a dead session would leave the app half-logged-in. On success the transport,
+    /// the projections and the UI all move together; on failure the previous session is restored
+    /// untouched.
+    pub async fn switch_google_account(&self, id: &str) -> Result<serde_json::Value, String> {
+        let account = self.db.get_account(id).ok_or("That account is no longer saved.")?;
+        let previous_cookie = self.it.cookie();
+        let previous_data_sync_id = self.it.data_sync_id();
+        let previous_visitor = self.it.visitor_data();
+
+        self.it.set_cookie(Some(account.session_cookie.clone()));
+        self.it.set_data_sync_id(account.data_sync_id.clone());
+        if let Some(visitor_data) = &account.visitor_data {
+            self.it.set_visitor_data(Some(visitor_data.clone()));
+        }
+
+        // An account saved mid multi-channel sign-in (cookie authenticated, no channel picked
+        // yet) returns to the required picker instead of silently acting as YouTube's default.
+        if account.selected_identity_json.is_none() {
+            self.db
+                .set_pending_auth_selection(&account.session_cookie)
+                .map_err(|e| format!("Couldn't activate the account: {e}"))?;
+            if let Some(visitor_data) = &account.visitor_data {
+                self.db.set_setting("visitor_data", visitor_data);
+            }
+            self.db.set_setting("active_account", id);
+            let snapshot = self.account_snapshot();
+            let _ = self.app.emit("account-selection-required", ());
+            let _ = self.app.emit("auth-changed", &snapshot);
+            return Ok(snapshot);
+        }
+
+        let client =
+            self.clients.get(innertube::METADATA_CLIENT).ok_or("metadata client missing")?;
+        let refreshed_visitor = match self.it.account_menu(client).await {
+            Ok(info) if info.name.is_some() => info.visitor_data.clone(),
+            Ok(_) => {
+                self.it.set_cookie(previous_cookie);
+                self.it.set_data_sync_id(previous_data_sync_id);
+                self.it.set_visitor_data(previous_visitor);
+                return Err("That account's session is no longer valid — sign in again.".into());
+            }
+            Err(error) => {
+                self.it.set_cookie(previous_cookie);
+                self.it.set_data_sync_id(previous_data_sync_id);
+                self.it.set_visitor_data(previous_visitor);
+                return Err(format!("Couldn't switch accounts: {error}"));
+            }
+        };
+
+        self.db
+            .restore_account(&account)
+            .map_err(|e| format!("Couldn't switch accounts: {e}"))?;
+        // A valid login-bound visitorData refreshes the stored one, like sign_in does. Runs after
+        // `restore_account` so it wins over the stored value, and syncs it back into the row.
+        if let Some(visitor_data) = &refreshed_visitor {
+            self.it.set_visitor_data(Some(visitor_data.clone()));
+            self.db.set_setting("visitor_data", visitor_data);
+            self.sync_active_account();
+        }
+        self.db.set_setting("active_account", id);
         self.forget_playlist_index();
-        let _ = self.db.clear_auth_identity();
-        let _ = self.app.emit("auth-changed", serde_json::json!({ "signedIn": false }));
+        let snapshot = self.account_snapshot();
+        let _ = self.app.emit("auth-changed", &snapshot);
+        Ok(snapshot)
+    }
+
+    /// Remove a saved Google account. Removing the active one signs out (drops to guest);
+    /// removing another just deletes its row.
+    pub fn remove_google_account(&self, id: &str) {
+        let is_active = self.db.get_setting("active_account").as_deref() == Some(id);
+        self.db.remove_account(id);
+        if is_active {
+            self.it.set_cookie(None);
+            self.it.set_data_sync_id(None);
+            self.db.delete_setting("session_cookie");
+            self.db.delete_setting("active_account");
+            self.forget_playlist_index();
+            let _ = self.db.clear_auth_identity();
+            let _ = self.app.emit("auth-changed", serde_json::json!({ "signedIn": false }));
+        }
+    }
+
+    /// Mirror the live session + identity projections into the `accounts` table. Called at the end
+    /// of every persist path (single-channel sign-in, channel pick, pending multi-channel
+    /// sign-in), so the saved row for the active session is always current. Best-effort: a
+    /// failure leaves the projections consistent with the transport and the next persist retries.
+    fn sync_active_account(&self) {
+        let Some(cookie) = self.it.cookie() else { return };
+        let account = StoredAccount {
+            id: crate::db::account_key(&cookie),
+            session_cookie: cookie.clone(),
+            data_sync_id: self.db.get_setting("data_sync_id").filter(|id| !id.is_empty()),
+            selected_identity_json: self.db.get_setting("selected_identity_json"),
+            account_json: self.db.get_setting("account_json"),
+            visitor_data: self.db.get_setting("visitor_data"),
+            added_at: now_secs(),
+        };
+        if let Err(error) = self.db.upsert_account(&account) {
+            tracing::warn!(%error, "could not persist the signed-in account row");
+            return;
+        }
+        self.db.set_setting("active_account", &account.id);
+        // The startup bootstrap reads this projection; keep it in step with the rotated jar.
+        self.db.set_setting("session_cookie", &cookie);
+    }
+
+    /// Persist the transport's current cookie jar for the active account if it has rotated.
+    /// Called on a timer: Google refreshes its short-lived tokens on authenticated responses, the
+    /// innertube transport merges them into its jar, and this writes them back to the saved
+    /// account row so a switch away and back (or a restart) never picks up a dead cookie.
+    pub(crate) fn refresh_active_account_cookie(&self) {
+        let Some(cookie) = self.it.cookie() else { return };
+        let Some(active) = self.db.get_setting("active_account") else { return };
+        if self.db.get_account(&active).map(|a| a.session_cookie == cookie) == Some(true) {
+            return;
+        }
+        self.sync_active_account();
     }
 
     /// Current account for the UI. New installs derive it from the canonical selected identity;

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -115,6 +115,18 @@ export interface AccountIdentity {
 	selected: boolean;
 }
 
+/** One saved Google account (multi-account). Display fields only — cookies stay in Rust. */
+export interface SavedAccount {
+	/** Opaque, process-local selector. */
+	id: string;
+	name?: string | null;
+	handle?: string | null;
+	email?: string | null;
+	thumbnail?: string | null;
+	/** The account whose session is currently driving requests. */
+	active: boolean;
+}
+
 export interface BrowseItem {
 	kind: 'song' | 'playlist' | 'album' | 'artist';
 	/** videoId (song) or browseId (playlist/album/artist). */
@@ -402,8 +414,18 @@ export const getAccountIdentities = () =>
 export const switchAccount = (selectionKey: string) =>
 	invoke<Account>('switch_account', { selectionKey });
 export const signOut = () => invoke<void>('sign_out');
-/** Open the in-app Google sign-in webview (context/15 Path A). Result arrives via onAuthChanged. */
-export const loginWebview = () => invoke<void>('login_webview');
+/**
+ * Open the in-app Google sign-in webview (context/15 Path A). Result arrives via onAuthChanged.
+ * With `addAccount`, Google's AddSession screen is used so a second account can be added even
+ * while the webview already holds a Google session.
+ */
+export const loginWebview = (addAccount = false) => invoke<void>('login_webview', { addAccount });
+/** Saved Google accounts for the account menu (display fields only). */
+export const getGoogleAccounts = () => invoke<SavedAccount[]>('get_google_accounts');
+/** Activate a saved account without a Google re-login. Fails if its stored session expired. */
+export const switchGoogleAccount = (id: string) => invoke<Account>('switch_google_account', { id });
+/** Delete a saved account; removing the active one signs out. */
+export const removeGoogleAccount = (id: string) => invoke<void>('remove_google_account', { id });
 
 // --- mini player (Rust mini.rs) ---------------------------------------------------------------
 /** Hide the app to the tray and open the floating widget (a second window running this same SPA). */

--- a/ui/src/lib/components/AccountMenu.svelte
+++ b/ui/src/lib/components/AccountMenu.svelte
@@ -2,22 +2,37 @@
 	// Account control for the titlebar (context/15) — moved out of the sidebar so sign-in lives in the
 	// top bar. Its own component because Titlebar.svelte already uses a single shared mx/my/menuOpen
 	// for the Last.fm menu; a second menu in that file would fight over them.
+	// Multi-account: the menu lists every saved Google account (the active one carries an "Active"
+	// badge), offers Add account (Google's AddSession flow) and per-account removal.
 	import { HugeiconsIcon } from '@hugeicons/svelte';
-	import { UserCircleIcon, Logout01Icon, ArrowDown01Icon } from '@hugeicons/core-free-icons';
+	import { UserCircleIcon, Logout01Icon, ArrowDown01Icon, Add01Icon, Cancel01Icon } from '@hugeicons/core-free-icons';
 	import { Button } from '$lib/components/ui/button';
 	import * as api from '$lib/api';
-	import { auth, openChannelPicker } from '$lib/player.svelte';
+	import { auth, openChannelPicker, toast } from '$lib/player.svelte';
 	import { thumb } from '$lib/thumb';
 	import { anchorMenu, fitMenu, NO_ANCHOR } from '$lib/menu';
 	import { t } from '$lib/i18n.svelte';
 
 	let menuOpen = $state(false);
 	let anchor = $state(NO_ANCHOR);
+	let accounts = $state<api.SavedAccount[]>([]);
+	let switching = $state<string | null>(null);
 
-	// Right-anchored under the trigger, like the Last.fm menu next to it.
-	function openMenu(e: MouseEvent) {
+	// Right-anchored under the trigger, like the Last.fm menu next to it. The saved-account list
+	// is refetched on every open so it can't go stale while the menu was closed.
+	async function openMenu(e: MouseEvent) {
 		anchor = anchorMenu(e, { align: 'right' });
 		menuOpen = !menuOpen;
+		if (menuOpen) await loadAccounts();
+	}
+
+	async function loadAccounts() {
+		try {
+			accounts = await api.getGoogleAccounts();
+		} catch (e) {
+			toast.error(String(e));
+			accounts = [];
+		}
 	}
 
 	// Sign-in/out state arrives via the `auth-changed` event (player.svelte.ts), which also reloads
@@ -32,9 +47,40 @@
 		menuOpen = false;
 	}
 
+	function addAccount() {
+		api.loginWebview(true); // Google's AddSession flow, so a second account can be added
+		menuOpen = false;
+	}
+
 	function switchChannel() {
 		menuOpen = false;
 		openChannelPicker();
+	}
+
+	async function chooseAccount(account: api.SavedAccount) {
+		if (switching || account.active) return;
+		switching = account.id;
+		try {
+			await api.switchGoogleAccount(account.id);
+			menuOpen = false; // auth-changed also fired; the library reload follows
+		} catch (e) {
+			toast.error(String(e));
+		} finally {
+			switching = null;
+		}
+	}
+
+	async function removeAccount(account: api.SavedAccount) {
+		if (switching) return;
+		switching = account.id;
+		try {
+			await api.removeGoogleAccount(account.id);
+			accounts = accounts.filter((a) => a.id !== account.id);
+		} catch (e) {
+			toast.error(String(e));
+		} finally {
+			switching = null;
+		}
 	}
 </script>
 
@@ -88,9 +134,74 @@
 					</div>
 				{/if}
 			</div>
+		{/if}
+
+		{#if accounts.length > 0}
+			<div class="mb-2 space-y-0.5">
+				{#each accounts as account (account.id)}
+					<div class="flex items-center gap-1 rounded-md py-0.5 pr-1 hover:bg-muted">
+						<button
+							type="button"
+							onclick={() => chooseAccount(account)}
+							disabled={switching !== null || account.active}
+							class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left disabled:cursor-default"
+						>
+							{#if account.thumbnail}
+								<img
+									src={thumb(account.thumbnail, 48)}
+									alt=""
+									style="width:1.25rem;height:1.25rem;max-width:none"
+									class="shrink-0 rounded-full object-cover ring-1 ring-border"
+								/>
+							{:else}
+								<HugeiconsIcon
+									icon={UserCircleIcon}
+									class="h-5 w-5 shrink-0 text-muted-foreground"
+								/>
+							{/if}
+							<span class="min-w-0 flex-1">
+								<span
+									class="block truncate text-xs font-medium {account.active
+										? ''
+										: 'text-muted-foreground'}"
+								>
+									{account.name ?? t('nav.account')}
+								</span>
+								{#if account.handle || account.email}
+									<span class="block truncate text-[11px] text-muted-foreground">
+										{account.handle ?? account.email}
+									</span>
+								{/if}
+							</span>
+						</button>
+						{#if account.active}
+							<span class="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-primary">
+								{t('nav.active')}
+							</span>
+						{:else}
+							<button
+								type="button"
+								onclick={() => removeAccount(account)}
+								disabled={switching !== null}
+								title={t('nav.remove_account')}
+								class="shrink-0 cursor-pointer rounded p-0.5 text-muted-foreground transition-colors hover:text-destructive disabled:cursor-wait"
+							>
+								<HugeiconsIcon icon={Cancel01Icon} class="h-3.5 w-3.5" />
+							</button>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		{#if auth.account?.signedIn}
 			<!-- Always offered, never gated on a stored "you have one channel": that answer comes from
 			     a single accounts_list call at sign-in, and when it fails the switcher used to vanish
 			     for good. The picker fetches the list live and shows its own error. -->
+			<Button variant="outline" size="sm" class="mb-2 w-full gap-2" onclick={addAccount}>
+				<HugeiconsIcon icon={Add01Icon} class="h-4 w-4" />
+				{t('nav.add_account')}
+			</Button>
 			<Button variant="outline" size="sm" class="mb-2 w-full gap-2" onclick={switchChannel}>
 				<HugeiconsIcon icon={UserCircleIcon} class="h-4 w-4" />
 				{t('nav.switch_channel')}
@@ -100,11 +211,21 @@
 				{t('nav.sign_out')}
 			</Button>
 		{:else}
-			<p class="text-sm font-medium">{t('nav.sign_in')}</p>
-			<p class="mt-1 text-xs text-muted-foreground">
-				{t('nav.sign_in_hint')}
-			</p>
+			{#if accounts.length === 0}
+				<p class="text-sm font-medium">{t('nav.sign_in')}</p>
+				<p class="mt-1 text-xs text-muted-foreground">
+					{t('nav.sign_in_hint')}
+				</p>
+			{:else}
+				<p class="text-xs text-muted-foreground">{t('nav.saved_accounts_hint')}</p>
+			{/if}
 			<Button class="mt-3 w-full" onclick={signInGoogle}>{t('common.sign_in_google')}</Button>
+			{#if accounts.length > 0}
+				<Button variant="outline" size="sm" class="mt-2 w-full gap-2" onclick={addAccount}>
+					<HugeiconsIcon icon={Add01Icon} class="h-4 w-4" />
+					{t('nav.add_account')}
+				</Button>
+			{/if}
 		{/if}
 	</div>
 {/if}

--- a/ui/src/lib/locales/en.json
+++ b/ui/src/lib/locales/en.json
@@ -77,6 +77,10 @@
 		"choose_channel_desc": "Library, likes and playlists will use this channel. You can switch again later.",
 		"cancel_sign_in": "Cancel sign in",
 		"sign_in_hint": "Sign in with your Google account to reach your YouTube Music library and playlists.",
+		"add_account": "Add account",
+		"active": "Active",
+		"remove_account": "Remove account",
+		"saved_accounts_hint": "Pick a saved account to switch to it.",
 		"history": "History"
 	},
 	"player": {


### PR DESCRIPTION
## Summary

Adds support for saving **multiple Google accounts** and switching between them at any time, reusing the existing in-app Google sign-in webview flow. The titlebar account menu now lists every saved account with the active one marked, offers **Add account**, per-account removal, and one-click switching back to any saved account — no re-login needed for a saved session.

Along the way, two session-lifecycle bugs were fixed: the add-account flow previously auto-continued into the wrong account, and stored sessions could go stale because Google's rotating cookie tokens were never persisted.

## Feature: multiple Google accounts

### How it works

- New `accounts` table in SQLite (`src-tauri/src/db.rs`): one row per Google account, keyed on a hash of the long-lived `SAPISID` cookie (`db::account_key`). Each row stores the full cookie jar, the selected YouTube channel (`data_sync_id`), identity metadata, and visitorData.
- The pre-existing `settings` rows (`session_cookie`, `selected_identity_json`, `data_sync_id`, `account_json`, `visitor_data`) remain as **active-account projections**, written atomically alongside the canonical table. Startup bootstrap, `account_snapshot`, and the channel switcher therefore work unchanged, and databases from older builds migrate once on open (`Db::open`).
- Signing in upserts by SAPISID: a new Google account adds a row, re-signing into a known account refreshes its row (cookies, identity, visitorData) without reordering the list.
- New Tauri commands: `get_google_accounts`, `switch_google_account`, `remove_google_account`; `login_webview` gains an `add_account` flag. Raw auth material still never crosses the Tauri boundary — the UI only sees display fields plus an opaque id.
- `switch_google_account` validates the stored cookie with `account_menu` before committing; on failure the previous session is restored untouched. An account saved mid multi-channel sign-in reopens the existing required channel picker instead of acting as YouTube's default channel.
- **Sign out removes the active account** from the saved list (per design discussion); other accounts stay available. A per-row ✕ in the menu removes any saved account.

### UI

- `AccountMenu.svelte`: saved-account list (Active badge), click-to-switch, per-account remove, **Add account**, plus the existing channel switcher and sign out. The list refetches on every menu open.
- New i18n strings in `en.json` (`add_account`, `active`, `remove_account`, `saved_accounts_hint`); other locales fall back to English as usual.

## Bug fix: add-account landing on the wrong account

Previously, after signing into a second account via Google's AddSession screen, the redirect back to music.youtube.com auto-continued as the webview's *default* session (`authuser=0`) — the first account — so the captured cookies belonged to the wrong account.

Fix (`src-tauri/src/session.rs`):

- Before opening the add-account screen, every `google.com` / `youtube.com` cookie is deleted from the webview's cookie store (`clear_google_webview_cookies`). This signs the *webview* out of Google only — the app's saved accounts live in SQLite and are untouched. The freshly signed-in account then becomes the webview's only session, and the YTM landing page shows that account.
- A one-shot account-chooser bounce is kept as a fallback if the captured cookie still matches a saved account (`AppState::matches_saved_account`).

## Bug fix: stored sessions going stale ("session expired")

Google rotates its short-lived cookie tokens (`__Secure-*SIDTS` and friends) on authenticated responses; the app previously stored one static snapshot, so a session — especially a freshly created one — died within minutes while another account was used.

Fixes:

- **Transport-level cookie rotation persistence** (`crates/innertube/src/transport.rs`): every authenticated response's `Set-Cookie` headers are now merged into the session jar the way a browser's cookie store would (replace / add / `Max-Age=0` delete). This also fixes the long-standing KI-2 cookie-staleness problem at the transport level.
- **Settled capture at sign-in** (`session.rs`): the webview is polled for ~4 seconds after landing on YTM and sign-in uses the *latest* jar, so the rotation tokens set by the YTM page's first requests are included.
- **Periodic persistence** (`state.rs` + `lib.rs`): a 60-second timer writes the rotated jar back to the active account's row (and the startup `session_cookie` projection), so switching away and back — or restarting — never revives a dead cookie.
- Switch errors now distinguish a genuinely dead session from a network failure.

## Files changed

| Area | Files |
|---|---|
| DB layer | `src-tauri/src/db.rs` |
| State / auth logic | `src-tauri/src/state.rs` |
| Commands + wiring | `src-tauri/src/commands.rs`, `src-tauri/src/lib.rs` |
| Login webview | `src-tauri/src/session.rs` |
| InnerTube transport | `crates/innertube/src/transport.rs` |
| UI | `ui/src/lib/api.ts`, `ui/src/lib/components/AccountMenu.svelte`, `ui/src/lib/locales/en.json` |
| Docs | `docs/SIGN-IN-SESSIONS.md` (new — documents where sign-in session data lives) |

## Testing

Automated: `cargo test -p limusic-app db::` (accounts table round-trip, refresh semantics, legacy migration) and `cargo test -p innertube` (Set-Cookie merge into the jar).

Manual (Windows, NSIS build):

1. Sign in with account A → browse → menu shows A as Active.
2. **Add account** → sign in with account B (password prompt — the webview session was cleared) → YTM landing page shows B → menu lists both, B Active.
3. Switch to A (one click, no password) → browse → switch back to B → browse. No "session expired".
4. Restart the app → switch A ↔ B again.
5. Remove B with the row ✕ → drops to guest; A still listed and switchable.
6. Multi-channel account: sign-in still opens the existing required channel picker.

## Compatibility & trade-offs

- Existing single-account databases migrate transparently on first launch; the legacy settings keys stay in sync as projections, so older builds reading them remain consistent.
- "Add account" signs the login webview out of Google first. Consequently, a later plain "Sign in with Google" asks for a password again — the intended trade-off for guaranteeing the fresh sign-in lands on the right account. Saved accounts are unaffected: switching back to them never needs a password.
- An account that sits unused long enough for Google to fully expire its session needs a fresh sign-in (remove + add again); while in use, sessions now keep themselves alive via cookie rotation.


<img width="1804" height="1204" alt="image" src="https://github.com/user-attachments/assets/eb40a897-d640-4ca3-94ce-c782a93449d2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for saving and managing multiple Google accounts.
  * Users can add, switch between, and remove saved accounts from the account menu.
  * Added active-account indicators and improved signed-out guidance.
  * Preserved sessions across restarts and refreshed session cookies automatically.

* **Bug Fixes**
  * Improved session cookie handling, including updates and expiration.

* **Documentation**
  * Added documentation covering sign-in session storage and account flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->