### PR TITLE
fix(macos): give ⌘H back to the system

### DIFF
--- a/ui/src/lib/components/KeyboardShortcuts.svelte
+++ b/ui/src/lib/components/KeyboardShortcuts.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	// Ctrl+H: what the keyboard can do. Nothing in the chrome points at the shortcuts, so this is
+	// Ctrl+H, ⌘/ on macOS: what the keyboard can do. Nothing in the chrome points at the shortcuts, so this is
 	// where they are discoverable. It documents the zoom keys too (zoom.ts owns those) — from the
 	// outside they are the same feature, and a list that only covers half of them is worse than none.
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { MOD } from '$lib/shortcuts';
+	import { HELP_COMBO, MOD } from '$lib/shortcuts';
 	import { ui } from '$lib/player.svelte';
 	import { t } from '$lib/i18n.svelte';
 
@@ -30,7 +30,7 @@
 				[t('dialogs.shortcuts.zoom_in'), `${MOD}+`],
 				[t('dialogs.shortcuts.zoom_out'), `${MOD}-`],
 				[t('dialogs.shortcuts.reset_zoom'), `${MOD}0`],
-				[t('dialogs.shortcuts.show_this_list'), `${MOD}H`]
+				[t('dialogs.shortcuts.show_this_list'), HELP_COMBO]
 			]
 		}
 	]);
@@ -40,7 +40,7 @@
 	<Dialog.Content class="sm:max-w-2xl">
 		<Dialog.Header>
 			<Dialog.Title>{t('dialogs.shortcuts.title')}</Dialog.Title>
-			<Dialog.Description>{t('dialogs.shortcuts.reopen_hint', { mod: MOD })}</Dialog.Description>
+			<Dialog.Description>{t('dialogs.shortcuts.reopen_hint', { key: HELP_COMBO })}</Dialog.Description>
 		</Dialog.Header>
 		<!-- Two columns that flow, so adding a row never means rebalancing the layout by hand. -->
 		<div class="gap-x-10 sm:columns-2">

--- a/ui/src/lib/components/SettingsDialog.svelte
+++ b/ui/src/lib/components/SettingsDialog.svelte
@@ -21,7 +21,7 @@
 	import { Alert, AlertDescription } from '$lib/components/ui/alert';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Select from '$lib/components/ui/select';
-	import { MOD } from '$lib/shortcuts';
+	import { HELP_COMBO } from '$lib/shortcuts';
 	import { copyText } from '$lib/clipboard';
 	import * as api from '$lib/api';
 	import { blocked, prefs, ui, toast, unblockArtist } from '$lib/player.svelte';
@@ -510,7 +510,7 @@
 						>
 							<HugeiconsIcon icon={KeyboardIcon} class="h-3.5 w-3.5" />
 							<span
-								>{shortcutsHint[0]}<kbd class="font-mono font-medium">{MOD}H</kbd>{shortcutsHint[1] ??
+								>{shortcutsHint[0]}<kbd class="font-mono font-medium">{HELP_COMBO}</kbd>{shortcutsHint[1] ??
 									''}</span
 							>
 						</button>

--- a/ui/src/lib/locales/en.json
+++ b/ui/src/lib/locales/en.json
@@ -397,7 +397,7 @@
 		},
 		"shortcuts": {
 			"title": "Keyboard shortcuts",
-			"reopen_hint": "{mod}H brings this back at any time.",
+			"reopen_hint": "{key} brings this back at any time.",
 			"group_playback": "Playback",
 			"group_general": "General",
 			"play_pause": "Play or pause",

--- a/ui/src/lib/locales/es.json
+++ b/ui/src/lib/locales/es.json
@@ -361,7 +361,7 @@
 		},
 		"shortcuts": {
 			"title": "Atajos de teclado",
-			"reopen_hint": "{mod}H abre esto en cualquier momento.",
+			"reopen_hint": "{key} abre esto en cualquier momento.",
 			"group_playback": "Reproducción",
 			"group_general": "General",
 			"play_pause": "Reproducir o pausar",

--- a/ui/src/lib/locales/fr.json
+++ b/ui/src/lib/locales/fr.json
@@ -361,7 +361,7 @@
 		},
 		"shortcuts": {
 			"title": "Raccourcis clavier",
-			"reopen_hint": "{mod}H permet de rouvrir cette fenêtre à tout moment.",
+			"reopen_hint": "{key} permet de rouvrir cette fenêtre à tout moment.",
 			"group_playback": "Lecture",
 			"group_general": "Général",
 			"play_pause": "Lecture ou pause",

--- a/ui/src/lib/locales/id.json
+++ b/ui/src/lib/locales/id.json
@@ -361,7 +361,7 @@
 		},
 		"shortcuts": {
 			"title": "Pintasan papan ketik",
-			"reopen_hint": "{mod}H menampilkan ini kembali kapan saja.",
+			"reopen_hint": "{key} menampilkan ini kembali kapan saja.",
 			"group_playback": "Pemutaran",
 			"group_general": "Umum",
 			"play_pause": "Putar atau jeda",

--- a/ui/src/lib/locales/pt_BR.json
+++ b/ui/src/lib/locales/pt_BR.json
@@ -361,7 +361,7 @@
 		},
 		"shortcuts": {
 			"title": "Atalhos de teclado",
-			"reopen_hint": "{mod}H abre isso a qualquer momento.",
+			"reopen_hint": "{key} abre isso a qualquer momento.",
 			"group_playback": "Reprodução",
 			"group_general": "Geral",
 			"play_pause": "Tocar ou pausar",

--- a/ui/src/lib/locales/tr.json
+++ b/ui/src/lib/locales/tr.json
@@ -362,7 +362,7 @@
 		},
 		"shortcuts": {
 			"title": "Klavye Kısayolları",
-			"reopen_hint": "{mod}H ile bu pencereyi istediğiniz zaman açabilirsiniz.",
+			"reopen_hint": "{key} ile bu pencereyi istediğiniz zaman açabilirsiniz.",
 			"group_playback": "Oynatma",
 			"group_general": "Genel",
 			"play_pause": "Oynat veya duraklat",

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -1032,7 +1032,7 @@ export const ui = $state({
 	linkOpen: false, // the "open a pasted link" modal
 	paletteOpen: false, // the Ctrl+K search palette
 	theaterOpen: false, // fullscreen theater view (artwork + lyrics)
-	shortcutsOpen: false, // the Ctrl+H keyboard-shortcuts list
+	shortcutsOpen: false, // the Ctrl+H (⌘/ on macOS) keyboard-shortcuts list
 	channelPickerOpen: false,
 	channelPickerRequired: false, // true while a multi-channel login is not finalized yet
 	channelIdentities: [] as AccountIdentity[],

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -6,9 +6,20 @@ import { browser } from '$app/environment';
 import * as api from './api';
 import { cycleRepeat, np, nudgeVolume, playback, toggleMute, ui } from './player.svelte';
 
+const IS_MAC = browser && navigator.platform.startsWith('Mac');
+
 /** How this machine writes the modifier these shortcuts hang off, for anything that shows a key
  *  hint. Mac takes the bare glyph; everywhere else the `+` is part of the spelling. */
-export const MOD = browser && navigator.platform.startsWith('Mac') ? '⌘' : 'Ctrl+';
+export const MOD = IS_MAC ? '⌘' : 'Ctrl+';
+
+/** macOS keeps ⌘H for the system "hide the window", so the shortcuts list answers to ⌘/ there. */
+export const HELP_KEY = IS_MAC ? '/' : 'H';
+
+/** The whole combo that opens the shortcuts list, spelled for this machine. */
+export const HELP_COMBO = `${MOD}${HELP_KEY}`;
+
+/** `HELP_KEY` as the event reports it. A letter arrives in either case; `/` only ever as itself. */
+const isHelpKey = (key: string) => key === HELP_KEY || key === HELP_KEY.toLowerCase();
 
 /** Percent per press, matching a step of the volume slider's arrow keys. */
 const VOLUME_STEP = 5;
@@ -31,16 +42,19 @@ export function initShortcuts(mini = false) {
 			e.preventDefault();
 			return;
 		}
-		if (mini && 'kKhHeE'.includes(e.key)) return;
+		if (mini && ('kKeE'.includes(e.key) || isHelpKey(e.key))) return;
+		// Out of the switch because the key is per-platform: on macOS ⌘H has to fall through
+		// untouched, so the window still hides.
+		if (isHelpKey(e.key)) {
+			ui.shortcutsOpen = !ui.shortcutsOpen;
+			e.preventDefault();
+			return;
+		}
 		switch (e.key) {
 			// Toggles, so the key that opened the palette also dismisses it.
 			case 'k':
 			case 'K':
 				ui.paletteOpen = !ui.paletteOpen;
-				break;
-			case 'h':
-			case 'H':
-				ui.shortcutsOpen = !ui.shortcutsOpen;
 				break;
 			case 'e':
 			case 'E':


### PR DESCRIPTION
## The problem

On macOS, `⌘H` hides the front window. It is one of the few shortcuts every
Mac app is expected to leave alone. The shortcuts list was taking it: the
window stayed put and a dialog opened instead.

It is hard to spot, too. Nothing in the chrome points at the shortcuts list,
so there is no other way to learn the key that collided.

## The fix

The help key moves out of the `switch` and becomes per-platform:

- **macOS:** the list opens with `⌘/`, the usual place for a cheat sheet.
  `⌘H` falls through untouched, so AppKit hides the window again.[^1]
- **Windows and Linux:** unchanged. Still `Ctrl+H`.

Every key hint now reads one `HELP_COMBO` export instead of a hardcoded `H`,
so the dialog and the Settings button print the right combo per platform.

## About the locale files

`reopen_hint` spelled the key itself: `"{mod}H"`. That cannot work once the
key differs per platform, so the placeholder became `"{key}"` and the combo
is passed in whole.

**This is a placeholder rename, not a translation edit.** No translated words
were touched. I know `CONTRIBUTING.md` asks for Weblate here, but leaving the
other languages on `{mod}H` would print the wrong key on every Mac. Happy to
redo it whichever way you prefer.

## Tested

Local release build on Apple Silicon (macOS 27, `tauri build`):

- `⌘H` hides the window. It comes back from the Dock.
- `⌘/` opens the shortcuts list. Pressing it again closes it.
- The list shows `⌘/` for "show this list", and the hint under Settings →
  General shows `⌘/` too.
- `⌘K`, `⌘E`, `⌘F`, `⌘D`, `⌘S`, `⌘R`, `⌘M` all still work.
- `npm run check`: 0 errors, 0 warnings.

Not tested on Windows or Linux. That path is unchanged, and the platform
check is a single `navigator.platform` read.

## A note on authorship

This change was written with Claude (Claude Code). I hit the bug on my own
machine, but the diagnosis, the platform split, the string changes and this
description were produced by Claude working in my checkout, and I reviewed
them. Individual commits carry a `Co-Authored-By: Claude` trailer. Flagging
it plainly so you can weigh the review accordingly.

[^1]: `⌘M` is still mute, and on macOS that is normally "minimize window" —
the same class of problem. I left it out to keep this to one concern. Say
the word and I will send a second PR.
