### PR TITLE
0.7.0 (menu play and shuffle, mini player shortcuts)

### DIFF
--- a/ui/src/lib/browse.ts
+++ b/ui/src/lib/browse.ts
@@ -54,10 +54,11 @@ export function openItem(item: BrowseItem): void {
 
 /**
  * Play the whole thing without opening it. A song is immediate; a playlist/album has to be fetched
- * first, so callers own the in-flight state (the pulsing button). Never throws — a failure toasts
- * and the user stays where they were.
+ * first, so callers own the in-flight state (the pulsing button). `shuffle` starts it shuffled
+ * (the card menu's shuffle button). Never throws — a failure toasts and the user stays where they
+ * were.
  */
-export async function playItem(item: BrowseItem): Promise<void> {
+export async function playItem(item: BrowseItem, shuffle = false): Promise<void> {
 	touchPick(item.id);
 	if (item.kind === 'song') {
 		playSong(asSong(item));
@@ -66,7 +67,7 @@ export async function playItem(item: BrowseItem): Promise<void> {
 	try {
 		if (item.kind === 'album') {
 			const album = await api.getAlbum(item.id);
-			await playFrom(item, album.items, null, album.playlistId ?? undefined);
+			await playFrom(item, album.items, null, album.playlistId ?? undefined, shuffle);
 		} else {
 			const pl = await api.getPlaylist(item.id);
 			// `sourceId` seeds autoplay off that playlist's radio. On Repeat is local, so there is
@@ -77,7 +78,7 @@ export async function playItem(item: BrowseItem): Promise<void> {
 				pl.items,
 				null,
 				item.id === api.ON_REPEAT_ID ? undefined : item.id,
-				undefined,
+				shuffle,
 				pl.continuation
 			);
 		}

--- a/ui/src/lib/components/PlaylistMenu.svelte
+++ b/ui/src/lib/components/PlaylistMenu.svelte
@@ -9,6 +9,8 @@
 		PinIcon,
 		PinOffIcon,
 		Radio02Icon,
+		PlayIcon,
+		ShuffleIcon,
 		ArrowUpNarrowWideIcon,
 		ArrowDownWideNarrowIcon,
 		BookmarkCheck02Icon,
@@ -20,7 +22,7 @@
 	} from '@hugeicons/core-free-icons';
 	import * as api from '$lib/api';
 	import type { BrowseItem } from '$lib/api';
-	import { enqueueItem } from '$lib/browse';
+	import { enqueueItem, playItem } from '$lib/browse';
 	import { anchorMenu, ctxHost, fitMenu, NO_ANCHOR, toBody } from '$lib/menu';
 	import { t } from '$lib/i18n.svelte';
 	import {
@@ -93,6 +95,14 @@
 		} finally {
 			queueing = false;
 		}
+	}
+
+	// Closes first, fetches after: the tracks take a moment to arrive and playback starting is its
+	// own feedback, so leaving the menu up until then just looks stuck.
+	function play(e: MouseEvent, shuffle: boolean) {
+		e.stopPropagation();
+		menuOpen = false;
+		playItem(item, shuffle);
 	}
 
 	let saving = $state(false);
@@ -193,6 +203,27 @@
 		{@attach toBody}
 		{@attach fitMenu(anchor)}
 	>
+		<!-- One row, two targets: the row plays, the small button on its right shuffles. Two
+		     siblings in a flex wrapper rather than a nested button (invalid HTML), with the hover
+		     tint on the wrapper so it still reads as a single item. -->
+		{#if item.kind === 'album' || item.kind === 'playlist'}
+			<div class="flex items-center rounded-md hover:bg-accent/10">
+				<button
+					class="flex flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-primary"
+					onclick={(e) => play(e, false)}
+				>
+					<HugeiconsIcon icon={PlayIcon} class="h-4 w-4" /> {t('player.play')}
+				</button>
+				<button
+					class="mr-1 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md hover:bg-accent/20"
+					title={t('player.shuffle_play')}
+					aria-label={t('player.shuffle_play')}
+					onclick={(e) => play(e, true)}
+				>
+					<HugeiconsIcon icon={ShuffleIcon} class="h-4 w-4" />
+				</button>
+			</div>
+		{/if}
 		{#if showPin}
 			<button
 				class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent/10"

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -18,7 +18,9 @@ const typing = (t: EventTarget | null) =>
 	t instanceof HTMLElement &&
 	(t.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(t.tagName));
 
-export function initShortcuts() {
+/** `mini` = the mini-player window: same transport keys, minus the ones that toggle a piece of
+ *  chrome that window doesn't render (palette, shortcut list, now-playing view). */
+export function initShortcuts(mini = false) {
 	const onKey = (e: KeyboardEvent) => {
 		if (!e.ctrlKey && !e.metaKey) {
 			// Space also activates a focused button and scrolls the page, so it is swallowed either
@@ -29,6 +31,7 @@ export function initShortcuts() {
 			e.preventDefault();
 			return;
 		}
+		if (mini && 'kKhHeE'.includes(e.key)) return;
 		switch (e.key) {
 			// Toggles, so the key that opened the palette also dismisses it.
 			case 'k':

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -109,7 +109,15 @@
 	onMount(() => {
 		// Before the mini-window bail-out: both windows run this SPA and both can throw.
 		initErrorLog();
-		if (isMini) return initApp(true);
+		if (isMini) {
+			// The widget gets the transport keys too. No zoom: it is a fixed-size card.
+			const teardownMiniApp = initApp(true);
+			const teardownMiniKeys = initShortcuts(true);
+			return () => {
+				teardownMiniApp();
+				teardownMiniKeys();
+			};
+		}
 		// First: it reveals the window (see initWin).
 		const teardownWin = initWin();
 		checkForUpdatesQuiet();


### PR DESCRIPTION
Two changes on top of 0.6.10.

### New features

- The right-click menu for an album or playlist opens with a Play row whose
  right-hand button starts the same tracks shuffled. (Discussion #171)

### Bug fixes

- The mini player had no keyboard listener at all: it returned from onMount
  before the shortcuts were wired. It gets the same one as the main window
  now, minus the keys that toggle chrome that window does not render. (#183)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct Play and Shuffle actions for albums and playlists in the playlist menu.
  - Album and playlist playback now supports shuffle mode.

- **Bug Fixes**
  - Improved mini-player keyboard shortcut behavior by ignoring controls unavailable in the mini-player.
  - Added proper cleanup for mini-player keyboard shortcuts when the window closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->