### PR TITLE
fix(macos): give ⌘M back to the system

### DIFF
--- a/ui/src/lib/components/KeyboardShortcuts.svelte
+++ b/ui/src/lib/components/KeyboardShortcuts.svelte
@@ -3,7 +3,7 @@
 	// where they are discoverable. It documents the zoom keys too (zoom.ts owns those) — from the
 	// outside they are the same feature, and a list that only covers half of them is worse than none.
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { HELP_COMBO, MOD } from '$lib/shortcuts';
+	import { HELP_COMBO, MOD, MUTE_COMBO } from '$lib/shortcuts';
 	import { ui } from '$lib/player.svelte';
 	import { t } from '$lib/i18n.svelte';
 
@@ -17,7 +17,7 @@
 				[t('dialogs.shortcuts.previous_song'), `${MOD}D`],
 				[t('dialogs.shortcuts.shuffle_queue'), `${MOD}S`],
 				[t('dialogs.shortcuts.toggle_repeat'), `${MOD}R`],
-				[t('dialogs.shortcuts.mute_unmute'), `${MOD}M`],
+				[t('dialogs.shortcuts.mute_unmute'), MUTE_COMBO],
 				[t('dialogs.shortcuts.volume_up'), `${MOD}>`],
 				[t('dialogs.shortcuts.volume_down'), `${MOD}<`]
 			]

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -21,6 +21,12 @@ export const HELP_COMBO = `${MOD}${HELP_KEY}`;
 /** `HELP_KEY` as the event reports it. A letter arrives in either case; `/` only ever as itself. */
 const isHelpKey = (key: string) => key === HELP_KEY || key === HELP_KEY.toLowerCase();
 
+/** macOS keeps ⌘M for the system "minimize the window", so mute asks for ⇧ on top there. */
+export const MUTE_COMBO = IS_MAC ? `${MOD}⇧M` : `${MOD}M`;
+
+/** Mute's key, shift and all. Elsewhere ⇧ is ignored, the way it always was for these letters. */
+const isMuteKey = (e: KeyboardEvent) => (e.key === 'm' || e.key === 'M') && (!IS_MAC || e.shiftKey);
+
 /** Percent per press, matching a step of the volume slider's arrow keys. */
 const VOLUME_STEP = 5;
 
@@ -47,6 +53,13 @@ export function initShortcuts(mini = false) {
 		// untouched, so the window still hides.
 		if (isHelpKey(e.key)) {
 			ui.shortcutsOpen = !ui.shortcutsOpen;
+			e.preventDefault();
+			return;
+		}
+		// Out of the switch for the same reason, and it has to read the whole event: on macOS a
+		// bare ⌘M falls through so AppKit still minimizes, and only ⌘⇧M mutes.
+		if (isMuteKey(e)) {
+			toggleMute();
 			e.preventDefault();
 			return;
 		}
@@ -78,10 +91,6 @@ export function initShortcuts(mini = false) {
 			case 'r':
 			case 'R':
 				cycleRepeat();
-				break;
-			case 'm':
-			case 'M':
-				toggleMute();
 				break;
 			// Shift+. and Shift+, on a US layout. The unshifted keys are accepted too, so the
 			// shortcut still works on layouts that put > and < somewhere else.


### PR DESCRIPTION
## The problem

On macOS `⌘M` minimizes the front window. Like `⌘H` it is one of the few
shortcuts every Mac app is expected to leave alone. Mute was taking it: the
window stayed put and the volume dropped instead.

This is the follow-up promised in #179. That PR fixed `⌘H` and left this one
out to keep itself to one concern.

## The fix

Mute becomes per-platform the same way the help key did:

- **macOS:** `⌘⇧M` mutes. A bare `⌘M` falls through untouched, so AppKit
  minimizes the window. Teams and Discord both put their mute toggle on
  `⌘⇧M`, so the combo should already be in the fingers.
- **Windows and Linux:** unchanged. Still `Ctrl+M`, with shift ignored as it
  always was for these letters.

Mute moves out of the `switch` to do it, because the decision needs the whole
event and not just the key. The shortcuts list reads one `MUTE_COMBO` export
instead of a hardcoded `M`.

**No locale change this time.** The mute row never spelled its key out.

## Tested

Local release build on Apple Silicon (macOS 27):

- `⌘M` minimizes. The window comes back from the Dock.
- `⌘⇧M` mutes and unmutes.
- The list reads `⌘⇧M` for "mute or unmute".
- Both behave the same in the mini player.
- `⌘K`, `⌘E`, `⌘F`, `⌘D`, `⌘S`, `⌘R`, `⌘/`, `⌘H` all still work.
- `pnpm check`: 0 errors, 0 warnings.

Not tested on Windows or Linux. That path is unchanged.

## A note on authorship

Written with Claude (Claude Code) in my checkout, and reviewed by me. Commits
carry a `Co-Authored-By: Claude` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the macOS mute shortcut to use Command+Shift+M, avoiding conflicts with the system minimize-window shortcut.
  * Kept the mute shortcut as Ctrl+M on other platforms.
  * Updated the keyboard shortcuts display to reflect the correct mute combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->