### PR TITLE
feat: add track multi-select and bulk actions

### DIFF
--- a/ui/src/lib/components/AddToPlaylist.svelte
+++ b/ui/src/lib/components/AddToPlaylist.svelte
@@ -8,6 +8,7 @@
 	import { t } from '$lib/i18n.svelte';
 	import {
 		ui,
+		auth,
 		toast,
 		bumpLibraryTrackCount,
 		notePlaylistAdd,
@@ -55,27 +56,53 @@
 	}
 
 	async function pick(pl: BrowseItem) {
+		if (ui.addPending) return;
 		const songs = ui.addSongs;
 		close();
 		if (!songs?.length) return;
+		if (songs.some((s) => api.isLocalId(s.video_id))) {
+			toast.error(t('selection.local_playlist'));
+			return;
+		}
+		const epoch = auth.epoch;
+		ui.addPending = true;
+		const added: typeof songs = [];
+		const confirmed: typeof songs = [];
+		let failure: string | null = null;
 		try {
-			// Sequential — a whole album is a handful of requests; don't hammer the API in parallel.
+			// Sequential — bulk selection can contain thousands of rows; avoid concurrent writes.
 			// YouTube refuses a track the playlist already holds, so only the ones it accepted get
 			// counted and drawn: an optimistic row for a refused add is a row that can never be
 			// removed (no setVideoId behind it) until the app restarts.
-			const added: typeof songs = [];
 			for (const song of songs) {
-				if (await api.addToPlaylist(pl.id, song.video_id)) added.push(song);
+				if (epoch !== auth.epoch) break;
+				try {
+					if (await api.addToPlaylist(pl.id, song.video_id)) added.push(song);
+					confirmed.push(song);
+				} catch (e) {
+					failure = String(e);
+					break;
+				}
 			}
-			const dupes = songs.length - added.length;
+			// A switched account owns different caches. Stop the batch and never patch those caches.
+			if (epoch !== auth.epoch) {
+				toast.error(t('selection.account_changed'));
+				return;
+			}
+			const dupes = confirmed.length - added.length;
 			// Every song, not just the accepted ones: a refusal means the playlist already holds it,
 			// so its "saved" mark is right either way.
-			noteSavedIn(pl.id, songs.map((s) => s.video_id));
+			noteSavedIn(pl.id, confirmed.map((s) => s.video_id));
 			if (added.length) {
 				bumpLibraryTrackCount(pl.id, added.length);
 				notePlaylistAdd(pl.id, added);
 			}
-			if (!added.length) {
+			if (failure !== null) {
+				toast.error(t('selection.playlist_partial', {
+					added: added.length, playlist: pl.title, duplicates: dupes,
+					remaining: songs.length - confirmed.length, error: failure
+				}));
+			} else if (!added.length) {
 				toast(
 					dupes > 1
 						? t('toasts.already_in_all', { count: dupes, playlist: pl.title })
@@ -94,6 +121,8 @@
 			}
 		} catch (e) {
 			toast.error(String(e));
+		} finally {
+			ui.addPending = false;
 		}
 	}
 </script>

--- a/ui/src/lib/components/TrackRow.svelte
+++ b/ui/src/lib/components/TrackRow.svelte
@@ -18,6 +18,7 @@
 	import ArtistLine from './ArtistLine.svelte';
 	import ExplicitIcon from './ExplicitIcon.svelte';
 	import { t } from '$lib/i18n.svelte';
+	import type { TrackSelection } from '$lib/selection.svelte';
 
 	let {
 		song,
@@ -31,7 +32,9 @@
 		onAdd,
 		onRemove,
 		removeLabel = t('player.remove_from_playlist'),
-		inLibraryList = false
+		inLibraryList = false,
+		selection,
+		selectionKey
 	}: {
 		song: SongItem;
 		/** Position badge when set (playlist/queue); omitted for flat search results. */
@@ -64,11 +67,30 @@
 		/** Adds a remove menu item (label via `removeLabel`). */
 		onRemove?: () => void;
 		removeLabel?: string;
+		/** Optional list-owned selection; the key identifies this occurrence, not the song. */
+		selection?: TrackSelection;
+		selectionKey?: string;
 	} = $props();
 
 	// In a session as guest, clicking a song adds it to the shared queue instead of playing it —
 	// reflect that in the hover icon + label so the row doesn't lie.
 	const guestAdd = $derived(lt.role === 'guest');
+	const selectable = $derived(!!selection && selectionKey !== undefined);
+	const selected = $derived(selection?.has(selectionKey) ?? false);
+	const selecting = $derived(selectable && (selection?.count ?? 0) > 0);
+
+	function select(range = false) {
+		if (selection && selectionKey !== undefined) selection.toggle(selectionKey, range);
+	}
+
+	function clickRow(e: MouseEvent) {
+		if (selectable && (e.ctrlKey || e.metaKey || e.shiftKey || selecting)) {
+			e.preventDefault();
+			select(e.shiftKey);
+			return;
+		}
+		onplay();
+	}
 
 	// Digits and colons, nothing else. A queue saved before the parser stopped reading a name with a
 	// colon in it ("Cast of EPIC: The Musical") as a length still holds those strings, and printing
@@ -89,7 +111,27 @@
 	// Only when the key lands on the row itself — keydowns bubble up from nested interactive
 	// elements (⋯ menu, artist link), and hijacking those would play the row instead.
 	function onKey(e: KeyboardEvent) {
-		if (e.target !== e.currentTarget) return;
+		if (e.target !== e.currentTarget) {
+			if (e.key === ' ') e.stopPropagation();
+			return;
+		}
+		if (selection && selectable) {
+			if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+				e.preventDefault();
+				e.stopPropagation();
+				selection.selectAll();
+				return;
+			}
+			if (e.key === 'Escape' || e.key === ' ') {
+				e.preventDefault();
+				e.stopPropagation();
+				if (!e.repeat) {
+					if (e.key === 'Escape') selection.clear();
+					else select(e.shiftKey);
+				}
+				return;
+			}
+		}
 		if (e.key === 'Enter' || e.key === ' ') {
 			e.preventDefault();
 			onplay();
@@ -128,13 +170,38 @@
 	role="button"
 	tabindex="0"
 	data-ctx
-	onclick={onplay}
+	onclick={clickRow}
 	onkeydown={onKey}
-	aria-label={guestAdd ? `Add ${song.title} to the session queue` : `Play ${song.title}`}
-	class="group flex w-full cursor-pointer items-center gap-3 rounded-lg p-2 transition-colors hover:bg-accent/10 {active
+	data-selection-key={selectionKey}
+	data-selected={selectable ? selected : undefined}
+	aria-label={selectable ? t(guestAdd ? 'selection.track_guest' : 'selection.track', { title: song.title }) : guestAdd ? `Add ${song.title} to the session queue` : `Play ${song.title}`}
+	class="group flex w-full cursor-pointer items-center gap-3 rounded-lg p-2 transition-colors hover:bg-accent/10 {selected
+		? 'bg-primary/10 ring-1 ring-inset ring-primary/40'
+		: active
 		? 'bg-accent/10'
 		: ''} {compact ? '' : '[content-visibility:auto] [contain-intrinsic-size:auto_3.5rem]'}"
 >
+	{#if selectable}
+		<input
+			type="checkbox"
+			checked={selected}
+			aria-label={t('selection.select_track', { title: song.title })}
+			class="h-4 w-4 shrink-0 cursor-pointer accent-primary"
+			onclick={(e) => {
+				e.stopPropagation();
+				select(e.shiftKey);
+				// Shift can keep an already selected endpoint selected. Its derived boolean then
+				// stays unchanged, so restore the checkbox the browser just toggled off.
+				e.currentTarget.checked = selection!.has(selectionKey);
+			}}
+			onkeydown={(e) => {
+				if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); selection!.clear(); }
+				if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+					e.preventDefault(); e.stopPropagation(); selection!.selectAll();
+				}
+			}}
+		/>
+	{/if}
 	<div class="flex min-w-0 flex-1 items-center gap-3">
 		<div class="flex min-w-0 shrink-0 items-center gap-3">
 			{#if index !== undefined}
@@ -143,10 +210,10 @@
 						? 'text-primary'
 						: 'text-muted-foreground'}"
 				>
-					<span class="group-hover:opacity-0">{index + 1}</span>
+					<span class={selecting ? '' : 'group-hover:opacity-0'}>{index + 1}</span>
 					<HugeiconsIcon
 						icon={guestAdd ? PlayListAddIcon : PlayIcon}
-						class="absolute inset-0 m-auto h-3.5 w-3.5 opacity-0 group-hover:opacity-100"
+						class="absolute inset-0 m-auto h-3.5 w-3.5 opacity-0 {selecting ? '' : 'group-hover:opacity-100'}"
 					/>
 				</span>
 			{/if}

--- a/ui/src/lib/components/TrackRow.svelte
+++ b/ui/src/lib/components/TrackRow.svelte
@@ -19,6 +19,7 @@
 	import ExplicitIcon from './ExplicitIcon.svelte';
 	import { t } from '$lib/i18n.svelte';
 	import type { TrackSelection } from '$lib/selection.svelte';
+	import { Checkbox } from './ui/checkbox';
 
 	let {
 		song,
@@ -182,19 +183,21 @@
 		: ''} {compact ? '' : '[content-visibility:auto] [contain-intrinsic-size:auto_3.5rem]'}"
 >
 	{#if selectable}
-		<input
-			type="checkbox"
+		<Checkbox
 			checked={selected}
 			aria-label={t('selection.select_track', { title: song.title })}
-			class="h-4 w-4 shrink-0 cursor-pointer accent-primary"
+			class="cursor-pointer"
 			onclick={(e) => {
+				// The list owns checked state, including Shift ranges whose endpoint stays selected.
+				e.preventDefault();
 				e.stopPropagation();
 				select(e.shiftKey);
-				// Shift can keep an already selected endpoint selected. Its derived boolean then
-				// stays unchanged, so restore the checkbox the browser just toggled off.
-				e.currentTarget.checked = selection!.has(selectionKey);
 			}}
 			onkeydown={(e) => {
+				if (e.key === ' ') {
+					e.preventDefault(); e.stopPropagation();
+					if (!e.repeat) select(e.shiftKey);
+				}
 				if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); selection!.clear(); }
 				if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
 					e.preventDefault(); e.stopPropagation(); selection!.selectAll();

--- a/ui/src/lib/components/TrackSelectionBar.svelte
+++ b/ui/src/lib/components/TrackSelectionBar.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { ArrowUpNarrowWideIcon, PlayListAddIcon } from '@hugeicons/core-free-icons';
+	import { Button } from './ui/button';
+	import { enqueue, openAddManyToPlaylist, ui } from '$lib/player.svelte';
+	import { isLocalId } from '$lib/api';
+	import { t } from '$lib/i18n.svelte';
+	import type { TrackSelection } from '$lib/selection.svelte';
+
+	let { selection, from }: { selection: TrackSelection; from?: string } = $props();
+	let busy = $state(false);
+	const canAdd = $derived(selection.count > 0 && selection.songs.every((s) => !isLocalId(s.video_id)));
+
+	function onKey(e: KeyboardEvent) {
+		// Space activates these buttons, never the app-wide transport shortcut.
+		if (e.key === ' ') e.stopPropagation();
+		if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); selection.clear(); }
+	}
+
+	async function queue(next: boolean) {
+		if (busy || selection.pending || !selection.count) return;
+		busy = true;
+		try {
+			// Snapshot before awaiting. Never append the source's continuation: only selected rows.
+			await enqueue([...selection.songs], next, from);
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<div class="sticky top-0 z-10 mb-2 rounded-lg border bg-background p-2" data-track-selection>
+	<div class="flex flex-wrap items-center gap-2" role="group" aria-label={t('selection.actions')}>
+		<span class="mr-auto text-sm text-muted-foreground" role="status">
+			{selection.count ? t('selection.count', { count: selection.count }) : t('selection.hint')}
+			{#if selection.hidden}
+				<span> · {t('selection.hidden', { count: selection.hidden })}</span>
+			{/if}
+		</span>
+		<Button variant="ghost" size="sm" disabled={!selection.visibleKeys.length}
+			onkeydown={onKey}
+			onclick={() => selection.selectAll()}>
+			{t('selection.select_all', { count: selection.visibleKeys.length })}
+		</Button>
+		{#if selection.count}
+			<Button variant="outline" size="sm" disabled={busy || selection.pending > 0} onkeydown={onKey} onclick={() => queue(true)}>
+				<HugeiconsIcon icon={ArrowUpNarrowWideIcon} class="h-4 w-4" /> {t('player.play_next')}
+			</Button>
+			<Button variant="outline" size="sm" disabled={busy || selection.pending > 0} onkeydown={onKey} onclick={() => queue(false)}>
+				<HugeiconsIcon icon={PlayListAddIcon} class="h-4 w-4" /> {t('player.add_to_queue')}
+			</Button>
+			{#if canAdd}
+				<Button variant="outline" size="sm" disabled={busy || ui.addPending || selection.pending > 0}
+					onkeydown={onKey}
+					onclick={() => openAddManyToPlaylist([...selection.songs])}>
+					{t('player.add_to_playlist')}
+				</Button>
+			{/if}
+		{/if}
+		{#if selection.count || selection.lost}
+			<Button variant="ghost" size="sm" onkeydown={onKey} onclick={() => selection.clear()}>{t('selection.clear')}</Button>
+		{/if}
+	</div>
+	{#if selection.pending}
+		<p class="mt-1 text-xs text-muted-foreground" role="status">
+			{t('selection.pending', { count: selection.pending })}
+		</p>
+	{/if}
+	{#if selection.lost}
+		<p class="mt-1 text-xs text-muted-foreground" role="status">
+			{t('selection.lost', { count: selection.lost })}
+		</p>
+	{/if}
+</div>

--- a/ui/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/ui/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Checkbox as CheckboxPrimitive } from "bits-ui";
+	import { HugeiconsIcon } from "@hugeicons/svelte";
+	import { Tick02Icon, MinusSignIcon } from "@hugeicons/core-free-icons";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	data-slot="checkbox"
+	class={cn(
+		"border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[6px] border transition-shadow group-has-disabled/field:opacity-50 focus-visible:ring-[3px] aria-invalid:ring-[3px] group-has-[:focus-visible]/field-label:ring-0 group-has-[:focus-visible]/field-label:not-data-checked:border-input group-has-[:focus-visible]/field-label:data-checked:border-primary peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:checked
+	bind:indeterminate
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<div
+			data-slot="checkbox-indicator"
+			class="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
+		>
+			{#if checked}
+				<HugeiconsIcon icon={Tick02Icon} strokeWidth={2} />
+			{:else if indeterminate}
+				<HugeiconsIcon icon={MinusSignIcon} strokeWidth={2} />
+			{/if}
+		</div>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/ui/src/lib/components/ui/checkbox/index.ts
+++ b/ui/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,7 @@
+import Root from "./checkbox.svelte";
+
+export {
+	Root,
+	//
+	Root as Checkbox,
+};

--- a/ui/src/lib/locales/en.json
+++ b/ui/src/lib/locales/en.json
@@ -1,4 +1,20 @@
 {
+	"selection": {
+		"actions": "Selected track actions",
+		"count": "{count} selected",
+		"hidden": "{count} hidden by the filter",
+		"hint": "Select tracks with the checkboxes or Ctrl/Cmd-click. Shift-click selects a range.",
+		"select_all": "Select all loaded matches ({count})",
+		"clear": "Clear selection",
+		"track": "{title}. Space to select, Enter to play.",
+		"track_guest": "{title}. Space to select, Enter to add to the session queue.",
+		"select_track": "Select {title}",
+		"lost": "{count} selections were cleared because those entries were removed or could not be matched after refresh.",
+		"pending": "Waiting for the remaining playlist pages to find {count} selected tracks. Retry loading the playlist if a page fails.",
+		"local_playlist": "Local files cannot be added to a YouTube playlist.",
+		"account_changed": "Stopped adding songs because the account changed.",
+		"playlist_partial": "Added {added} to {playlist}; {duplicates} already there; {remaining} unconfirmed. {error}"
+	},
 	"common": {
 		"loading": "Loading...",
 		"retry": "Retry",

--- a/ui/src/lib/player.svelte.ts
+++ b/ui/src/lib/player.svelte.ts
@@ -1025,6 +1025,7 @@ export async function startRadio(
 // Transient UI state for write actions.
 export const ui = $state({
 	addSongs: null as SongItem[] | null, // add-to-playlist picker target(s), full items for optimistic appends
+	addPending: false, // one playlist batch at a time, even after the picker closes
 	share: null as BrowseItem | null, // the share modal's target
 	toast: null as Toast | null,
 	settingsOpen: false, // the settings modal
@@ -1079,11 +1080,12 @@ export function openShare(item: BrowseItem) {
 }
 
 export function openAddToPlaylist(song: SongItem) {
-	ui.addSongs = [song];
+	openAddManyToPlaylist([song]);
 }
 
 /** Open the picker to add several tracks at once (e.g. a whole album). */
 export function openAddManyToPlaylist(songs: SongItem[]) {
+	if (ui.addPending) return;
 	ui.addSongs = songs.length ? songs : null;
 }
 

--- a/ui/src/lib/selection.check.ts
+++ b/ui/src/lib/selection.check.ts
@@ -1,0 +1,101 @@
+// node --experimental-strip-types ui/src/lib/selection.check.ts
+import type { SongItem } from './api.ts';
+import { emptySelection, reconcileSelection, reconcileTracks, retainSelection, toggleTrack, visibleTrackKeys } from './selection.ts';
+
+function ok(value: boolean, message: string) {
+	if (!value) throw new Error(message);
+}
+const song = (id: string, occurrence?: string): SongItem => ({
+	video_id: id, title: id, artists: 'Artist', set_video_id: occurrence
+});
+let seq = 0;
+const key = () => String(++seq);
+const a = song('same', 'first');
+const b = song('other');
+const c = song('same', 'second');
+const d = song('last');
+let entries = reconcileTracks([a, b, c, d], [], key);
+const originalKeys = entries.map((e) => e.key);
+let state = toggleTrack(emptySelection(), originalKeys[2], originalKeys);
+ok(state.keys.size === 1 && !state.keys.has(originalKeys[0]), 'Duplicate occurrences select independently');
+state = toggleTrack(state, originalKeys[0], originalKeys);
+ok(state.keys.size === 2, 'Both copies can be selected');
+
+// Bulk actions read the source order, even when selected in reverse order.
+ok(entries.filter((e) => state.keys.has(e.key)).map((e) => e.song.set_video_id).join(',') === 'first,second',
+	'Queue order follows the list, not click order');
+
+// Filtering and virtualization only affect projection, never selection retention.
+const visible = visibleTrackKeys(entries, [b, c]);
+ok(visible.join(',') === [originalKeys[1], originalKeys[2]].join(','), 'Filtered keys address source occurrences');
+state = retainSelection(state, entries);
+ok(state.keys.size === 2, 'Hidden and unmounted rows remain selected');
+state = toggleTrack(state, originalKeys[1], visible, true);
+ok(state.keys.size === 3, 'A hidden range anchor does not select filtered-out rows');
+
+// Shift ranges span the complete matching model, not the rendered viewport.
+const many = Array.from({ length: 5000 }, (_, i) => song(`track-${i}`));
+const longEntries = reconcileTracks(many, [], key);
+const longKeys = longEntries.map((e) => e.key);
+let range = toggleTrack(emptySelection(), longKeys[12], longKeys);
+range = toggleTrack(range, longKeys[4900], longKeys, true);
+ok(range.keys.size === 4889, 'Shift range includes unmounted rows across a large list');
+range = toggleTrack(range, longKeys[4900], longKeys);
+ok(range.keys.size === 4888, 'Toggling removes exactly one occurrence');
+
+let backward = toggleTrack(emptySelection(), longKeys[20], longKeys);
+backward = toggleTrack(backward, longKeys[5], longKeys, true);
+ok(backward.keys.size === 16 && backward.keys.has(longKeys[5]) && backward.keys.has(longKeys[20]) &&
+	!backward.keys.has(longKeys[4]) && !backward.keys.has(longKeys[21]),
+	'Backward Shift range includes both endpoints and excludes neighboring rows');
+
+// Sorting and appending pages preserve existing keys; new rows are not auto-selected.
+entries = reconcileTracks([d, c, b, a, song('new-page')], entries, key);
+ok(entries.slice(0, 4).map((e) => e.key).join(',') === originalKeys.slice().reverse().join(','), 'Sort keeps keys');
+state = retainSelection(state, entries);
+ok(state.keys.size === 3 && !state.keys.has(entries[4].key), 'Continuation does not change selection');
+
+// A fresh response with explicit occurrence IDs retains the correct duplicate, not its position.
+const refreshed = reconcileTracks([song('same', 'second'), song('same', 'first'), song('other')], entries, key);
+ok(refreshed[0].key === originalKeys[2] && refreshed[1].key === originalKeys[0], 'Fresh playlist IDs match exact copies');
+ok(refreshed[2].key === originalKeys[1], 'A unique song survives object replacement');
+const removed = retainSelection(state, refreshed.slice(1));
+ok(!removed.keys.has(originalKeys[2]) && removed.keys.size === 2, 'Removed occurrence is pruned alone');
+
+// With no occurrence IDs, identical refreshes are ambiguous; retaining by index would select the wrong copy.
+const twins = reconcileTracks([song('duplicate'), song('duplicate')], [], key);
+const ambiguous = reconcileTracks([song('duplicate'), song('duplicate')], twins, key);
+const oneTwin = toggleTrack(emptySelection(), twins[0].key, twins.map((e) => e.key));
+ok(retainSelection(oneTwin, ambiguous).keys.size === 0, 'Ambiguous refreshed duplicates clear safely');
+const sameTwins = reconcileTracks([twins[1].song, twins[0].song], twins, key);
+ok(sameTwins[0].key === twins[1].key, 'Duplicate objects keep identity through a local sort');
+
+const beforeBackfill = reconcileTracks([song('optimistic')], [], key);
+const afterBackfill = reconcileTracks([song('optimistic', 'server-id')], beforeBackfill, key);
+ok(afterBackfill[0].key === beforeBackfill[0].key, 'An unambiguous playlist ID backfill preserves selection');
+const replaced = reconcileTracks([song('optimistic', 'different-occurrence')], afterBackfill, key);
+ok(replaced[0].key !== afterBackfill[0].key, 'Different explicit occurrence IDs never match');
+
+const repeated = song('same-object');
+const repeatEntries = reconcileTracks([repeated, repeated], [], key);
+ok(new Set(visibleTrackKeys(repeatEntries, [repeated, repeated])).size === 2, 'Repeated object references remain distinct');
+ok(toggleTrack(emptySelection(), 'stale', originalKeys).keys.size === 0, 'Stale row events cannot select missing entries');
+ok(retainSelection(state, []).anchor === null, 'Removing the anchor clears it');
+
+// A server sort returns its first page before the selected occurrences' new positions are known.
+const beforeSort = reconcileTracks([a, b, c], [], key);
+const beforeKeys = beforeSort.map((e) => e.key);
+let chosen = toggleTrack(emptySelection(), beforeKeys[0], beforeKeys);
+chosen = toggleTrack(chosen, beforeKeys[2], beforeKeys);
+const firstPage = reconcileSelection([song('other')], beforeSort, chosen, key, false);
+ok(firstPage.selection.keys.size === 2, 'Partial server reload retains selections on unloaded pages');
+ok([...chosen.keys].every((k) => !firstPage.loadedKeys.has(k)), 'Unresolved selections are identified');
+const lastPage = reconcileSelection([song('other'), song('same', 'second'), song('same', 'first')],
+	firstPage.entries, firstPage.selection, key, true);
+ok(lastPage.entries.filter((e) => chosen.keys.has(e.key)).map((e) => e.song.set_video_id).join(',') === 'second,first',
+	'Continuation resolves selected occurrences in their new server order');
+const deleted = reconcileSelection([song('other')], firstPage.entries, chosen, key, true);
+ok(deleted.selection.keys.size === 0, 'Only a completed reload prunes missing selections');
+const cancelled = reconcileSelection([song('other')], firstPage.entries, emptySelection(), key, false);
+ok(cancelled.entries.length === 1, 'Cleared selections do not retain orphan entries');
+console.log('selection.check: ok');

--- a/ui/src/lib/selection.svelte.ts
+++ b/ui/src/lib/selection.svelte.ts
@@ -1,0 +1,59 @@
+import { untrack } from 'svelte';
+import type { SongItem } from './api';
+import { emptySelection, reconcileSelection, toggleTrack, visibleTrackKeys,
+	type TrackEntry } from './selection';
+
+/** One list owns selection. Rows may unmount freely; navigation/account changes reset the scope. */
+export function trackSelection(
+	items: () => SongItem[], visible: () => SongItem[], scope: () => string,
+	complete: () => boolean = () => true
+) {
+	let entries = $state.raw<TrackEntry[]>([]);
+	let loadedKeys = $state.raw<ReadonlySet<string>>(new Set());
+	let selected = $state.raw(emptySelection());
+	let lost = $state(0);
+	let lastScope: string | undefined;
+	let nextKey = 0;
+	$effect(() => {
+		const songs = items();
+		const currentScope = scope();
+		const allLoaded = complete();
+		untrack(() => {
+			if (lastScope !== currentScope) {
+				entries = [];
+				selected = emptySelection();
+				lost = 0;
+				lastScope = currentScope;
+			}
+			// A server sort or cached-page refresh may replace a long list with its first page.
+			// Missing selected occurrences are unresolved until the final page, not deleted.
+			const next = reconcileSelection(songs, entries, selected, () => String(++nextKey), allLoaded);
+			entries = next.entries;
+			loadedKeys = next.loadedKeys;
+			lost += selected.keys.size - next.selection.keys.size;
+			selected = next.selection;
+		});
+	});
+	const visibleKeys = $derived(visibleTrackKeys(entries, visible()));
+	const songs = $derived(entries.filter((e) => selected.keys.has(e.key)).map((e) => e.song));
+	const pending = $derived(entries.filter((e) => selected.keys.has(e.key) && !loadedKeys.has(e.key)).length);
+	const hidden = $derived(selected.keys.size - pending - visibleKeys.filter((k) => selected.keys.has(k)).length);
+	return {
+		get count() { return selected.keys.size; },
+		get songs() { return songs; },
+		get visibleKeys() { return visibleKeys; },
+		get hidden() { return hidden; },
+		get pending() { return pending; },
+		get lost() { return lost; },
+		has(key: string | undefined) { return key !== undefined && selected.keys.has(key); },
+		toggle(key: string, range = false) {
+			selected = toggleTrack(selected, key, visibleKeys, range);
+		},
+		selectAll() {
+			selected = { keys: new Set([...selected.keys, ...visibleKeys]), anchor: visibleKeys[0] ?? null };
+		},
+		clear() { selected = emptySelection(); lost = 0; }
+	};
+}
+
+export type TrackSelection = ReturnType<typeof trackSelection>;

--- a/ui/src/lib/selection.ts
+++ b/ui/src/lib/selection.ts
@@ -1,0 +1,102 @@
+import type { SongItem } from './api';
+
+export interface TrackEntry {
+	key: string;
+	song: SongItem;
+}
+
+/** Reconcile occurrences, never just video IDs. Ambiguous refreshed duplicates get new keys. */
+export function reconcileTracks(
+	songs: SongItem[],
+	previous: TrackEntry[],
+	newKey: () => string
+): TrackEntry[] {
+	const byOccurrence = new Map<string, TrackEntry[]>();
+	const byObject = new Map<SongItem, TrackEntry[]>();
+	const byVideo = new Map<string, TrackEntry[]>();
+	const counts = new Map<string, number>();
+	const occurrence = (s: SongItem) => s.set_video_id ? JSON.stringify([s.video_id, s.set_video_id]) : '';
+	const add = <K>(map: Map<K, TrackEntry[]>, key: K, entry: TrackEntry) => {
+		const bucket = map.get(key);
+		if (bucket) bucket.push(entry);
+		else map.set(key, [entry]);
+	};
+	for (const entry of previous) {
+		if (occurrence(entry.song)) add(byOccurrence, occurrence(entry.song), entry);
+		add(byObject, entry.song, entry);
+		add(byVideo, entry.song.video_id, entry);
+	}
+	for (const song of songs) counts.set(song.video_id, (counts.get(song.video_id) ?? 0) + 1);
+	const used = new Set<string>();
+	return songs.map((song) => {
+		const exact = byOccurrence.get(occurrence(song))?.find((e) => !used.has(e.key));
+		const sameObject = byObject.get(song)?.find((e) => !used.has(e.key));
+		const candidates = byVideo.get(song.video_id) ?? [];
+		// A unique track may have been re-fetched or acquired its playlist ID after an add.
+		// Two different explicit playlist IDs always denote different occurrences.
+		const unique = counts.get(song.video_id) === 1 && candidates.length === 1 &&
+			!(song.set_video_id && candidates[0].song.set_video_id &&
+				song.set_video_id !== candidates[0].song.set_video_id) ? candidates[0] : undefined;
+		const old = exact ?? sameObject ?? unique;
+		const key = old && !used.has(old.key) ? old.key : newKey();
+		used.add(key);
+		return { key, song };
+	});
+}
+
+/** Filtering/sorting keeps the source objects. Buckets also handle repeated object references. */
+export function visibleTrackKeys(entries: TrackEntry[], visible: SongItem[]): string[] {
+	const buckets = new Map<SongItem, string[]>();
+	for (const { key, song } of entries) {
+		const bucket = buckets.get(song);
+		if (bucket) bucket.push(key);
+		else buckets.set(song, [key]);
+	}
+	return visible.flatMap((song) => {
+		const key = buckets.get(song)?.shift();
+		return key === undefined ? [] : [key];
+	});
+}
+
+export interface SelectionState {
+	keys: ReadonlySet<string>;
+	anchor: string | null;
+}
+
+export const emptySelection = (): SelectionState => ({ keys: new Set(), anchor: null });
+
+export function toggleTrack(
+	state: SelectionState, key: string, visible: string[], range = false
+): SelectionState {
+	if (!visible.includes(key)) return state;
+	const keys = new Set(state.keys);
+	const from = state.anchor === null ? -1 : visible.indexOf(state.anchor);
+	if (range && from >= 0) {
+		const to = visible.indexOf(key);
+		for (const k of visible.slice(Math.min(from, to), Math.max(from, to) + 1)) keys.add(k);
+		return { keys, anchor: state.anchor };
+	}
+	if (range || !keys.delete(key)) keys.add(key);
+	return { keys, anchor: key };
+}
+
+export function retainSelection(state: SelectionState, entries: TrackEntry[]): SelectionState {
+	const available = new Set(entries.map((e) => e.key));
+	return {
+		keys: new Set([...state.keys].filter((key) => available.has(key))),
+		anchor: state.anchor !== null && available.has(state.anchor) ? state.anchor : null
+	};
+}
+
+/** A partial server reload cannot prove that a selected occurrence was removed. */
+export function reconcileSelection(
+	songs: SongItem[], previous: TrackEntry[], state: SelectionState,
+	newKey: () => string, complete = true
+) {
+	const loaded = reconcileTracks(songs, previous, newKey);
+	const loadedKeys = new Set(loaded.map((e) => e.key));
+	const waiting = complete ? [] : previous.filter((e) =>
+		state.keys.has(e.key) && !loadedKeys.has(e.key));
+	const entries = [...loaded, ...waiting];
+	return { entries, loadedKeys, selection: retainSelection(state, entries) };
+}

--- a/ui/src/lib/shortcuts.ts
+++ b/ui/src/lib/shortcuts.ts
@@ -33,6 +33,8 @@ const typing = (t: EventTarget | null) =>
  *  chrome that window doesn't render (palette, shortcut list, now-playing view). */
 export function initShortcuts(mini = false) {
 	const onKey = (e: KeyboardEvent) => {
+		// Focused controls (including track selection) have already handled this key.
+		if (e.defaultPrevented) return;
 		if (!e.ctrlKey && !e.metaKey) {
 			// Space also activates a focused button and scrolls the page, so it is swallowed either
 			// way once we know it isn't being typed.

--- a/ui/src/routes/album/[id]/+page.svelte
+++ b/ui/src/routes/album/[id]/+page.svelte
@@ -16,6 +16,8 @@
         BookmarkCheck02Icon,
     } from "@hugeicons/core-free-icons";
     import TrackRow from "$lib/components/TrackRow.svelte";
+    import TrackSelectionBar from "$lib/components/TrackSelectionBar.svelte";
+    import { trackSelection } from "$lib/selection.svelte";
     import TrackFilter, {
         filterTracks,
     } from "$lib/components/TrackFilter.svelte";
@@ -64,6 +66,7 @@
     const id = $derived(page.params.id ?? "");
     // The rows actually on screen. Identical to `album.items` with no query typed.
     const shown = $derived(filterTracks(album?.items ?? [], query));
+    const selection = trackSelection(() => album?.items ?? [], () => shown, () => `${auth.epoch}:${id}`);
     // A local album has no YouTube playlist behind it: nothing to save or add to a playlist.
     // Playing, shuffling and Shortcuts all work exactly the same.
     const isLocal = $derived(api.isLocalId(id));
@@ -468,9 +471,12 @@
 
     <!-- Numbered track list -->
     <div class="content-in p-6 pt-2">
-        {#each shown as item, i (item.video_id + i)}
+        <TrackSelectionBar {selection} from={album.title} />
+        {#each shown as item, i (JSON.stringify([item.video_id, i]))}
             <TrackRow
                 song={item}
+                {selection}
+                selectionKey={selection.visibleKeys[i]}
                 index={i}
                 hideThumb
                 showPlayCount

--- a/ui/src/routes/playlist/[id]/+page.svelte
+++ b/ui/src/routes/playlist/[id]/+page.svelte
@@ -25,6 +25,8 @@
 	import * as RadioGroup from '$lib/components/ui/radio-group';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import TrackRow from '$lib/components/TrackRow.svelte';
+	import TrackSelectionBar from '$lib/components/TrackSelectionBar.svelte';
+	import { trackSelection } from '$lib/selection.svelte';
 	import EditPlaylistDialog from '$lib/components/EditPlaylistDialog.svelte';
 	import TrackFilter, { filterTracks } from '$lib/components/TrackFilter.svelte';
 	import TrackRowSkeleton from '$lib/components/TrackRowSkeleton.svelte';
@@ -211,6 +213,8 @@
 	// The rows actually on screen: the sorted list, narrowed by the header's filter box. Identical
 	// to `sortedItems` with no query typed.
 	const shown = $derived(filterTracks(sortedItems, applied));
+	const selection = trackSelection(() => sortedItems, () => shown,
+		() => `${auth.epoch}:${id}`, () => !pl?.continuation);
 	const filtering = $derived(!!applied.trim());
 
 	// A sort has to cover the whole playlist, not the pages scrolled so far, so pull the rest in.
@@ -544,7 +548,8 @@
 	// own marker, never a fresher walk's.
 	let walkingFor: string | null = null;
 	$effect(() => {
-		if (!filtering || !pl?.continuation || walkingFor === id) return;
+		// Recover selected occurrences in the new server order before enabling bulk actions.
+		if ((!filtering && !selection.pending) || !pl?.continuation || walkingFor === id || moreError) return;
 		const pid = id;
 		walkingFor = pid;
 		loadAll().finally(() => {
@@ -879,17 +884,20 @@
 				class="p-4 transition-opacity {resorting ? 'opacity-50' : ''}"
 				aria-busy={resorting}
 			>
+				<TrackSelectionBar {selection} from={pl.title} />
 				{#if shown.length}
 					<!-- The padding stands in for the rows outside the window, so the scrollbar is the
 					     length of the whole playlist even though only ~30 rows exist.
 					     data-rows: what the scroller measures row 0's position from. -->
 					<div data-rows style="padding-top:{win.padTop}px;padding-bottom:{win.padBottom}px">
-						{#each shown.slice(win.start, win.end) as item, i (item.video_id + (win.start + i))}
+						{#each shown.slice(win.start, win.end) as item, i (JSON.stringify([item.video_id, win.start + i]))}
 							{@const n = win.start + i}
 							<!-- data-row: what the scroller measures a row's real height from. -->
 							<div data-row>
 								<TrackRow
 									song={item}
+									{selection}
+									selectionKey={selection.visibleKeys[n]}
 									index={n}
 									showPlayCount
 									active={item.video_id === nowId}

--- a/ui/src/routes/search-more/+page.svelte
+++ b/ui/src/routes/search-more/+page.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import TrackRow from '$lib/components/TrackRow.svelte';
+	import TrackSelectionBar from '$lib/components/TrackSelectionBar.svelte';
+	import { trackSelection } from '$lib/selection.svelte';
 	import TrackRowSkeleton from '$lib/components/TrackRowSkeleton.svelte';
 	import MediaCard from '$lib/components/MediaCard.svelte';
 	import MediaCardSkeleton from '$lib/components/MediaCardSkeleton.svelte';
 	import ErrorState from '$lib/components/ErrorState.svelte';
 	import * as api from '$lib/api';
 	import type { BrowseItem, SongItem } from '$lib/api';
-	import { openAddToPlaylist, playSong } from '$lib/player.svelte';
+	import { auth, openAddToPlaylist, playSong } from '$lib/player.svelte';
 	import { getCached, putCached } from '$lib/pagecache';
 	import { t } from '$lib/i18n.svelte';
 
@@ -20,6 +22,7 @@
 
 	const q = $derived(page.url.searchParams.get('q') ?? '');
 	const cat = $derived(page.url.searchParams.get('cat') ?? 'songs');
+	const selection = trackSelection(() => songs, () => songs, () => `${auth.epoch}:${q}:${cat}`);
 	const label = $derived(
 		{
 			songs: t('common.songs'),
@@ -89,9 +92,12 @@
 		<ErrorState message={error} onRetry={() => load(q, cat)} />
 	{:else if cat === 'songs'}
 		<div class="content-in">
-			{#each songs as song (song.video_id)}
+			<TrackSelectionBar {selection} />
+			{#each songs as song, i (JSON.stringify([song.video_id, i]))}
 				<TrackRow
 					{song}
+					{selection}
+					selectionKey={selection.visibleKeys[i]}
 					showPlayCount
 					onplay={() => playSong(song)}
 					onAdd={() => openAddToPlaylist(song)}

--- a/ui/src/routes/search/+page.svelte
+++ b/ui/src/routes/search/+page.svelte
@@ -16,13 +16,15 @@
 	import MediaCardSkeleton from '$lib/components/MediaCardSkeleton.svelte';
 	import SearchSuggest from '$lib/components/SearchSuggest.svelte';
 	import TrackRow from '$lib/components/TrackRow.svelte';
+	import TrackSelectionBar from '$lib/components/TrackSelectionBar.svelte';
+	import { trackSelection } from '$lib/selection.svelte';
 	import TrackRowSkeleton from '$lib/components/TrackRowSkeleton.svelte';
 	import ErrorState from '$lib/components/ErrorState.svelte';
 	import Shelf from '$lib/components/Shelf.svelte';
 	import * as api from '$lib/api';
 	import type { SearchResults, SongItem } from '$lib/api';
 	import { getCached, putCached } from '$lib/pagecache';
-	import { openAddToPlaylist, playSong } from '$lib/player.svelte';
+	import { auth, openAddToPlaylist, playSong } from '$lib/player.svelte';
 	import { asSong } from '$lib/browse';
 	import { t } from '$lib/i18n.svelte';
 
@@ -100,6 +102,8 @@
 	});
 
 	const songRows = $derived(songs.length ? songs : (res?.songs ?? []).map(asSong));
+	const previewSongs = $derived(songRows.slice(0, 6));
+	const selection = trackSelection(() => previewSongs, () => previewSongs, () => `${auth.epoch}:${searched}`);
 
 	// Sections are horizontal card rows, except Songs which is a vertical list. `top` has no "show more".
 	const sections = $derived(
@@ -177,9 +181,12 @@
 							{/if}
 						</div>
 						{#if sec.list}
-							{#each songRows.slice(0, sec.max) as song (song.video_id)}
+							<TrackSelectionBar {selection} />
+							{#each previewSongs as song, i (JSON.stringify([song.video_id, i]))}
 								<TrackRow
 									{song}
+									{selection}
+									selectionKey={selection.visibleKeys[i]}
 									showPlayCount
 									onplay={() => playSong(song)}
 									onAdd={() => openAddToPlaylist(song)}


### PR DESCRIPTION
This PR makes it easier to select multiple tracks in playlists, albums, song-search previews, and expanded song search, then use **Play next**, **Add to queue**, or **Add to playlist** on them together.

Selection mode is enabled through a button in the list header. Checkboxes and selection hints appear only while the mode is active. A floating action bar at the bottom provides icon-only Play next, Add to queue, and Add to playlist buttons without shifting the track rows. Select all switches to Clear when everything is selected; Clear is also available for a partial selection. Selected rows use a flat background tint.

- In selection mode, clicking a row or its checkbox selects individual occurrences, including duplicate songs. Shift selects ranges; Enter retains playback; Space selects; Escape leaves selection mode and clears the selection. Selectable rows also expose localized Selected/Not selected descriptions for assistive technology.
- Select all loads the remaining playlist pages before selecting. Clearing or leaving selection mode during loading keeps the selection cleared when those pages arrive.
- Selection survives filtering, sorting, pagination, and virtualization. Bulk actions preserve list order, include selected songs hidden by a filter, and exclude unselected continuation tracks. Actions wait while a server reload resolves selected occurrences.
- Playlist additions remain sequential, report confirmed additions/duplicates/unconfirmed requests after partial failure, and stop subsequent requests after an account change. Local files are rejected for YouTube playlists.

## Issue scope

Closes #194: select multiple songs and play them next or add them to the queue.

Partially addresses #141: select multiple songs and add them to a playlist. Drag-and-drop into playlists is not implemented and remains follow-up work, along with selection on additional list surfaces.

The changes are confined to the UI, with no Rust, dependency, or build-configuration changes.

## Screenshots

[Maintainer’s demo of the updated selection UI](https://github.com/user-attachments/assets/b98052bf-de9b-417b-8f47-48836ebe4aa9).

The screenshots below predate the maintainer’s UI refinements. They show the earlier always-visible checkboxes and action strip; the merged version uses opt-in selection and a floating bottom action bar.

<details>
<summary>Earlier screenshots, before the maintainer’s UI refinements</summary>

Select tracks and apply a bulk action:

![Three selected tracks in AD:PIANO with Play next, Add to queue, and Add to playlist actions](https://github.com/user-attachments/assets/6823e2d7-7348-443e-a17d-9815f56eabee)

<details>
<summary>Filtering and adding selected tracks to a playlist</summary>

Selection stays intact while filtering. Here, two selected tracks match the filter and one selected track is hidden:

![Filtered AD:PIANO album showing 3 selected tracks, including 1 hidden by the filter](https://github.com/user-attachments/assets/13b94036-010c-4721-8f8a-495b396ad02d)

Choose a destination playlist for the selected tracks:

![Add to playlist chooser opened for the three selected album tracks](https://github.com/user-attachments/assets/9436c86f-29f8-4ca1-a53e-b85b9878afc8)

</details>

</details>

## Validation

**After syncing the final PR head (`9e294f4`, 15 September):** `pnpm check` passed with 0 errors and 0 warnings, and the portable selection check passed. A focused Chromium smoke test using the real Svelte pages and mocked Tauri transport passed for entering/exiting selection mode, Select all followed by Clear while a playlist page was loading, Select all across the completed playlist, and ordered Play next, Add to queue, and Add to playlist actions on playlists, albums, song-search previews, and expanded song search. These checks did not repeat native Windows/WebView or live-service testing. The smoke-test harness remains local.

**Earlier validation, before the maintainer’s refinements:**

After the accessibility follow-up, the selection, Svelte, build, and component/route checks passed again. Focused Chromium accessibility-tree checks also passed for selected/unselected descriptions, keyboard behavior, duplicate tracks, virtualization, locale fallback, and rows without selection support. I retested the follow-up in the Windows app and it seemed fine. The automated accessibility checks inspect the accessibility tree; they do not verify spoken output.

- `pnpm check` in `ui`: **0 errors, 0 warnings**; `pnpm build`: passed.
- `node --experimental-strip-types ui/src/lib/selection.check.ts`: passed, including duplicate identity, forward/backward ranges, 5,000-row selection, hidden selections, sorting, paging, and incomplete reloads. Existing `rows`, `sort`, `queue`, `dnd`, `localsearch`, and `menu` checks also passed.
- Mocked Chromium component and four-route checks passed for keyboard/pointer controls, virtualization, ordered payloads, failure/retry, partial playlist writes, and account changes. Light/dark layouts were checked at 1280px and 760px. This ad hoc harness is local; the portable selection check is included in the PR.
- Windows `cargo tauri dev` build/launch passed. Manual native checks passed for selection counts, queue order, keyboard shortcuts, filtering/sorting, and real Add to playlist.
- `cargo fmt --all -- --check`: passed.
- `cargo test --all --no-fail-fast`: **234 passed, 0 failed, 3 ignored live-service tests**, with the Windows test-launch adjustments below.

The Windows Rust test run required a process-local `TAURI_CONFIG={"bundle":{"resources":[]}}` to skip copying the loaded libmpv DLL, plus the working app's Common Controls v6 manifest beside the generated test executable. These local test adjustments are outside the PR. macOS/Linux native WebViews and packaged installers were not tested; failure/account-switch checks used mocked transport.

## AI Disclosure

This is how I've used AI to help me code the features mentioned and a backward Shift-range regression assertion was added and passed. The needed manual Windows tests were done by me personally.

- **OpenAI Codex (GPT-6 Astra):** implementation, local validation, and integration of review feedback.
- **AGY / Gemini 3.8 Flash High**, `gemini-3.8-flash-high`, effort `high`: independent source review.
- **Command Code / MuseSpark 1.3 Contributor**, `meta/muse-spark-1.3-contributor`, effort `xhigh`: independent source review

AGY also reviewed the selection-description follow-up with the same model and effort and reported no actionable introduced defects. These AI reviews covered the contributor’s changes before the maintainer’s refinements.

The text of this PR was written both by me and by Codex using Astra to make sure the technical terms were used properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-track selection on album, playlist, and search pages.
  - Select tracks individually, with Shift-range selection, or select all across filtering and pagination.
  - Added actions to play next, add to queue, and add selected tracks to playlists.
  - Added selection status indicators for hidden, pending, and unavailable tracks.
  - Added keyboard controls, accessible labels, checkboxes, and a floating selection action bar.

- **Bug Fixes**
  - Prevented duplicate playlist batches and improved partial-failure handling.
  - Prevented invalid playlist actions for local-only tracks or changed accounts.
  - Prevented selection controls from triggering unrelated keyboard shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
