### PR TITLE
fix(macos): drop the duplicate rpaths dylibbundler leaves in libmpv

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -242,8 +242,39 @@ jobs:
             -s "$BREW_PREFIX/lib" < /dev/null
           echo "bundled $(ls "$APP/Contents/Frameworks" | wc -l | tr -d ' ') libraries"
 
+      # dylibbundler rewrites EVERY LC_RPATH it finds to the same -p prefix, and Homebrew's libmpv
+      # ships two of them (the Xcode Swift toolchain and /usr/lib/swift). Both become
+      # "@executable_path/../Frameworks/", and dyld refuses to load a Mach-O that lists one rpath
+      # twice: `Library not loaded: ... Reason: duplicate LC_RPATH`. The app then dies the instant
+      # it launches, on every machine including this runner, while `otool -L` stays perfectly clean
+      # -- which is exactly why the Homebrew guard below cannot see it.
+      - name: Drop the duplicate rpaths dylibbundler leaves behind
+        run: |
+          set -euo pipefail
+          APP=target/release/bundle/macos/limusic.app
+          find "$APP" -type f -print0 | while IFS= read -r -d '' f; do
+            # `otool -l` on a non-Mach-O file just prints nothing useful, so no file-type test is
+            # needed; the awk below yields no rpaths and the inner loop does nothing.
+            #
+            # [[:space:]], not \s, for the same BSD-grep/awk reason as the guard further down.
+            otool -l "$f" 2>/dev/null \
+              | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{print $2; g=0}' \
+              | sort | uniq -c | while read -r n rp; do
+                  [ "$n" -gt 1 ] || continue
+                  # -delete_rpath removes ONE matching entry per call, so repeat it n-1 times and
+                  # leave the last copy in place.
+                  echo "${f#$APP/}: dropping $((n - 1)) duplicate rpath(s) $rp"
+                  i=1
+                  while [ "$i" -lt "$n" ]; do
+                    install_name_tool -delete_rpath "$rp" "$f"
+                    i=$((i + 1))
+                  done
+                done
+          done
+          echo "rpath tables deduplicated"
+
       # Ad-hoc signature. Not an Apple Developer identity (see the header), but arm64 macOS will not
-      # execute a Mach-O with no valid signature at all, and every install-name rewrite above
+      # execute a Mach-O with no valid signature at all, and every install-name and rpath rewrite
       # invalidated the one the linker put there. This is the difference between an app that opens
       # and one that dies with "Killed: 9".
       - name: Re-sign the bundle
@@ -252,6 +283,29 @@ jobs:
           APP=target/release/bundle/macos/limusic.app
           codesign --force --deep --sign - "$APP"
           codesign --verify --deep --strict --verbose=2 "$APP"
+
+      # Regression guard for the dedupe step above, placed after the re-sign so it inspects the
+      # bundle in exactly the state that gets archived. A duplicate LC_RPATH is invisible to
+      # `otool -L` and to `codesign --verify`, so without this check the first symptom is the
+      # shipped .dmg refusing to start on every user's Mac.
+      - name: Check no Mach-O lists a duplicate rpath
+        run: |
+          set -euo pipefail
+          APP=target/release/bundle/macos/limusic.app
+          # `|| true` for the same reason as the Homebrew guard: uniq -d exits 0 but the awk
+          # pipeline must not be allowed to abort the command substitution on a clean file.
+          DUPES="$(find "$APP" -type f -print0 | while IFS= read -r -d '' f; do
+            otool -l "$f" 2>/dev/null \
+              | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{print $2; g=0}' \
+              | sort | uniq -d | sed "s|^|${f#$APP/} <- |" || true
+          done)"
+          if [ -n "$DUPES" ]; then
+            echo "::error::these Mach-O files list the same rpath twice, so dyld refuses to load them:"
+            echo "$DUPES"
+            echo "The dedupe step above should have removed these. Did dylibbundler run after it?"
+            exit 1
+          fi
+          echo "every rpath table is free of duplicates"
 
       # The regression test for this workflow, and the only one available without a Mac in hand:
       # nothing in the bundle may still point at Homebrew. A single missed dependency is an app that

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -299,6 +299,10 @@ jobs:
         run: |
           set -euo pipefail
           APP=target/release/bundle/macos/limusic.app
+          # errexit does not reach inside a command substitution unless this is on, so without it
+          # a file whose inspection failed is skipped and the loop still reports success as long as
+          # a later file succeeds.
+          shopt -s inherit_errexit
           # No `|| true` here, unlike the Homebrew guard: that one needs it because grep exits 1
           # on every clean file, whereas uniq -d exits 0. Letting the pipeline fail is the point.
           # A swallowed failure (otool unresolvable on some future runner image) would leave DUPES

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -257,8 +257,15 @@ jobs:
             # needed; the awk below yields no rpaths and the inner loop does nothing.
             #
             # [[:space:]], not \s, for the same BSD-grep/awk reason as the guard further down.
+            # Strip the `path ` prefix and the ` (offset N)` suffix rather than taking $2, so an
+            # rpath containing a space is not silently truncated to its first word.
+            #
+            # `otool -l` prints the load commands of every slice, so on a universal binary one
+            # legitimate rpath per architecture would count as a duplicate and -delete_rpath would
+            # then strip it from all of them. Thin arm64 only here; count per `-arch` if the Intel
+            # leg in the header ever becomes a fat build instead of a second job.
             otool -l "$f" 2>/dev/null \
-              | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{print $2; g=0}' \
+              | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{sub(/^[[:space:]]*path /, ""); sub(/ \(offset [0-9]+\)$/, ""); print; g=0}' \
               | sort | uniq -c | while read -r n rp; do
                   [ "$n" -gt 1 ] || continue
                   # -delete_rpath removes ONE matching entry per call, so repeat it n-1 times and
@@ -292,12 +299,14 @@ jobs:
         run: |
           set -euo pipefail
           APP=target/release/bundle/macos/limusic.app
-          # `|| true` for the same reason as the Homebrew guard: uniq -d exits 0 but the awk
-          # pipeline must not be allowed to abort the command substitution on a clean file.
+          # No `|| true` here, unlike the Homebrew guard: that one needs it because grep exits 1
+          # on every clean file, whereas uniq -d exits 0. Letting the pipeline fail is the point.
+          # A swallowed failure (otool unresolvable on some future runner image) would leave DUPES
+          # empty and pass this step over a bundle it never actually inspected.
           DUPES="$(find "$APP" -type f -print0 | while IFS= read -r -d '' f; do
             otool -l "$f" 2>/dev/null \
-              | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{print $2; g=0}' \
-              | sort | uniq -d | sed "s|^|${f#$APP/} <- |" || true
+              | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{sub(/^[[:space:]]*path /, ""); sub(/ \(offset [0-9]+\)$/, ""); print; g=0}' \
+              | sort | uniq -d | sed "s|^|${f#$APP/} <- |"
           done)"
           if [ -n "$DUPES" ]; then
             echo "::error::these Mach-O files list the same rpath twice, so dyld refuses to load them:"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,17 @@ offline. If you touch a lyrics provider, run the ignored ones: a provider whose
 endpoint has changed returns "no lyrics" rather than an error, so it looks
 exactly like a track that simply has none.
 
+On macOS the test binaries link libmpv just like the app does, so they need the
+same `LIBRARY_PATH` as the build or they fail to link with
+`ld: library 'mpv' not found`:
+
+```bash
+export LIBRARY_PATH="$(brew --prefix)/lib:$LIBRARY_PATH"
+```
+
+See [docs/BUILD-PLATFORMS.md](docs/BUILD-PLATFORMS.md) for the rest of the macOS
+setup.
+
 ## Pull requests
 
 - **Open from a branch, not your fork's `master`.** It keeps your default branch

--- a/docs/BUILD-PLATFORMS.md
+++ b/docs/BUILD-PLATFORMS.md
@@ -128,7 +128,10 @@ cargo tauri build --bundles deb   # → target/release/bundle/deb/limusic_*.deb
    ```bash
    brew install dylibbundler
    APP=target/release/bundle/macos/limusic.app
-   dylibbundler -cd -of -b -x "$APP/Contents/MacOS/limusic" \
+   # The executable is NOT named after the bundle: productName names the .app, the cargo package
+   # names the binary (limusic-app). Ask the bundle rather than guessing.
+   BIN="$APP/Contents/MacOS/$(plutil -extract CFBundleExecutable raw "$APP/Contents/Info.plist")"
+   dylibbundler -cd -of -b -x "$BIN" \
      -d "$APP/Contents/Frameworks" -p "@executable_path/../Frameworks" -s "$(brew --prefix)/lib"
    ```
    Check the result with `find "$APP" -type f -exec otool -L {} + | grep /opt/homebrew`. Anything
@@ -172,16 +175,17 @@ cargo tauri build --bundles deb   # → target/release/bundle/deb/limusic_*.deb
    Finder (the icon bounces once and goes away), so run the binary in a terminal, where dyld says
    what it could not load:
    ```bash
-   "$APP/Contents/MacOS/limusic"
+   "$APP/Contents/MacOS/$(plutil -extract CFBundleExecutable raw "$APP/Contents/Info.plist")"
    ```
 - `bundle.macOS.minimumSystemVersion` is **14.0** because Homebrew bottles are built per macOS
   version, so whatever the CI runner ships is the floor. It tracks `runs-on` in the workflow.
 - Media keys use **MPNowPlayingInfoCenter / MPRemoteCommandCenter** (Control Center + the Now
   Playing widget). Works from the `.app` bundle; a bare binary run won't register.
-- **Login is currently broken on macOS.** `session.rs::read_login_cookies` uses `cookies_for_url`,
-  which on WKWebView matches the cookie's host exactly, so YouTube's `.youtube.com` cookies never
-  match `music.youtube.com` and the jar comes back empty. WebKitGTK does real domain matching, which
-  is why Linux is unaffected.
+- **Login works, but not via `cookies_for_url`.** WKWebView's implementation compares the cookie's
+  domain to the URL's host with `==`, so YouTube's `.youtube.com` cookies never match
+  `music.youtube.com` and the jar came back empty (no SAPISID, so sign-in gave up silently).
+  `session.rs::youtube_cookie_header` therefore domain-matches by hand. WebKitGTK matches properly,
+  which is why Linux never saw this. Fixed in d18ed4a; don't reintroduce `cookies_for_url` here.
 
 ---
 

--- a/docs/BUILD-PLATFORMS.md
+++ b/docs/BUILD-PLATFORMS.md
@@ -120,7 +120,7 @@ cargo tauri build --bundles deb   # → target/release/bundle/deb/limusic_*.deb
    cd ui && pnpm build && cd ..
    cargo tauri build          # → target/release/bundle/{macos,dmg}/limusic.{app,dmg}
    ```
-5. **Bundle the dylibs, all of them, then re-sign.** What comes out of step 4 runs on *your* machine
+5. **Bundle the dylibs, all of them.** What comes out of step 4 runs on *your* machine
    only: the binary links `libmpv.2.dylib` by its absolute Homebrew path, and libmpv in turn links
    about forty more Homebrew dylibs (all of ffmpeg, libass, libplacebo, uchardet) the same way.
    `install_name_tool` on libmpv alone fixes one edge of that graph and leaves the rest, so use
@@ -130,15 +130,50 @@ cargo tauri build --bundles deb   # → target/release/bundle/deb/limusic_*.deb
    APP=target/release/bundle/macos/limusic.app
    dylibbundler -cd -of -b -x "$APP/Contents/MacOS/limusic" \
      -d "$APP/Contents/Frameworks" -p "@executable_path/../Frameworks" -s "$(brew --prefix)/lib"
-   codesign --force --deep --sign - "$APP"     # NOT optional, see below
    ```
    Check the result with `find "$APP" -type f -exec otool -L {} + | grep /opt/homebrew`. Anything
    it prints is a library the app will fail to find on someone else's Mac; CI runs exactly that as
    a build guard.
-6. **The re-sign is mandatory on Apple Silicon.** arm64 macOS refuses to execute a Mach-O with no
-   valid signature, the linker's ad-hoc one is invalidated by every install-name rewrite above, and
-   the symptom is the app dying instantly with `Killed: 9`. Ad-hoc (`--sign -`) is enough to run;
-   it is not enough to satisfy Gatekeeper on a downloaded app (see `RELEASING.md` §6).
+6. **Drop the duplicate rpaths dylibbundler leaves behind.** It rewrites *every* `LC_RPATH` it
+   finds to the `-p` prefix, and Homebrew's libmpv ships two of them (the Xcode Swift toolchain and
+   `/usr/lib/swift`). Both come out as `@executable_path/../Frameworks/`, and dyld refuses to load
+   a Mach-O that lists one rpath twice, so the app dies the moment it starts:
+   ```
+   Library not loaded: @executable_path/../Frameworks/libmpv.2.dylib
+   Reason: tried: '.../Contents/Frameworks/libmpv.2.dylib'
+           (duplicate LC_RPATH '@executable_path/../Frameworks/')
+   ```
+   `otool -L` and `codesign --verify` both stay clean through this, so the Homebrew guard above
+   will not catch it. `-delete_rpath` removes one entry per call:
+   ```bash
+   install_name_tool -delete_rpath '@executable_path/../Frameworks/' \
+     "$APP/Contents/Frameworks/libmpv.2.dylib"
+   ```
+   To find every offender rather than just libmpv, and to check the fix afterwards:
+   ```bash
+   find "$APP" -type f -print0 | while IFS= read -r -d '' f; do
+     otool -l "$f" 2>/dev/null \
+       | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{print $2; g=0}' \
+       | sort | uniq -d | sed "s|^|${f#$APP/} <- |"
+   done
+   ```
+   CI does both, in `Drop the duplicate rpaths dylibbundler leaves behind` and
+   `Check no Mach-O lists a duplicate rpath`.
+7. **Re-sign, and it is mandatory on Apple Silicon.**
+   ```bash
+   codesign --force --deep --sign - "$APP"
+   codesign --verify --deep --strict "$APP"
+   ```
+   arm64 macOS refuses to execute a Mach-O with no valid signature, the linker's ad-hoc one is
+   invalidated by every install-name and rpath rewrite above, and the symptom is the app dying
+   instantly with `Killed: 9`. Ad-hoc (`--sign -`) is enough to run; it is not enough to satisfy
+   Gatekeeper on a downloaded app (see `RELEASING.md` §6).
+8. **Smoke-test the bundle before believing it.** Every failure above looks identical from the
+   Finder (the icon bounces once and goes away), so run the binary in a terminal, where dyld says
+   what it could not load:
+   ```bash
+   "$APP/Contents/MacOS/limusic"
+   ```
 - `bundle.macOS.minimumSystemVersion` is **14.0** because Homebrew bottles are built per macOS
   version, so whatever the CI runner ships is the floor. It tracks `runs-on` in the workflow.
 - Media keys use **MPNowPlayingInfoCenter / MPRemoteCommandCenter** (Control Center + the Now

--- a/docs/BUILD-PLATFORMS.md
+++ b/docs/BUILD-PLATFORMS.md
@@ -156,7 +156,7 @@ cargo tauri build --bundles deb   # → target/release/bundle/deb/limusic_*.deb
    ```bash
    find "$APP" -type f -print0 | while IFS= read -r -d '' f; do
      otool -l "$f" 2>/dev/null \
-       | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{print $2; g=0}' \
+       | awk '/LC_RPATH/{g=1} g&&/^[[:space:]]*path /{sub(/^[[:space:]]*path /, ""); sub(/ \(offset [0-9]+\)$/, ""); print; g=0}' \
        | sort | uniq -d | sed "s|^|${f#$APP/} <- |"
    done
    ```


### PR DESCRIPTION
`macos-release.yml` currently produces a `.dmg` that cannot start on any Mac, including the runner that built it. I hit it building locally, then reproduced it on `macos-14` in CI.

## The bug

`dylibbundler` rewrites **every** `LC_RPATH` it finds to the `-p` prefix. Homebrew's libmpv ships two of them:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx
/usr/lib/swift
```

Both come out as `@executable_path/../Frameworks/`, and dyld refuses to load a Mach-O that lists one rpath twice:

```
dyld: Library not loaded: @executable_path/../Frameworks/libmpv.2.dylib
  Referenced from: .../limusic.app/Contents/MacOS/limusic-app
  Reason: tried: '.../Contents/Frameworks/libmpv.2.dylib'
          (duplicate LC_RPATH '@executable_path/../Frameworks/')
```

The app dies instantly. From the Finder it looks exactly like the `Killed: 9` case the docs already warn about, so it is easy to misread as a signing problem.

**Nothing in the current pipeline can catch this.** `otool -L` stays clean, because the *dependency list* is correct — it is the rpath table that is malformed. `codesign --verify --deep --strict` passes too. So the existing "Check nothing still links to Homebrew" guard goes green on a bundle that starts on nobody's machine.

## The fix

Two steps in `macos-release.yml`:

1. **`Drop the duplicate rpaths dylibbundler leaves behind`**, after `dylibbundler`, before the re-sign. Walks every Mach-O in the bundle and removes the extra copies. `install_name_tool -delete_rpath` removes one entry per call, so it repeats n-1 times and leaves the last one. Idempotent.
2. **`Check no Mach-O lists a duplicate rpath`**, after the re-sign, so it inspects the bundle in the exact state that gets archived. Fails the build if any duplicate survives.

Ordering matters: the dedupe has to run before the re-sign, because rewriting a load command invalidates the signature.

## Evidence

A dry run of the patched workflow on `macos-14`:
https://github.com/oglimmer/limusic/actions/runs/33992030940

```
Bundle libmpv and its dependency graph          bundled 48 libraries
Drop the duplicate rpaths ...                   Contents/Frameworks/libmpv.2.dylib: dropping 1 duplicate rpath(s) @executable_path/../Frameworks/
Drop the duplicate rpaths ...                   rpath tables deduplicated
Check no Mach-O lists a duplicate rpath         every rpath table is free of duplicates
Check nothing still links to Homebrew           every linked library is either bundled or a macOS system library
Re-sign the bundle                              success
```

So the runner hits the same single duplicate on the same library. That run ends red at `Archive + sign the updater bundle`, which is four steps later and only because my fork has no `TAURI_SIGNING_PRIVATE_KEY`. Nothing before it fails.

## Commits

| | |
|---|---|
| `fix(macos): drop the duplicate rpaths...` | the workflow steps, plus the same two steps and a smoke-test step in the docs |
| `docs(macos): correct two things that stopped being true` | see below |
| `docs: say that cargo test needs LIBRARY_PATH on macOS` | see below |

Two stale things in `docs/BUILD-PLATFORMS.md`, both found while following the section by hand:

- The `dylibbundler` snippet points `-x` at `Contents/MacOS/limusic`, which does not exist. `productName` names the `.app`, the cargo package names the executable (`limusic-app`). Now read from `Info.plist`, the way the workflow already does.
- "Login is currently broken on macOS" has not been true since d18ed4a. The reason in the note is still correct and worth keeping, so I kept it and dropped the claim.

And in `CONTRIBUTING.md`: `cargo test --all` reads as though it works from a clean checkout, but on macOS the test binaries link libmpv like the app does, so without `LIBRARY_PATH` they fail with `ld: library 'mpv' not found` before a single test runs.

Happy to split any of these out if you would rather take them separately.

## Tested

- Full local bundle on macOS 27 / arm64: built, deduped, re-signed. The app starts, the window loads, `OS media controls attached`, PoToken minter comes up. Before the fix the same bundle died on launch every time.
- Reproduced the broken state deliberately on a copy of libmpv, then checked the guard fails on it, the dedupe fixes it, the guard passes, and a second dedupe changes nothing.
- CI dry run above.
- `cargo test --all` 210 passed / 0 failed, `cargo fmt --all` clean, `pnpm check` 891 files / 0 errors.

Not tested: Intel, and the updater tarball path, which needs the signing key.

## A note on authorship

This change was written with Claude (Claude Code). I hit the bug on my own machine, but the diagnosis, the workflow steps, the guard and this description were produced by Claude working in my checkout, and I reviewed them. Individual commits carry a `Co-Authored-By: Claude` trailer. Flagging it plainly so you can weigh the review accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS release packaging to preserve runtime paths containing spaces and prevent duplicate paths that could stop the application from launching.
  - Strengthened release checks so packaging failures are reported instead of being silently ignored.

- **Documentation**
  - Expanded macOS build and testing instructions, including library setup, bundle signing, runtime-path cleanup, and smoke testing.
  - Updated guidance to identify the application executable automatically.
  - Clarified macOS login behavior and current cookie-handling workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->